### PR TITLE
fix(rule-context): correct padding column number

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -4,5 +4,6 @@
   "disallowTrailingWhitespace": null,
   "disallowQuotedKeysInObjects": null,
   "requireSpacesInAnonymousFunctionExpression": null,
-  "requireSpaceBetweenArguments": null
+  "requireSpaceBetweenArguments": null,
+  "requireLineFeedAtFileEnd": null
 }

--- a/src/rule/compute-location.js
+++ b/src/rule/compute-location.js
@@ -12,7 +12,7 @@ export default function computeLocation(node, padding) {
     let column = node.loc.start.column;
     if (padding.line > 0) {
         line += padding.line;
-        // hen report with padding {line, column}, message.column should be 0 + padding.column.
+        // when report with padding {line, column}, message.column should be 0 + padding.column.
         // In other word, padding line > 0 and message.column start with 0.
         if (padding.column) {
             // means 0 + padding column

--- a/src/rule/compute-location.js
+++ b/src/rule/compute-location.js
@@ -27,4 +27,4 @@ export default function computeLocation(node, padding) {
         line,
         column
     };
-};
+}

--- a/src/rule/compute-location.js
+++ b/src/rule/compute-location.js
@@ -26,5 +26,5 @@ export default function computeLocation(node, padding) {
     return {
         line,
         column
-    }
-}
+    };
+};

--- a/src/rule/compute-location.js
+++ b/src/rule/compute-location.js
@@ -1,0 +1,27 @@
+// LICENSE : MIT
+"use strict";
+/**
+ *
+ * @param node
+ * @param padding
+ * @returns {{line: number, column: number}}
+ */
+export default function computeLocation(node, padding) {
+    let line = node.loc.start.line;
+    let column = node.loc.start.column;
+    if (padding.line > 0) {
+        line += padding.line;
+        // when has padding line, column start with 0.
+        if (padding.column) {
+            column = padding.column;
+        }
+    } else {
+        if (padding.column) {
+            column += padding.column;
+        }
+    }
+    return {
+        line,
+        column
+    }
+}

--- a/src/rule/compute-location.js
+++ b/src/rule/compute-location.js
@@ -1,9 +1,10 @@
 // LICENSE : MIT
 "use strict";
 /**
+ * compute node's location with error's padding location.
  *
- * @param node
- * @param padding
+ * @param {TxtNode} node
+ * @param {RuleError} padding
  * @returns {{line: number, column: number}}
  */
 export default function computeLocation(node, padding) {
@@ -11,8 +12,10 @@ export default function computeLocation(node, padding) {
     let column = node.loc.start.column;
     if (padding.line > 0) {
         line += padding.line;
-        // when has padding line, column start with 0.
+        // hen report with padding {line, column}, message.column should be 0 + padding.column.
+        // In other word, padding line > 0 and message.column start with 0.
         if (padding.column) {
+            // means 0 + padding column
             column = padding.column;
         }
     } else {

--- a/src/rule/rule-context-agent.js
+++ b/src/rule/rule-context-agent.js
@@ -2,6 +2,7 @@ const EventEmitter = require("carrack");
 const UnionSyntax = require("../parser/union-syntax");
 const debug = require('debug')('textlint:rule-context-agent');
 const RuleError = require("./rule-error");
+const computeLocation = require("./compute-location");
 /**
  * The Agent communicate between RuleContext and Rules.
  */
@@ -25,15 +26,14 @@ export default class RuleContextAgent extends EventEmitter {
      */
     pushReport({ruleId, node, severity, error}) {
         debug('pushReport %s', error);
-        let lineNumber = error.line ? node.loc.start.line + error.line : node.loc.start.line;
-        let columnNumber = error.column ? node.loc.start.column + error.column : node.loc.start.column;
+        let {line,column} = computeLocation(node, error);
         // add TextLintMessage
         let message = {
             ruleId: ruleId,
             message: error.message,
             // See https://github.com/textlint/textlint/blob/master/typing/textlint.d.ts
-            line: lineNumber,        // start with 1(1-based line number)
-            column: columnNumber + 1,// start with 1(1-based column number)
+            line: line,        // start with 1(1-based line number)
+            column: column + 1,// start with 1(1-based column number)
             severity: severity // it's for compatible ESLint formatter
         };
         if (!(error instanceof RuleError)) {

--- a/test/rule-context-test.js
+++ b/test/rule-context-test.js
@@ -100,7 +100,48 @@ describe("rule-context-test", function () {
         });
     });
     describe("#report", function () {
-        it("also report data", function () {
+        context("RuleError", function () {
+            it("could has padding column", function () {
+                textlint.setupRules({
+                    "rule-key": function (context) {
+                        return {
+                            [context.Syntax.Str](node){
+                                let ruleError = new context.RuleError("error", 1);
+                                context.report(node, ruleError);
+                            }
+                        }
+                    }
+                });
+                return textlint.lintMarkdown("test").then(result => {
+                    assert(result.messages.length === 1);
+                    let message = result.messages[0];
+                    assert.equal(message.line, 1);
+                    assert.equal(message.column, 2);
+                });
+            });
+            it("could has padding location", function () {
+                textlint.setupRules({
+                    "rule-key": function (context) {
+                        return {
+                            [context.Syntax.Code](node){
+                                let ruleError = new context.RuleError("error", {
+                                    line: 5,// if line >=1
+                                    column: 5// then start with 0 + column
+                                });
+                                context.report(node, ruleError);
+                            }
+                        }
+                    }
+                });
+                return textlint.lintMarkdown("test`code`test").then(result => {
+                    assert(result.messages.length === 1);
+                    let message = result.messages[0];
+                    assert.equal(message.line, 6);
+                    assert.equal(message.column, 5 + 1);
+                });
+            });
+        });
+        it("can also report data", function () {
             var expectedData = {message: "message", key: "value"};
             textlint.setupRules({
                 // rule-key : rule function(see docs/create-rules.md)


### PR DESCRIPTION
When report with padding {line, column}, `message.column` should be `0 + padding.column`.
In other word, padding line > 0 and `message.column` start with 0.