### PR TITLE
feat(rule-context): `context.report` can also report any data 

### DIFF
--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -3,21 +3,20 @@
 Pass following object to reporter module .
 
 ```js
-{
-    results: [
-        {
-            filePath: "./myfile.js",
-            messages: [
-                {
-                    ruleId: "semi",
-                    line: 1,
-                    column: 23,
-                    message: "Expected a semicolon."
-                }
-            ]
-        }
-    ]
-}
+var results = [
+    {
+        filePath: "./myfile.js",
+        messages: [
+            {
+                ruleId: "semi",
+                line: 1,
+                column: 23,
+                message: "Expected a semicolon."
+            }
+        ]
+    }
+]
+
 ```
 
 ## How to get sourcecode of a result?

--- a/src/rule/rule-context-agent.js
+++ b/src/rule/rule-context-agent.js
@@ -43,7 +43,7 @@ export default class RuleContextAgent extends EventEmitter {
         if (!(error instanceof RuleError)) {
             // `error` is a any data.
             let data = error;
-            message["data"] = data;
+            message.data = data;
         }
         this.messages.push(message);
     }

--- a/src/rule/rule-context.js
+++ b/src/rule/rule-context.js
@@ -31,26 +31,26 @@ function getSeverity(ruleConfig) {
     return SeverityLevel.error;
 }
 
-function RuleContext(ruleId, textLint, textLintConfig, ruleConfig) {
+function RuleContext(ruleId, agent, textLintConfig, ruleConfig) {
     Object.defineProperty(this, 'id', {value: ruleId});
     Object.defineProperty(this, 'config', {value: textLintConfig});
     let severity = getSeverity(ruleConfig);
     /**
      *
      * @param {TxtNode} node
-     * @param {RuleError} error
+     * @param {RuleError|any} error error is a RuleError instance or any data
      */
     this.report = function (node, error) {
-        textLint.pushReport({ruleId, node, severity, error});
+        agent.pushReport({ruleId, node, severity, error});
     };
     // Const Values
     Object.defineProperty(this, 'Syntax', {
         get(){
-            return textLint.getSyntax();
+            return agent.getSyntax();
         }
     });
     /** {@link textLint.getSource} */
-    this.getSource = textLint.getSource.bind(textLint);
+    this.getSource = agent.getSource.bind(agent);
     // CustomError object
     this.RuleError = RuleError;
 }

--- a/test/rule-context-test.js
+++ b/test/rule-context-test.js
@@ -6,7 +6,7 @@ describe("rule-context-test", function () {
     afterEach(function () {
         textlint.resetRules();
     });
-    context("to traverse rule", function () {
+    context("in traverse", function () {
         var callCount;
         beforeEach(function () {
             callCount = 0;
@@ -90,6 +90,26 @@ describe("rule-context-test", function () {
                 });
                 textlint.lintMarkdown(expectedText);
             });
+        });
+    });
+    context("report", function () {
+        it("also report data", function () {
+            var expectedData = {message: "message", key: "value"};
+            textlint.setupRules({
+                // rule-key : rule function(see docs/create-rules.md)
+                "rule-key": function (context) {
+                    return {
+                        [context.Syntax.Str](node){
+                            context.report(node, expectedData);
+                        }
+                    }
+                }
+            });
+            let result = textlint.lintMarkdown("test");
+            assert(result.messages.length === 1);
+            let message = result.messages[0];
+            assert.equal(message.message, expectedData.message);
+            assert.deepEqual(message.data, expectedData);
         });
     });
 });

--- a/typing/textlint.d.ts
+++ b/typing/textlint.d.ts
@@ -1,6 +1,9 @@
 interface TextLintMessage {
     ruleId: string;
     message: string;
+    // optional data
+    data?: any;
+    // location info
     line: number; // start with 1
     column: number;// start with 1
     // Text -> AST TxtNode(0-based columns) -> textlint -> TextLintMessage(**1-based columns**)


### PR DESCRIPTION
`context.report(node, error|data)` can also report any data.
It is useful for usage other than linting. 

```js
export default function (context) {
	return {
		[context.Syntax.Str](node){
			context.report(node, {
            	message : "message",
                customKey: "value"
            );
        }
	}
}
```                    