### PR TITLE
refactor(config): split up config into Constructor and loading config

### DIFF
--- a/src/textlint-engine.js
+++ b/src/textlint-engine.js
@@ -29,7 +29,7 @@ class TextLintEngine {
             // Almost internal use-case
             this.config = options;
         } else {
-            this.config = new Config(options);
+            this.config = Config.initWithAutoLoading(options);
         }
         this.textLint = new TextLintCore(this.config);
         this.ruleManager = new RuleManager();

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -14,7 +14,7 @@ describe("config", function () {
     });
     context("when set `configFile`", function () {
         it("should has config.rules", function () {
-            var config = new Config({
+            var config = Config.initWithAutoLoading({
                 configFile: path.join(__dirname, "fixtures", ".textlintrc")
             });
             assert(config.rules.length > 0);
@@ -22,9 +22,29 @@ describe("config", function () {
             assert(config.rulePaths.length === 0);
         });
     });
+    context("when exist `rules` adn `configFile`", function () {
+        it("should not overwrite rules of options by config", function () {
+            var options = {
+                rules: {
+                    // overwrite config file options by this
+                    "no-todo": {
+                        "key": "value"
+                    }
+                }
+            };
+            var config = Config.initWithAutoLoading({
+                rules: Object.keys(options.rules),
+                rulesConfig: options.rules,
+                configFile: path.join(__dirname, "fixtures", ".textlintrc")
+            });
+            assert(config.rules.length > 0);
+            assert.deepEqual(config.rules, ["no-todo"]);
+            assert.deepEqual(config.rulesConfig, options.rules);
+        });
+    });
     context("when has `plugins` in configFile", function () {
         it("should set config's `plugins`", function () {
-            var config = new Config({
+            var config = Config.initWithAutoLoading({
                 rulesBaseDirectory: path.join(__dirname, "fixtures", "plugins"),
                 configFile: path.join(__dirname, "fixtures", "plugin.textlintrc")
             });
@@ -33,7 +53,7 @@ describe("config", function () {
             assert(config.plugins[1] === "configurable-plugin");
         });
         it("should has rulesConfig that is loaded from plugins", function () {
-            var config = new Config({
+            var config = Config.initWithAutoLoading({
                 rulesBaseDirectory: path.join(__dirname, "fixtures", "plugins"),
                 configFile: path.join(__dirname, "fixtures", "plugin.textlintrc")
             });

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -24,8 +24,9 @@ describe("textlint-engine-test", function () {
             it("should set directory to config", function () {
                 // Issue : when use Config as argus, have to export `../src/config/config`
                 var Config = require("../src/config/config");
-                var config = new Config();
-                config.rulePaths = [rulesDir];
+                var config = new Config({
+                    rulePaths: [rulesDir]
+                });
                 let engine = new TextLintEngine(config);
                 assert.deepEqual(engine.config.rulePaths, [rulesDir]);
             });


### PR DESCRIPTION
- `new Config` => not load ConfigFile, init Config
- `Config.initWithAutoLoading` => load ConfigFile and init Config