### PR TITLE
refactor(plugin): move availableExtensions to Config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "textlint",
   "description": "The pluggable linting tool for text and markdown.",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "homepage": "https://github.com/textlint/textlint/",
   "keywords": [
     "plugable",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -5,7 +5,10 @@ const concat = require("unique-concat");
 import loadConfig from "./config-loader";
 import {isPluginRuleKey, isPresetRuleKey} from "../util/config-util";
 import {mapRulesConfig} from "./preset-loader";
-import loadRulesConfigFromPlugins from "./plugin-loader";
+import {
+    loadRulesConfig as loadRulesConfigFromPlugins,
+    loadAvailableExtensions
+} from "./plugin-loader";
 import loadRulesConfigFromPresets from "./preset-loader";
 import TextLintModuleResolver from "../engine/textlint-module-resolver";
 /**
@@ -243,10 +246,14 @@ class Config {
         const pluginRulesConfig = loadRulesConfigFromPlugins(this.plugins, moduleResolver);
         const presetRulesConfig = loadRulesConfigFromPresets(this.presets, moduleResolver);
         this.rulesConfig = objectAssign({}, presetRulesConfig, pluginRulesConfig, options.rulesConfig);
+
         /**
          * @type {string[]}
          */
         this.extensions = options.extensions ? options.extensions : defaultOptions.extensions;
+        // additional availableExtensions from plugin
+        const additionalExtensions = loadAvailableExtensions(this.plugins, moduleResolver);
+        this.extensions = this.extensions.concat(additionalExtensions);
         /**
          * @type {string[]}
          */

--- a/src/config/plugin-loader.js
+++ b/src/config/plugin-loader.js
@@ -3,6 +3,7 @@
 const interopRequire = require("interop-require");
 const ObjectAssign = require("object-assign");
 const debug = require("debug")("textlint:plugin-loader");
+const assert = require("assert");
 export function mapRulesConfig(rulesConfig, pluginName) {
     const mapped = {};
     if (rulesConfig === undefined) {
@@ -20,17 +21,36 @@ export function mapRulesConfig(rulesConfig, pluginName) {
  * @param {TextLintModuleResolver} moduleResolver
  * @returns {{}}
  */
-export default function loadRulesConfigFromPlugins(pluginNames = [], moduleResolver) {
-    var pluginRulesConfig = {};
+export function loadRulesConfig(pluginNames = [], moduleResolver) {
+    const pluginRulesConfig = {};
     pluginNames.forEach(pluginName => {
         const pkgPath = moduleResolver.resolvePluginPackageName(pluginName);
         const plugin = interopRequire(pkgPath);
         if (!plugin.hasOwnProperty("rulesConfig")) {
-            debug(`${pluginName} has not rulesConfig`);
             return;
         }
+        debug(`${pluginName} has rulesConfig`);
         // set config of <rule> to "<plugin>/<rule>"
         ObjectAssign(pluginRulesConfig, mapRulesConfig(plugin.rulesConfig, pluginName));
     });
     return pluginRulesConfig;
+}
+
+export function loadAvailableExtensions(pluginNames = [], moduleResolver) {
+    const availableExtensions = [];
+    pluginNames.forEach(pluginName => {
+        const pkgPath = moduleResolver.resolvePluginPackageName(pluginName);
+        const plugin = interopRequire(pkgPath);
+        if (!plugin.hasOwnProperty("Processor")) {
+            return;
+        }
+        const Processor = plugin.Processor;
+        debug(`${pluginName} has Processor`);
+        if (typeof Processor.availableExtensions === "function") {
+
+        }
+        assert(typeof Processor.availableExtensions === "function", "Processor.availableExtensions() should be implemented");
+        availableExtensions.push(...Processor.availableExtensions());
+    });
+    return availableExtensions;
 }

--- a/src/config/plugin-loader.js
+++ b/src/config/plugin-loader.js
@@ -46,9 +46,6 @@ export function loadAvailableExtensions(pluginNames = [], moduleResolver) {
         }
         const Processor = plugin.Processor;
         debug(`${pluginName} has Processor`);
-        if (typeof Processor.availableExtensions === "function") {
-
-        }
         assert(typeof Processor.availableExtensions === "function", "Processor.availableExtensions() should be implemented");
         availableExtensions.push(...Processor.availableExtensions());
     });

--- a/src/engine/textlint-engine-core.js
+++ b/src/engine/textlint-engine-core.js
@@ -89,6 +89,7 @@ new TextLintEngine({
      * load plugin manually
      * Note: it high cost, please use config
      * @param {string} pluginName
+     * @deprecated use Constructor(config) insteadof it
      */
     loadPlugin(pluginName) {
         this.moduleLoader.loadPlugin(pluginName);
@@ -99,6 +100,7 @@ new TextLintEngine({
      * load plugin manually
      * Note: it high cost, please use config
      * @param {string} presetName
+     * @deprecated use Constructor(config) insteadof it
      */
     loadPreset(presetName) {
         this.moduleLoader.loadPreset(presetName);
@@ -109,6 +111,7 @@ new TextLintEngine({
      * load plugin manually
      * Note: it high cost, please use config
      * @param {string} ruleName
+     * @deprecated use Constructor(config) insteadof it
      */
     loadRule(ruleName) {
         this.moduleLoader.loadRule(ruleName);

--- a/test/config-fixtures/has-a-processor-plugin/.textlintrc
+++ b/test/config-fixtures/has-a-processor-plugin/.textlintrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "textlint-plugin-pl-example"
+  ]
+}

--- a/test/config-fixtures/has-a-processor-plugin/expect.json
+++ b/test/config-fixtures/has-a-processor-plugin/expect.json
@@ -1,0 +1,8 @@
+{
+  "rules": [],
+  "rulesConfig": {},
+  "extensions": [
+    ".test1",
+    ".test2"
+  ]
+}

--- a/test/config-fixtures/has-a-processor-plugin/modules/textlint-plugin-pl-example/index.js
+++ b/test/config-fixtures/has-a-processor-plugin/modules/textlint-plugin-pl-example/index.js
@@ -1,0 +1,27 @@
+// LICENSE : MIT
+"use strict";
+class TestProcessor {
+    static availableExtensions() {
+        return [
+            ".test1",
+            ".test2"
+        ];
+    }
+
+    processor(ext) {
+        return {
+            preProcess(text, filePath) {
+                return text;
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath
+                };
+            }
+        };
+    }
+}
+module.exports = {
+    Processor: TestProcessor
+};

--- a/test/config-fixtures/has-a-processor-plugin/modules/textlint-plugin-pl-example/package.json
+++ b/test/config-fixtures/has-a-processor-plugin/modules/textlint-plugin-pl-example/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "textlint-plugin-pl-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "azu",
+  "license": "MIT"
+}

--- a/test/fixtures/engine/textlint-module-resolver/preset.js
+++ b/test/fixtures/engine/textlint-module-resolver/preset.js
@@ -3,4 +3,4 @@
 export default {
     rules: {},
     rulesConfig: {}
-}
+};

--- a/test/fixtures/plugin-loader/textlint-plugin-has-not-processor.js
+++ b/test/fixtures/plugin-loader/textlint-plugin-has-not-processor.js
@@ -1,0 +1,4 @@
+// LICENSE : MIT
+"use strict";
+module.exports = {
+};

--- a/test/fixtures/plugin-loader/textlint-plugin-has-not-rulesconfig.js
+++ b/test/fixtures/plugin-loader/textlint-plugin-has-not-rulesconfig.js
@@ -1,0 +1,3 @@
+// LICENSE : MIT
+"use strict";
+module.exports = {};

--- a/test/fixtures/plugin-loader/textlint-plugin-has-processor-4-extensions.js
+++ b/test/fixtures/plugin-loader/textlint-plugin-has-processor-4-extensions.js
@@ -1,0 +1,29 @@
+// LICENSE : MIT
+"use strict";
+class TestProcessor {
+    static availableExtensions() {
+        return [
+            ".test1",
+            ".test2",
+            ".test3",
+            ".test4"
+        ];
+    }
+
+    processor(ext) {
+        return {
+            preProcess(text, filePath) {
+                return text;
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath
+                };
+            }
+        };
+    }
+}
+module.exports = {
+    Processor: TestProcessor
+};

--- a/test/fixtures/plugin-loader/textlint-plugin-has-processor.js
+++ b/test/fixtures/plugin-loader/textlint-plugin-has-processor.js
@@ -1,0 +1,26 @@
+// LICENSE : MIT
+"use strict";
+class TestProcessor {
+    static availableExtensions() {
+        return [
+            ".test"
+        ];
+    }
+
+    processor(ext) {
+        return {
+            preProcess(text, filePath) {
+                return text;
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath
+                };
+            }
+        };
+    }
+}
+module.exports = {
+    Processor: TestProcessor
+};

--- a/test/fixtures/plugin-loader/textlint-plugin-has-rulesconfig.js
+++ b/test/fixtures/plugin-loader/textlint-plugin-has-rulesconfig.js
@@ -1,0 +1,11 @@
+// LICENSE : MIT
+"use strict";
+module.exports = {
+    rules: {
+        a: function () {
+        }
+    },
+    rulesConfig: {
+        a: true
+    }
+};

--- a/test/plugin-loader-test.js
+++ b/test/plugin-loader-test.js
@@ -1,0 +1,53 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+const path = require("path");
+import Config from "../src/config/config";
+import {loadRulesConfig, loadAvailableExtensions} from "../src/config/plugin-loader";
+import TextLintModuleResolver from "../src/engine/textlint-module-resolver";
+const moduleResolver = new TextLintModuleResolver(Config, path.join(__dirname, "fixtures/plugin-loader"));
+describe("plugin-loader", function () {
+    describe("#loadRulesConfig", function () {
+        context("when the plugin has not {rulesConfig}", function () {
+            it("should return empty object", function () {
+                const rulesConfig = loadRulesConfig(["has-not-rulesconfig"], moduleResolver);
+                assert.equal(Object.keys(rulesConfig).length, 0);
+            });
+        });
+        context("when the plugin has {rulesConfig}", function () {
+            it("should return {rulesConfig}", function () {
+                const rulesConfig = loadRulesConfig(["has-rulesconfig"], moduleResolver);
+                assert.equal(Object.keys(rulesConfig).length, 1);
+            });
+        });
+        context("when both plugin exist", function () {
+            it("should return {rulesConfig}", function () {
+                const rulesConfig = loadRulesConfig(["has-not-rulesconfig", "has-rulesconfig"], moduleResolver);
+                assert.equal(Object.keys(rulesConfig).length, 1);
+            });
+        });
+    });
+    describe("#loadAvailableExtensions", function () {
+        context("when the plugin has not {Processor}", function () {
+            it("should return empty array", function () {
+                const availableExtensions = loadAvailableExtensions(["has-not-processor"], moduleResolver);
+                assert.equal(availableExtensions.length, 0);
+            });
+        });
+        context("when the plugin has {Processor}", function () {
+            it("should return all [availableExtensions]", function () {
+                const availableExtensions = loadAvailableExtensions(["has-processor-4-extensions"], moduleResolver);
+                assert.equal(availableExtensions.length, 4);
+                assert(availableExtensions.indexOf(".test1") !== -1);
+                assert(availableExtensions.indexOf(".test2") !== -1);
+                assert(availableExtensions.indexOf(".test3") !== -1);
+                assert(availableExtensions.indexOf(".test4") !== -1);
+            });
+            it("should return [availableExtensions]", function () {
+                const availableExtensions = loadAvailableExtensions(["has-processor"], moduleResolver);
+                assert.equal(availableExtensions.length, 1);
+                assert.equal(availableExtensions[0], ".test");
+            });
+        });
+    });
+});

--- a/test/pluguins/HTMLProcessor-test.js
+++ b/test/pluguins/HTMLProcessor-test.js
@@ -3,7 +3,6 @@
 import assert from "power-assert";
 import {Processor as HTMLProcessor} from "textlint-plugin-html";
 import {TextLintCore} from "../../src/index";
-import MapLike from "../../src/shared/MapLike";
 import path from "path";
 describe("HTMLPlugin", function () {
     let textlint;


### PR DESCRIPTION
- [x] move availableExtensions to Config #182 
- [ ] remove `engine.availableExtensions` ? => #184 
      - it is need to keep backward compatibiliy
      - it will remove next major update?