### PR TITLE
feat(cli): --init fill "rules" with installed rule packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "object-assign": "^4.0.1",
     "optionator": "^0.8.0",
     "rc-loader": "^1.0.0",
+    "read-pkg": "^1.1.0",
     "string-width": "^1.0.1",
     "structured-source": "^3.0.2",
     "text-table": "^0.2.0",

--- a/src/config/config-initializer.js
+++ b/src/config/config-initializer.js
@@ -35,7 +35,7 @@ const getTextlintDependencyNames = (dir) => {
 /**
  * create object that fill with `defaultValue`
  * @param {Array} array
- * @param {*}defaultValue
+ * @param {*} defaultValue
  * @returns {Object}
  */
 const arrayToObject = (array, defaultValue) => {

--- a/test/config-initializer/config-initializer-test.js
+++ b/test/config-initializer/config-initializer-test.js
@@ -9,53 +9,84 @@ import configInit from "../../src/config/config-initializer";
 import loadConfig from "../../src/config/config-loader";
 import Logger from "../../src/util/logger";
 /*
-    config file generate test
+ config file generate test
  */
-describe("config-initializer-test", function () {
+describe("config-initializer-test", function() {
     let configDir;
     const originErrorLog = Logger.error;
 
-    before(function () {
+    beforeEach(function() {
         configDir = os.tmpdir() + "/textlint-config";
         sh.mkdir("-p", configDir);
     });
 
-    after(function () {
+    afterEach(function() {
         sh.rm("-r", configDir);
     });
-
-    context("when .textlintrc is not existed", function () {
-        it("should create new file", function () {
+    context("when pacakge.json has textlint-rule-* packages", function() {
+        beforeEach(function() {
+            const packageFilePath = path.join(__dirname, "fixtures", "package.json");
+            sh.cp(packageFilePath, configDir);
+        });
+        it("should create new file with packages", function() {
             const configFile = path.join(configDir, ".textlintrc");
-            return configInit.initializeConfig(configDir).then(function (exitStatus) {
+            return configInit.initializeConfig(configDir).then(function(exitStatus) {
                 assert.equal(exitStatus, 0);
                 const result = loadConfig(configFile, {
                     configPackagePrefix: Config.CONFIG_PACKAGE_PREFIX,
                     configFileName: Config.CONFIG_FILE_NAME
                 });
+                assert.equal(typeof result.filters, "object");
+                assert.equal(typeof result.rules, "object");
+                assert.deepEqual(result.filters, {
+                    "comments": true
+                });
+                assert.deepEqual(result.rules, {
+                    "eslint": true,
+                    "prh": true,
+                    "preset-ja-technical-writing": true
+                });
+            });
+        });
+    });
+    context("when .textlintrc is not existed", function() {
+        it("should create new file", function() {
+            const configFile = path.join(configDir, ".textlintrc");
+            return configInit.initializeConfig(configDir).then(function(exitStatus) {
+                assert.equal(exitStatus, 0);
+                const result = loadConfig(configFile, {
+                    configPackagePrefix: Config.CONFIG_PACKAGE_PREFIX,
+                    configFileName: Config.CONFIG_FILE_NAME
+                });
+                assert.equal(typeof result.filters, "object");
                 assert.equal(typeof result.rules, "object");
                 assert(Object.keys(result.rules).length === 0);
             });
         });
     });
-    context("when .textlintrc is existed", function () {
-        before(function () {
+    context("when .textlintrc is existed", function() {
+        beforeEach(function() {
             // mock console API
             Logger.error = function mockErrorLog() {
             };
         });
 
-        after(function () {
+        afterEach(function() {
             Logger.error = originErrorLog;
         });
 
-        it("should be an error", function () {
+        it("should be an error", function() {
             Logger.error = function mockErrorLog(message) {
                 assert.equal(message, ".textlintrc is already existed.");
             };
-            return configInit.initializeConfig(configDir).then(function (result) {
-                assert.equal(result, 1);
-            });
+            return configInit.initializeConfig(configDir).then((exitStatus) => {
+                assert.equal(exitStatus, 0)
+                // try to re-create
+                return configInit.initializeConfig(configDir);
+            }).then(exitStatus => {
+                assert.equal(exitStatus, 1);
+            })
+
         });
     });
 });

--- a/test/config-initializer/fixtures/package.json
+++ b/test/config-initializer/fixtures/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "js-primer",
+  "private": true,
+  "devDependencies": {
+    "@alrra/travis-scripts": "^3.0.1",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-jsdoc-to-assert": "^2.0.1",
+    "babel-preset-power-assert": "^1.0.0",
+    "babel-register": "^6.7.2",
+    "eslint": "^3.0.0",
+    "front-matter": "^2.1.0",
+    "gitbook-cli": "^2.1.2",
+    "gitbook-plugin-canonical-link": "^2.0.2",
+    "gitbook-plugin-edit-link": "^2.0.2",
+    "gitbook-plugin-include-codeblock": "^1.4.0",
+    "gitbook-plugin-japanese-support": "0.0.1",
+    "gitbook-summary-to-path": "^1.0.1",
+    "globby": "^5.0.0",
+    "mocha": "^2.2.5",
+    "npm-run-all": "^2.3.0",
+    "power-assert": "^1.3.1",
+    "power-doctest": "^1.1.0",
+    "remark": "^5.0.1",
+    "strict-eval": "^1.0.1",
+    "textlint": "^7.0.1",
+    "textlint-filter-rule-comments": "^1.2.1",
+    "textlint-rule-eslint": "^1.1.1",
+    "textlint-rule-preset-ja-technical-writing": "^0.1.1",
+    "textlint-rule-prh": "^3.0.1",
+    "unist-util-select": "^1.5.0"
+  }
+}


### PR DESCRIPTION
- fill "rules" with installed rule packages
- support "filters" field

When package.json has `textlint-rule-alex`

```json
  "devDependencies": {
    "textlint-rule-alex": "^1.0.1"
  },
```

Then `textlint --init` should create follwoing `.textlintrc`

```json
{
    "rules": {
        "alex": true
    }
}
```

close #129