### PR TITLE
feat(cli): add `--stdin-filename` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,24 @@ See command help.
 
 ```
 $ textlint -h
-  textlint [options] file.md [file.txt] [dir]
-  
-  Options:
-    -h, --help                 Show help.
-    -c, --config path::String  Use configuration from this file or sharable config.
-    --plugin [String]          Specify plugins
-    --rule [path::String]      Set rule package name
-    --preset [path::String]    Set preset package name and load rules from preset package.
-    --rulesdir [path::String]  Set rules from this directory and set all default rules to off.
-    -f, --format String        Use a specific output format.
-    -v, --version              Outputs the version number.
-    --ext [String]             Specify text file extensions.
-    --no-color                 Disable color in piped output.
-    -o, --output-file path::String  Enable report to be written to a file.
-    --quiet                    Report errors only. - default: false
-    --stdin                    Lint code provided on <STDIN>. - default: false
+textlint [options] file.md [file.txt] [dir]
+
+Options:
+  -h, --help                 Show help.
+  -c, --config path::String  Use configuration from this file or sharable config.
+  --plugin [String]          Specify plugins
+  --rule [path::String]      Set rule package name
+  --preset [path::String]    Set preset package name and load rules from preset package.
+  --rulesdir [path::String]  Set rules from this directory and set all default rules to off.
+  -f, --format String        Use a specific output format.
+  -v, --version              Outputs the version number.
+  --no-color                 Disable color in piped output.
+  -o, --output-file path::String  Enable report to be written to a file.
+  --quiet                    Report errors only. - default: false
+
+Using stdin:
+  --stdin                    Lint code provided on <STDIN>. - default: false
+  --stdin-filename String    Specify filename to process STDIN as
 ```
 
 Allow to use with multiple rules.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Options:
   --quiet                    Report errors only. - default: false
 
 Using stdin:
-  --stdin                    Lint code provided on <STDIN>. - default: false
+  --stdin                    Lint text provided on <STDIN>. - default: false
   --stdin-filename String    Specify filename to process STDIN as
 ```
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,10 +9,10 @@ const options = require('./options');
 const TextLintEngine = require('./textlint-engine');
 const Config = require('./config/config');
 /*
-    cli.js is command line **interface**
+ cli.js is command line **interface**
 
-    processing role is cli-engine.js.
-    @see cli-engine.js
+ processing role is cli-engine.js.
+ @see cli-engine.js
  */
 /**
  * Print results of lining text.
@@ -70,8 +70,10 @@ const cli = {
         } else if (currentOptions.help || !files.length && !text) {
             console.log(options.generateHelp());
         } else {
-            debug(`Running on ${ text ? 'text' : 'files' }`);
-            return this.executeWithOptions(currentOptions, files, text);
+            // specify file name of stdin content
+            const stdinFilename = currentOptions.stdinFilename;
+            debug(`Running on ${ text ? 'text' : 'files' }, stdin-filename: ${stdinFilename}`);
+            return this.executeWithOptions(currentOptions, files, text, stdinFilename);
         }
         return Promise.resolve(0);
     },
@@ -80,9 +82,10 @@ const cli = {
      * @param {object} cliOptions
      * @param {string[]} files files are file path list
      * @param {string} text?
+     * @param {string} stdinFilename?
      * @returns {Promise<number>} exit status
      */
-    executeWithOptions(cliOptions, files, text){
+    executeWithOptions(cliOptions, files, text, stdinFilename){
         const config = Config.initWithCLIOptions(cliOptions);
         const engine = new TextLintEngine(config);
         // TODO: should indirect access ruleManager
@@ -95,7 +98,7 @@ See https://github.com/textlint/textlint/blob/master/docs/configuring.md
 
             return Promise.resolve(0);
         }
-        const resultsPromise = text ? engine.executeOnText(text) : engine.executeOnFiles(files);
+        const resultsPromise = text ? engine.executeOnText(text, stdinFilename) : engine.executeOnFiles(files);
         return resultsPromise.then(results => {
             const output = engine.formatResults(results);
             if (printResults(output, cliOptions)) {

--- a/src/options.js
+++ b/src/options.js
@@ -79,7 +79,7 @@ module.exports = optionator({
             option: 'stdin',
             type: 'Boolean',
             default: 'false',
-            description: 'Lint code provided on <STDIN>.'
+            description: 'Lint text provided on <STDIN>.'
         },
         {
             option: "stdin-filename",

--- a/src/options.js
+++ b/src/options.js
@@ -55,11 +55,6 @@ module.exports = optionator({
             description: 'Outputs the version number.'
         },
         {
-            option: 'ext',
-            type: '[String]',
-            description: 'Specify text file extensions.'
-        },
-        {
             option: 'color',
             type: 'Boolean',
             default: 'true',
@@ -78,10 +73,19 @@ module.exports = optionator({
             description: 'Report errors only.'
         },
         {
+            heading: "Using stdin"
+        },
+        {
             option: 'stdin',
             type: 'Boolean',
             default: 'false',
             description: 'Lint code provided on <STDIN>.'
+        },
+        {
+            option: "stdin-filename",
+            type: "String",
+            description: "Specify filename to process STDIN as",
+            example: 'cat ./README.md | textlint --stdin --stdin-filename README.md'
         }
     ]
 });

--- a/src/textlint-engine.js
+++ b/src/textlint-engine.js
@@ -8,9 +8,8 @@ const Config = require('./config/config');
 const createFormatter = require('textlint-formatter');
 const tryResolve = require('try-resolve');
 const path = require('path');
-import assert from "assert";
-import { isPluginRuleKey } from "./util/config-util";
-import { findFiles } from "./util/find-util";
+import {isPluginRuleKey} from "./util/config-util";
+import {findFiles} from "./util/find-util";
 const debug = require('debug')('textlint:cli-engine');
 class TextLintEngine {
     /**
@@ -227,7 +226,12 @@ class TextLintEngine {
      * @returns {TextLintResult[]}
      */
     executeOnText(text, ext = ".txt") {
-        return this.textLint.lintText(text, ext).then(result => {
+        // filepath or ext
+        const actualExt = ext[0] === "." ? ext : path.extname(ext);
+        if (actualExt.length === 0) {
+            throw new Error("should specify the extension.\nex) .md");
+        }
+        return this.textLint.lintText(text, actualExt).then(result => {
             return [result];
         });
     }

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -261,6 +261,32 @@ describe("textlint-engine-test", function () {
                 assert.deepEqual(beforeRuleNames, afterRuleNames);
             });
         });
+        context("when specify ext", function () {
+            it("should lint text as ext", function () {
+                let engine = new TextLintEngine({
+                    rulePaths: [rulesDir]
+                });
+                return engine.executeOnText("text", ".md").then(results => {
+                    assert(Array.isArray(results));
+                    var lintResult = results[0];
+                    assert(lintResult.filePath === "<markdown>");
+                    assert(Array.isArray(lintResult.messages));
+                    assert(lintResult.messages.length > 0);
+                });
+            });
+            it("should lint text as ext( of path )", function () {
+                let engine = new TextLintEngine({
+                    rulePaths: [rulesDir]
+                });
+                return engine.executeOnText("text", "index.md").then(results => {
+                    assert(Array.isArray(results));
+                    var lintResult = results[0];
+                    assert(lintResult.filePath === "<markdown>");
+                    assert(Array.isArray(lintResult.messages));
+                    assert(lintResult.messages.length > 0);
+                });
+            });
+        });
     });
     describe("formatResults", function () {
         context("when use default formatter", function () {


### PR DESCRIPTION
Currently, We can't specify a file type to process STDIN as.
To fix #117 and we will treat STDIN's content as markdown file.

    cat ./README.md | textlint --stdin --stdin-filename README.md
    # STDIN as README.md

However, some formatter still un-available on STDIN.
Because `pretty-error` formatter read actual file.

We will improve that at next time.

#117 