### PR TITLE
feat(core): add fileName to trailing of error message

### DIFF
--- a/src/textlint-core.js
+++ b/src/textlint-core.js
@@ -17,6 +17,19 @@ import RuleCreatorSet from "./core/rule-creator-set";
 import FixerProcessor from "./fixer/fixer-processor";
 // parallel
 import LinterProcessor from "./linter/linter-processor";
+
+/**
+ * add fileName to trailing of error message
+ * @param {string|undefined} fileName
+ * @param {string} message
+ * @returns {string}
+ */
+function addingAtFileNameToError(fileName, message) {
+    if (!fileName) {
+        return message;
+    }
+    return `${message} at ${fileName}`;
+}
 /**
  * @class {TextlintCore}
  */
@@ -102,6 +115,9 @@ export default class TextlintCore {
             config: this.config,
             ruleCreatorSet: this.ruleCreatorSet,
             sourceCode: sourceCode
+        }).catch(error => {
+            error.message = addingAtFileNameToError(filePath, error.message);
+            return Promise.reject(error);
         });
     }
 
@@ -194,6 +210,9 @@ export default class TextlintCore {
             config: this.config,
             ruleCreatorSet: this.ruleCreatorSet,
             sourceCode: sourceCode
+        }).catch(error => {
+            error.message = addingAtFileNameToError(filePath, error.message);
+            return Promise.reject(error);
         });
     }
 }

--- a/src/textlint-core.js
+++ b/src/textlint-core.js
@@ -28,7 +28,9 @@ function addingAtFileNameToError(fileName, message) {
     if (!fileName) {
         return message;
     }
-    return `${message} at ${fileName}`;
+    return `${message}
+at ${fileName}`;
+
 }
 /**
  * @class {TextlintCore}

--- a/test/rule-context/fixtures/rules/throw-error-in-rule.js
+++ b/test/rule-context/fixtures/rules/throw-error-in-rule.js
@@ -1,0 +1,9 @@
+// LICENSE : MIT
+"use strict";
+module.exports = function (context) {
+    var exports = {};
+    exports[context.Syntax.Str + ":exit"] = function () {
+        throw new Error("Error in rule");
+    };
+    return exports;
+};

--- a/test/rule-context/rule-context-test.js
+++ b/test/rule-context/rule-context-test.js
@@ -72,19 +72,39 @@ describe("rule-context-test", function () {
             beforeEach(function () {
                 textlint.setupRules({
                     // rule-key : rule function(see docs/rule.md)
-                    "rule-key": function (context) {
-                        var exports = {};
-                        exports[context.Syntax.Str + ":exit"] = function (node) {
-                            throw new Error("Error in rule");
-                        };
-                        return exports;
-                    }
+                    "throw-error-in-rule": require("./fixtures/rules/throw-error-in-rule")
                 });
             });
             it("should catch error", function () {
                 return textlint.lintMarkdown("text").catch(error => {
+                    assert(error instanceof Error);
+                });
+            });
+        });
+        context("when throw error in a rule at file", function () {
+            beforeEach(function () {
+                textlint.setupRules({
+                    // rule-key : rule function(see docs/rule.md)
+                    "throw-error-in-rule": require("./fixtures/rules/throw-error-in-rule")
+                });
+            });
+            it("should catch error including <file path>", function () {
+                const filePath = path.join(__dirname, "fixtures/test.md");
+                return textlint.lintFile(filePath).catch(error => {
                     // TODO: improve error message including rule and file name
                     assert(error instanceof Error);
+                    /*
+                     Before
+
+                     Error in rule
+                     
+                     After:
+                     
+                     Error in rule
+                     at /Users/azu/.ghq/github.com/textlint/textlint/test/rule-context/fixtures/test.md
+                     
+                     */
+                    assert(error.message.indexOf(filePath) !== -1);
                 });
             });
         });

--- a/test/rule-context/rule-context-test.js
+++ b/test/rule-context/rule-context-test.js
@@ -91,19 +91,7 @@ describe("rule-context-test", function () {
             it("should catch error including <file path>", function () {
                 const filePath = path.join(__dirname, "fixtures/test.md");
                 return textlint.lintFile(filePath).catch(error => {
-                    // TODO: improve error message including rule and file name
                     assert(error instanceof Error);
-                    /*
-                     Before
-
-                     Error in rule
-                     
-                     After:
-                     
-                     Error in rule
-                     at /Users/azu/.ghq/github.com/textlint/textlint/test/rule-context/fixtures/test.md
-                     
-                     */
                     assert(error.message.indexOf(filePath) !== -1);
                 });
             });


### PR DESCRIPTION
When throw error  in the rule.

```js
module.exports = function (context) {
    var exports = {};
    exports[context.Syntax.Str + ":exit"] = function () {
        throw new Error("Error in rule");
    };
    return exports;
};
```

Before:

	Error in rule

After:

	Error in rule at ~/textlint/textlint/test/rule-context/fixtures/test.md

Fix #165 