### PR TITLE
fix(plugin): fix 3rd party plugin is not working

### DIFF
--- a/src/engine/textlint-engine-core.js
+++ b/src/engine/textlint-engine-core.js
@@ -69,12 +69,7 @@ export default class TextLintEngineCore {
         });
         // load rule/plugin/processor
         this.moduleLoader.loadFromConfig(this.config);
-        // execute files that are filtered by availableExtensions.
-        // TODO: it very hackable way, should be fixed
-        this.availableExtensions = this.textlint.processors.reduce((availableExtensions, processor) => {
-            const Processor = processor.constructor;
-            return availableExtensions.concat(Processor.availableExtensions());
-        }, this.config.extensions);
+
         // set settings to textlint core
         this._setupRules();
     }
@@ -126,6 +121,14 @@ new TextLintEngine({
         this.textlint.setupRules(this.ruleMap.getAllRules(), textlintConfig.rulesConfig);
         // set Processor
         this.textlint.setupProcessors(this.processorMap.toJSON());
+        // execute files that are filtered by availableExtensions.
+        // TODO: it very hackable way, should be fixed
+        // it is depend on textlintCore's state
+        this.availableExtensions = this.textlint.processors.reduce((availableExtensions, processor) => {
+            const Processor = processor.constructor;
+            return availableExtensions.concat(Processor.availableExtensions());
+        }, this.config.extensions);
+
     }
 
     /**

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -118,74 +118,97 @@ describe("cli-test", function () {
         });
     });
 
-    context("When run with --preset", function () {
-        it("should lint the file with long name", function (done) {
+    context("When run with --plugin", function () {
+        it("should lint the file with long name", function () {
             let isCalled = false;
             Logger.log = function mockLog(message) {
                 isCalled = true;
                 assert(message.length > 0);
             };
-            const targetFile = path.join(__dirname, "fixtures/test.md");
+            const targetFile = path.join(__dirname, "fixtures/cli/todo.html");
             const longName = "textlint-plugin-html";
             const ruleModuleName = "no-todo";
-            cli.execute(`${targetFile} --plugin ${longName} --rule ${ruleModuleName}`).then(result => {
-                assert.equal(result, 0);
-                assert(!isCalled);
-                done();
+            return cli.execute(`${targetFile} --plugin ${longName} --rule ${ruleModuleName}`).then(result => {
+                assert.equal(result, 1);
+                assert(isCalled);
             });
         });
-        it("should lint the file with long name", function (done) {
+        it("should lint the file with long name", function () {
             let isCalled = false;
             Logger.log = function mockLog(message) {
                 isCalled = true;
                 assert(message.length > 0);
             };
-            const targetFile = path.join(__dirname, "fixtures/test.md");
+            const targetFile = path.join(__dirname, "fixtures/cli/todo.html");
             const shortName = "html";
             const ruleModuleName = "no-todo";
-            cli.execute(`${targetFile} --plugin ${shortName} --rule ${ruleModuleName}`).then(result => {
-                assert.equal(result, 0);
+            return cli.execute(`${targetFile} --plugin ${shortName} --rule ${ruleModuleName}`).then(result => {
+                assert.equal(result, 1);
+                assert(isCalled);
+            });
+        });
+
+        it("should lint and correct error", function () {
+            let isCalled = false;
+            Logger.log = function mockLog(message) {
+                isCalled = true;
+                assert(message.length > 0);
+            };
+            const targetFile = path.join(__dirname, "fixtures/cli/todo.html");
+            const shortName = "html";
+            const ruleModuleName = "no-todo";
+            return cli.execute(`${targetFile} --plugin ${shortName} --rule ${ruleModuleName}`).then(result => {
+                assert(isCalled);
+                assert.equal(result, 1);
+            });
+        });
+        it("when not error, status is 0", function () {
+            let isCalled = false;
+            Logger.log = function mockLog() {
+                isCalled = true;
+            };
+            const targetFile = path.join(__dirname, "fixtures/cli/pass.html");
+            const shortName = "html";
+            const ruleModuleName = "no-todo";
+            return cli.execute(`${targetFile} --plugin ${shortName} --rule ${ruleModuleName}`).then(result => {
                 assert(!isCalled);
-                done();
+                assert.equal(result, 0);
             });
         });
     });
     context("When run with --fix", function () {
         context("when not set rules", function () {
-            it("show suggestion message from FAQ", function (done) {
+            it("show suggestion message from FAQ", function () {
                 let isCalled = false;
                 Logger.log = function mockLog(message) {
                     isCalled = true;
                     assert(message.length > 0);
                 };
                 const targetFile = path.join(__dirname, "fixtures/test.md");
-                cli.execute(`${targetFile} --fix`).then(result => {
+                return cli.execute(`${targetFile} --fix`).then(result => {
                     assert.equal(result, 0);
                     assert(isCalled);
-                    done();
                 });
             });
         });
         context("when has rule", function () {
-            it("should execute fixer", function (done) {
+            it("should execute fixer", function () {
                 const ruleDir = path.join(__dirname, "fixtures/fixer-rules");
                 const targetFile = path.join(__dirname, "fixtures/test.md");
-                cli.execute(`--rulesdir ${ruleDir} --fix ${targetFile}`).then(result => {
+                return cli.execute(`--rulesdir ${ruleDir} --fix ${targetFile}`).then(result => {
                     assert.equal(result, 0);
-                    done();
                 });
             });
         });
     });
     context("When not set rules", function () {
-        it("show suggestion message from FAQ", function (done) {
+        it("show suggestion message from FAQ", function () {
             Logger.log = function mockLog(message) {
                 assert(message.length > 0);
             };
             var targetFile = path.join(__dirname, "fixtures/test.md");
-            cli.execute(`${targetFile}`).then(result => {
+            return cli.execute(`${targetFile}`).then(result => {
                 assert.equal(result, 0);
-                done();
             });
         });
     });

--- a/test/fixtures/cli/pass.html
+++ b/test/fixtures/cli/pass.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+OK
+</body>
+</html>

--- a/test/fixtures/cli/todo.html
+++ b/test/fixtures/cli/todo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<p>TODO: THIS IS TODO</p>
+</body>
+</html>

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -122,13 +122,19 @@ describe("textlint-engine-test", function () {
                 assert(engine.ruleMap.getRule("example/example-rule") === ruleObject);
             });
         });
-        context("when load html plugin", function () {
+        context("when loading html plugin", function () {
             it("should add .html to availableExtensions", function () {
                 const engine = new TextLintEngine({
                     plugins: ["html"]
                 });
                 const availableExtensions = engine.availableExtensions;
                 assert(availableExtensions.indexOf(".html") !== -1);
+            });
+            it("manually loading case, should add .html to availableExtensions", function () {
+                const engine = new TextLintEngine();
+                assert(engine.availableExtensions.indexOf(".html") === -1);
+                engine.loadPlugin("html");
+                assert(engine.availableExtensions.indexOf(".html") !== -1);
             });
         });
     });

--- a/test/textlint-engine-test.js
+++ b/test/textlint-engine-test.js
@@ -122,6 +122,15 @@ describe("textlint-engine-test", function () {
                 assert(engine.ruleMap.getRule("example/example-rule") === ruleObject);
             });
         });
+        context("when load html plugin", function () {
+            it("should add .html to availableExtensions", function () {
+                const engine = new TextLintEngine({
+                    plugins: ["html"]
+                });
+                const availableExtensions = engine.availableExtensions;
+                assert(availableExtensions.indexOf(".html") !== -1);
+            });
+        });
     });
 
     describe("#loadPreset", function () {


### PR DESCRIPTION
When load a plugin, then add available extensions like .html" to core.
But, `engine.availableExtensions` always is empty at  textlint v6.0.3.

fix #180