### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ npm install textlint -g
 
 textlint has no default rule!!
 
-Use textlint with `--rule` or `--ruledir`, `.textlintrc` config file.
+Use textlint with `--rule` or `--rulesdir`, `.textlintrc` config file.
 
 ```sh
 # Install textlint's rule


### PR DESCRIPTION
I got an error with `--ruledir` and I got a message below:

```
Invalid option '--ruledir' - perhaps you meant '--rulesdir'?
```