### PR TITLE
fix(docs): lint docs by textlint

### DIFF
--- a/docs/.textlintrc
+++ b/docs/.textlintrc
@@ -1,0 +1,24 @@
+{
+  "rules": {
+    "unexpanded-acronym": {
+      "ignore_acronyms": [
+        "XML",
+        "YAML",
+        "JSON",
+        "TODO",
+        "API"
+      ]
+    },
+    "rousseau": {
+      "showLevels": [
+        "warning",
+        "error"
+      ],
+      "ignoreTypes": [
+        "sentence:uppercase",
+        "passive",
+        "weasel"
+      ]
+    }
+  }
+}

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -4,7 +4,7 @@
 
 - `.textlintrc`
 
-`.textlintrc` is config file that is loaded as YAML, JSON or JS via [MoOx/rc-loader](https://github.com/MoOx/rc-loader "MoOx/rc-loader").
+`.textlintrc` is config file that loaded as YAML, JSON or JS via [MoOx/rc-loader](https://github.com/MoOx/rc-loader "MoOx/rc-loader").
 
 Put the config of rules into `.textlintrc`
 
@@ -23,8 +23,8 @@ Put the config of rules into `.textlintrc`
 
 It means that 
 
-- enable "no-todo" rule
-- disable "very-nice-rule" rule
+- enable `"no-todo"` rule
+- disable `"very-nice-rule"` rule
 
 ### Rule's config
 
@@ -43,8 +43,8 @@ Each rule's config can accept a `object`.
 
 It means that
 
-- enable "no-todo" rule
-- enable "very-nice-rule" rule and pass `{ "key" : "value" }` to the rule
+- enable `"no-todo"` rule
+- enable `"very-nice-rule"` rule and pass `{ "key" : "value" }` to the rule
 
 For rules creator:
 

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -1,6 +1,6 @@
 # Formatter
 
-Pass following object to reporter module .
+Pass following object to reporter module.
 
 ```js
 var results = [

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -33,8 +33,8 @@ See [docs/rule.md](./rule.md).
 
 ## Default Configuration for Plugins
    
-You can provide default configuration for the rules included in your plugin by modifying exported object to include rulesConfig property.
-rulesConfig follows the same pattern as you would use in your `.textlintrc` config rules property, but without plugin name as a prefix.
+You can provide default configuration for the rules included in your plugin by modifying exported object to include `rulesConfig` property.
+`rulesConfig` follows the same pattern as you would use in your `.textlintrc` config rules property, but without plugin name as a prefix.
    
 ```js
 export default {

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -6,7 +6,7 @@ Textlint's AST(Abstract Syntax Tree) is defined these pages.
 - [txtnode.md](./txtnode.md)
     - If you want to know AST of a text, use [Online Parsing Demo](./txtnode.md#online-parsing-demo)
 
-Each rules are represented by a object with several properties.
+Each rules are represented by a object with some properties.
 The properties are equivalent to AST node types from TxtNode.
 
 The basic source code format for a rule is:
@@ -164,7 +164,9 @@ export default function (context) {
 
 This example aim to found `- [ ]` and `todo:` texts.
 
-Rule file name is equal to rule ID(i.e., no-todo.js for rule ID no-todo).
+Rule file name is equal to rule ID.
+
+e.g.) no-todo.js for rule ID no-todo.
 
 File Name: `no-todo.js`
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -101,7 +101,7 @@ This is for compatibility with JavaScript AST.
 
 > Text -> AST TxtNode(**0-based columns** here) -> textlint -> TextLintMessage(1-based columns)
 
-`TxtNode` has **0-based columns**, but The result of linting which is named `TextLintMessage` has **1-based columns**.
+`TxtNode` has **0-based columns**, but The result of linting which named `TextLintMessage` has **1-based columns**.
 
 This means that textlint's rule handle `TxtNode`( **0-based columns** ), but the result of textlint's API output `TextLintMessage`( **1-based columns** ).
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
-    "lint:doc": "eslint docs/ --ext md",
+    "lint:doc": "eslint docs/ --ext md && ./bin/textlint.js -c docs/.textlintrc docs/*.md -f pretty-error",
     "lint:js": "jscs src",
     "test:example": "./test/example-test.sh",
     "test": "mocha test/*.js && npm run lint:doc && npm run lint:js && npm run test:example",
@@ -57,7 +57,9 @@
     "power-assert": "^1.0.1",
     "textlint-plugin-html": "^0.1.2",
     "textlint-rule-helper": "^1.1.3",
-    "textlint-rule-no-todo": "^1.0.2"
+    "textlint-rule-no-todo": "^1.0.2",
+    "textlint-rule-rousseau": "^1.3.0",
+    "textlint-rule-unexpanded-acronym": "^1.2.1"
   },
   "dependencies": {
     "bluebird": "^3.0.5",


### PR DESCRIPTION
lint textlint's docs by it-self.

- [azu/textlint-rule-rousseau: textlint rule check english sentence using rousseau](https://github.com/azu/textlint-rule-rousseau)
- [azu/textlint-rule-unexpanded-acronym: textlint rule that check unexpanded acronym.](https://github.com/azu/textlint-rule-unexpanded-acronym)

We want to rules for english text.
(@azu is not native speaker...)