### PR TITLE
Negate help message of --no-color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ $ textlint -h
   Options:
     -h, --help                 Show help.
     -c, --config path::String  Use configuration from this file or sharable config.
-    --rule [path::String]      Set rule package name and set all default rules to off.
+    --plugin [String]          Specify plugins
+    --rule [path::String]      Set rule package name
+    --preset [path::String]    Set preset package name and load rules from preset package.
     --rulesdir [path::String]  Set rules from this directory and set all default rules to off.
-    -f, --format String        Use a specific output format. - default: stylish
+    -f, --format String        Use a specific output format.
     -v, --version              Outputs the version number.
     --ext [String]             Specify text file extensions.
     --no-color                 Disable color in piped output.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ textlint -h
     -f, --format String        Use a specific output format. - default: stylish
     -v, --version              Outputs the version number.
     --ext [String]             Specify text file extensions.
-    --no-color                 Enable color in piped output.
+    --no-color                 Disable color in piped output.
     -o, --output-file path::String  Enable report to be written to a file.
     --quiet                    Report errors only. - default: false
     --stdin                    Lint code provided on <STDIN>. - default: false

--- a/src/options.js
+++ b/src/options.js
@@ -63,7 +63,7 @@ module.exports = optionator({
             option: 'color',
             type: 'Boolean',
             default: 'true',
-            description: 'Enable color in piped output.'
+            description: 'Disable color in piped output.'
         },
         {
             option: 'output-file',


### PR DESCRIPTION
See: https://github.com/eslint/eslint/commit/741d0c1f83a877c51ce71773bb2c4041a808a1f2

The second commit update CLI doc in README with current help output.