### PR TITLE
feat(ignore): add `{ ruleId }` option object to `shouldIgnore`

### DIFF
--- a/docs/rule.md
+++ b/docs/rule.md
@@ -97,7 +97,7 @@ RuleContext object has following property:
 - **Experimental**: `shouldIgnore(range, { ruleId })` is a method that report reports ignoring `range`( is array like `[start, end]`).
     - e.g.) `context.shouldIgnore(node.range);`
     - `context.shouldIgnore(node.range, { ruleId: "rule-id" });` ignore messages of "rule-id" rule. 
-    - `context.shouldIgnore(node.range, { ruleId: "*" });` ignore all messages. It work as wildcard. Be careful to use. :warning: 
+    - `context.shouldIgnore(node.range, { ruleId: "*" });` ignore all messages. It work as wildcard. :warning: Be careful to use.
     - :warning: Caution: One rule should one Task. It means that should not mixed `report()` and `shouldIgnore()` in a one rule.
 - `getSource(<node>)`  is a method gets the source code for the given node.
     - e.g.) `context.getSource(node); // => "text"`

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -96,6 +96,8 @@ RuleContext object has following property:
     - e.g.) `context.report(node, new context.RuleError("found rule error"));`
 - **Experimental**: `shouldIgnore(range, { ruleId })` is a method that report reports ignoring `range`( is array like `[start, end]`).
     - e.g.) `context.shouldIgnore(node.range);`
+    - `context.shouldIgnore(node.range, { ruleId: "rule-id" });` ignore messages of "rule-id" rule. 
+    - `context.shouldIgnore(node.range, { ruleId: "*" });` ignore all messages. It work as wildcard. Be careful to use. :warning: 
     - :warning: Caution: One rule should one Task. It means that should not mixed `report()` and `shouldIgnore()` in a one rule.
 - `getSource(<node>)`  is a method gets the source code for the given node.
     - e.g.) `context.getSource(node); // => "text"`

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -94,7 +94,7 @@ RuleContext object has following property:
     - [src/shared/type/NodeType.js](../src/shared/type/NodeType.js)
 - `report(<node>, <ruleError>)` is a method that reports a message from one of the rules.
     - e.g.) `context.report(node, new context.RuleError("found rule error"));`
-- **Experimental**: `shouldIgnore([start, end])` is a method that report reports ignoring node from one of the rules.
+- **Experimental**: `shouldIgnore(range, { ruleId })` is a method that report reports ignoring `range`( is array like `[start, end]`).
     - e.g.) `context.shouldIgnore(node.range);`
     - :warning: Caution: One rule should one Task. It means that should not mixed `report()` and `shouldIgnore()` in a one rule.
 - `getSource(<node>)`  is a method gets the source code for the given node.

--- a/src/core/rule-context.js
+++ b/src/core/rule-context.js
@@ -32,7 +32,8 @@ export default function RuleContext({ruleId, sourceCode, report, ignoreReport, t
      * report ignoring range
      * @param {number[]} range
      * @param {{ ruleId: string }} [optional] ignoring option object
-     * - `ruleId` match the TextLintMessage.ruleId and filter the message. (default: all filtered)
+     * - `ruleId` match the TextLintMessage.ruleId and filter the message. (default: `ruleId` of the rule)
+     *   if `ruleId` is "*", match any TextLintMessage.ruleId.
      */
     this.shouldIgnore = function (range, optional = {}) {
         assert(Array.isArray(range) && typeof range[0] === "number" && typeof range[1] === "number",

--- a/src/core/rule-context.js
+++ b/src/core/rule-context.js
@@ -27,14 +27,17 @@ export default function RuleContext({ruleId, sourceCode, report, ignoreReport, t
     Object.defineProperty(this, "config", {value: textLintConfig});
     const severity = getSeverity(ruleConfig);
 
+
     /**
      * report ignoring range
      * @param {number[]} range
+     * @param {{ ruleId: string }} [optional] ignoring option object
+     * - `ruleId` match the TextLintMessage.ruleId and filter the message. (default: all filtered)
      */
-    this.shouldIgnore = function (range) {
+    this.shouldIgnore = function (range, optional = {}) {
         assert(Array.isArray(range) && typeof range[0] === "number" && typeof range[1] === "number",
             "shouldIgnore([number, number]); accept range.");
-        ignoreReport({ruleId, range});
+        ignoreReport({ruleId, range, optional});
     };
     /**
      * report function that is called in a rule

--- a/src/shared/message-filter.js
+++ b/src/shared/message-filter.js
@@ -2,6 +2,16 @@
 "use strict";
 import MessageType from "./type/MessageType";
 /**
+ * the `index` is in the `range` and return true.
+ * @param {Number} index
+ * @param {Number[]} range
+ * @returns {boolean}
+ */
+const isContainedRange = (index, range) => {
+    const [start, end] = range;
+    return start <= index && index <= end;
+};
+/**
  * filter messages by ignore messages
  * @param {Object[]} messages
  * @returns {Object[]} filtered messages
@@ -13,11 +23,14 @@ export function filterMessages(messages = []) {
     const ignoreMessages = messages.filter(message => {
         return message.type === MessageType.ignore;
     });
+    // if match, reject the message
     return lintingMessages.filter(message => {
         return !ignoreMessages.some(ignoreMessage => {
-            const index = message.index;
-            const [start, end] = ignoreMessage.range;
-            return start <= index && index <= end;
+            const isInIgnoringRange = isContainedRange(message.index, ignoreMessage.range);
+            if (isInIgnoringRange && ignoreMessage.ignoringRuleId) {
+                return message.ruleId === ignoreMessage.ignoringRuleId;
+            }
+            return isInIgnoringRange;
         });
     });
 }

--- a/src/shared/message-filter.js
+++ b/src/shared/message-filter.js
@@ -28,6 +28,10 @@ export function filterMessages(messages = []) {
         return !ignoreMessages.some(ignoreMessage => {
             const isInIgnoringRange = isContainedRange(message.index, ignoreMessage.range);
             if (isInIgnoringRange && ignoreMessage.ignoringRuleId) {
+                // "*" is wildcard that match any rule
+                if (ignoreMessage.ignoringRuleId === "*") {
+                    return true;
+                }
                 return message.ruleId === ignoreMessage.ignoringRuleId;
             }
             return isInIgnoringRange;

--- a/src/task/textlint-core-task.js
+++ b/src/task/textlint-core-task.js
@@ -69,13 +69,16 @@ export default class TextLintCoreTask extends EventEmitter {
         const reportFunction = (reportedMessage) => {
             throwWithoutExperimental("shouldIgnore() is experimental feature.\n" +
                 "You can use it with `--experimental` flag. It may will be changed in the future.");
-            const {ruleId, range} = reportedMessage;
+            const {ruleId, range, optional} = reportedMessage;
             assert(typeof range[0] !== "undefined" && typeof range[1] !== "undefined" && range[0] >= 0 && range[1] >= 0,
                 "ignoreRange should have actual range: " + range);
+            const filterRuleId = optional.ruleId;
             const message = {
                 type: MessageType.ignore,
                 ruleId: ruleId,
-                range: range
+                range: range,
+                // ignoring target ruleId
+                ignoringRuleId: filterRuleId
             };
             this.emit(TextLintCoreTask.events.message, message);
         };

--- a/src/task/textlint-core-task.js
+++ b/src/task/textlint-core-task.js
@@ -58,12 +58,15 @@ export default class TextLintCoreTask extends EventEmitter {
 
     createIgnoreReporter() {
         /**
+         * Message of ignoring
          * @typedef {Object} ReportIgnoreMessage
          * @property {string} ruleId
          * @property {number[]} range
+         * @property {string} ignoringRuleId to ignore ruleId
+         * "*" is special case, it match all ruleId(work as wildcard).
          */
         /**
-         * push new RuleError to results
+         * create ReportIgnoreMessage and emit it.
          * @param {ReportIgnoreMessage} reportedMessage
          */
         const reportFunction = (reportedMessage) => {
@@ -72,13 +75,12 @@ export default class TextLintCoreTask extends EventEmitter {
             const {ruleId, range, optional} = reportedMessage;
             assert(typeof range[0] !== "undefined" && typeof range[1] !== "undefined" && range[0] >= 0 && range[1] >= 0,
                 "ignoreRange should have actual range: " + range);
-            const filterRuleId = optional.ruleId;
             const message = {
                 type: MessageType.ignore,
                 ruleId: ruleId,
                 range: range,
-                // ignoring target ruleId
-                ignoringRuleId: filterRuleId
+                // ignoring target ruleId - default: filter messages in the rule.
+                ignoringRuleId: optional.ruleId || ruleId
             };
             this.emit(TextLintCoreTask.events.message, message);
         };

--- a/test/message-filter/message-filter-test.js
+++ b/test/message-filter/message-filter-test.js
@@ -139,6 +139,44 @@ describe("message-filter", function () {
         });
     });
     context("when the message has ignoringRuleId", function () {
+        it("* match any rule", function () {
+            const messages = [
+                {
+                    type: "lint",
+                    ruleId: "rule-a",
+                    message: "message",
+                    index: 10,
+                    line: 1,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "lint",
+                    ruleId: "rule-b",
+                    message: "message",
+                    index: 10,
+                    line: 1,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "lint",
+                    ruleId: "rule-b",
+                    message: "message",
+                    index: 20,
+                    line: 2,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "ignore",
+                    ruleId: "ignore-rule",
+                    range: [1, 100],
+                    ignoringRuleId: "*"// filter all rule
+                }
+            ];
+            assert.equal(filterMessages(messages).length, 0);
+        });
         it("should only filter messages that are matched the ruleId", function () {
             const messages = [
                 {

--- a/test/message-filter/message-filter-test.js
+++ b/test/message-filter/message-filter-test.js
@@ -138,4 +138,45 @@ describe("message-filter", function () {
             assert.equal(filterMessages(messages).length, 0);
         });
     });
+    context("when the message has ignoringRuleId", function () {
+        it("should only filter messages that are matched the ruleId", function () {
+            const messages = [
+                {
+                    type: "lint",
+                    ruleId: "rule-a",
+                    message: "message",
+                    index: 10,
+                    line: 1,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "lint",
+                    ruleId: "rule-b",
+                    message: "message",
+                    index: 10,
+                    line: 1,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "lint",
+                    ruleId: "rule-b",
+                    message: "message",
+                    index: 20,
+                    line: 2,
+                    column: 4,
+                    severity: 2
+                },
+                {
+                    type: "ignore",
+                    ruleId: "ignore-rule",
+                    range: [1, 100],
+                    ignoringRuleId: "rule-b"// filter only "rule-b"
+                }
+            ];
+            assert.equal(filterMessages(messages).length, 1);
+            assert.equal(filterMessages(messages)[0].ruleId, "rule-a");
+        });
+    });
 });

--- a/test/rule-context/rule-context-test.js
+++ b/test/rule-context/rule-context-test.js
@@ -273,15 +273,45 @@ describe("rule-context-test", function () {
                     "ignore-rule": function (context) {
                         return {
                             [context.Syntax.Str](node){
-                                context.shouldIgnore(node.range);
-                                context.shouldIgnore(node.range);
-                                context.shouldIgnore(node.range);
+                                context.shouldIgnore(node.range, {
+                                    ruleId: "*"
+                                });
+                                context.shouldIgnore(node.range, {
+                                    ruleId: "*"
+                                });
+                                context.shouldIgnore(node.range, {
+                                    ruleId: "*"
+                                });
                             }
                         };
                     }
                 });
                 return textlint.lintMarkdown("test").then(result => {
                     assert(result.messages.length === 0);
+                });
+            });
+        });
+        context("when ignoreMessages that is not specified ruleId", function () {
+            it("should return filtered messages by matched ruleId", function () {
+                textlint.setupRules({
+                    "rule": function (context) {
+                        return {
+                            [context.Syntax.Str](node){
+                                context.report(node, new context.RuleError("message"));
+                            }
+                        };
+                    },
+                    "ignore-rule": function (context) {
+                        return {
+                            [context.Syntax.Str](node){
+                                // no specify ruleId
+                                context.shouldIgnore(node.range);
+                            }
+                        };
+                    }
+                });
+                return textlint.lintMarkdown("test").then(result => {
+                    assert(result.messages.length === 1);
                 });
             });
         });
@@ -298,7 +328,9 @@ describe("rule-context-test", function () {
                     "ignore-rule": function (context) {
                         return {
                             [context.Syntax.Str](node){
-                                context.shouldIgnore(node.range);
+                                context.shouldIgnore(node.range, {
+                                    ruleId: "*"
+                                });
                             }
                         };
                     }


### PR DESCRIPTION
When the `ruleId` of option object is matched ruleId of error message, filter only the message,
Default is filter all message in the ignoring range.

## UseCase

https://github.com/textlint/textlint-rule-ignore-comment

```
<!-- textlint-disable ruleA -->
this is wrong
<!-- textlint-enable -->
```

Disable specific rule on the fly.