### PR TITLE
fix(fixer): fix to work commands that accept `Node`

### DIFF
--- a/src/core/filter-rule-context.js
+++ b/src/core/filter-rule-context.js
@@ -19,8 +19,8 @@ export default function FilterRuleContext({ruleId, sourceCode, ignoreReport, tex
     Object.defineProperty(this, "id", {value: ruleId});
     Object.defineProperty(this, "config", {value: textLintConfig});
     /**
-     * report ignoring range
-     * @param {number[]} range
+     * Report range for filtering
+     * @param {number[]} range the `range` is absolute position values
      * @param {{ ruleId: string }} [optional] ignoring option object
      * - `ruleId` match the TextLintMessage.ruleId and filter the message. (default: `ruleId` of the rule)
      *   if `ruleId` is "*", match any TextLintMessage.ruleId.

--- a/src/core/source-location.js
+++ b/src/core/source-location.js
@@ -22,8 +22,8 @@ export default class SourceLocation {
         const errorPrefix = `[${ruleId}]` || "";
         const padding = ruleError;
         /*
-            FIXME: It is old and un-document way
-            new RuleError("message", index);
+         FIXME: It is old and un-document way
+         new RuleError("message", index);
          */
         let _backwardCompatibleIndexValue;
         if (typeof padding === "number") {
@@ -81,11 +81,11 @@ report(node, new RuleError("message", {
         const adjustedLoc = this._adjustLoc(node, padding, _backwardCompatibleIndexValue);
         const adjustedFix = this._adjustFix(node, padding);
         /*
-        {
-            line,
-            column
-            fix?
-        }
+         {
+         line,
+         column
+         fix?
+         }
          */
         return ObjectAssign({}, adjustedLoc, adjustedFix);
     }
@@ -136,9 +136,9 @@ report(node, new RuleError("message", {
         // FIXME: backward compatible @ un-document
         // Remove next version 6?
         /*
-            new RuleError({
-                column: index
-            });
+         new RuleError({
+         column: index
+         });
          */
         if (padding.column !== undefined && padding.column > 0) {
             const addedColumn = column + padding.column;
@@ -154,18 +154,38 @@ report(node, new RuleError("message", {
         };
     }
 
-    _adjustFix(node, padding) {
+    /**
+     * Adjust `fix` command range
+     * if `fix.isAbsolute` is not absolute position, adjust the position from the `node`.
+     * @param {TxtAST.TxtNode} node
+     * @param {TextLintMessage} paddingMessage
+     * @returns {FixCommand|Object}
+     * @private
+     */
+    _adjustFix(node, paddingMessage) {
         const nodeRange = node.range;
         // if not found `fix`, return empty object
-        if (padding.fix === undefined) {
+        if (paddingMessage.fix === undefined) {
             return {};
         }
-        assert(typeof padding.fix === "object", "fix should be FixCommand object");
+        assert(typeof paddingMessage.fix === "object", "fix should be FixCommand object");
+        // if absolute position return self
+        if (paddingMessage.fix.isAbsolute) {
+            return {
+                // remove other property that is not related `fix`
+                // the return object will be merged by `Object.assign`
+                fix: {
+                    range: paddingMessage.fix.range,
+                    text: paddingMessage.fix.text
+                }
+            };
+        }
+        // if relative position return adjusted position
         return {
             // fix(command) is relative from node's range
             fix: {
-                range: [nodeRange[0] + padding.fix.range[0], nodeRange[0] + padding.fix.range[1]],
-                text: padding.fix.text
+                range: [nodeRange[0] + paddingMessage.fix.range[0], nodeRange[0] + paddingMessage.fix.range[1]],
+                text: paddingMessage.fix.text
             }
         };
     }

--- a/test/rule-context/rule-context-test.js
+++ b/test/rule-context/rule-context-test.js
@@ -387,7 +387,7 @@ describe("rule-context-test", function () {
                 });
             });
             context("when ignoreMessages that is not specified ruleId", function () {
-                it("should filter all messages *", function () {
+                it("should filter all messages as `*`", function () {
                     const reporter = (context) => {
                         return {
                             [context.Syntax.Str](node){
@@ -408,7 +408,7 @@ describe("rule-context-test", function () {
                         "filter-rule": function (context) {
                             return {
                                 [context.Syntax.Str](node){
-                                    // no specify ruleId
+                                    // Not specify id = all filter
                                     context.shouldIgnore(node.range);
                                 }
                             };

--- a/test/source-location/source-location-test.js
+++ b/test/source-location/source-location-test.js
@@ -3,6 +3,7 @@
 import assert from "power-assert";
 import SourceLocation from "../../src/core/source-location";
 import RuleError from "../../src/core/rule-error";
+import RuleFixer from "../../src/fixer/rule-fixer-commaner";
 import createDummySourceCode from "./../util/dummy-source-code";
 import {_logger} from "../../src";
 const sourceCode = createDummySourceCode();
@@ -298,19 +299,48 @@ describe("compute-location", function () {
                     }
                 }
             };
+            const fixer = new RuleFixer();
             const ruleError = new RuleError("message", {
                 line: 1,
                 column: 1,
-                fix: {
-                    range: [1, 5],
-                    text: "replace"
-                }
+                fix: fixer.replaceTextRange([1, 5], "replace")
             });
             const {fix} = sourceLocation.adjust({
                 node,
                 ruleError
             });
             assert.deepEqual(fix.range, [11, 15]);
+        });
+    });
+
+    context("When fix command is absolute", function () {
+        it("not adjust fix command range", function () {
+            const sourceLocation = new SourceLocation(sourceCode);
+            const node = {
+                type: "Str",
+                range: [10, 20],
+                raw: "dummy",
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 10
+                    },
+                    end: {
+                        line: 1,
+                        column: 20
+                    }
+                }
+            };
+            const fixer = new RuleFixer();
+            const ruleError = new RuleError("message", {
+                fix: fixer.remove(node)
+            });
+            const {fix} = sourceLocation.adjust({
+                node,
+                ruleError
+            });
+            assert.deepEqual(fix.range, [10, 20]);
+            assert.deepEqual(fix.text, "");
         });
     });
 });

--- a/typings/textlint.d.ts
+++ b/typings/textlint.d.ts
@@ -3,7 +3,8 @@ import TxtAST from "./txtast";
 // "range" is replaced by "text"
 interface TextLintFixCommand {
     text: string;
-    range: [number,number],
+    range: [number,number];
+    isAbsolute: boolean;
 }
 interface TextLintMessage {
     // See src/shared/type/MessageType.js


### PR DESCRIPTION
Correct these method

- `insertTextAfter(node, text)`
- `insertTextBefore(node, text)`
- `replaceText(node, text)`
- `remove(node)`

fix  #229