### PR TITLE
fix(config): use rc-config-loader insteadof rc-loader

### DIFF
--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -87,7 +87,7 @@
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
     "optionator": "^0.8.0",
-    "rc-loader": "^1.0.0",
+    "rc-config-loader": "^1.0.2",
     "read-pkg": "^1.1.0",
     "string-width": "^1.0.1",
     "structured-source": "^3.0.2",

--- a/packages/textlint/src/config/config-loader.js
+++ b/packages/textlint/src/config/config-loader.js
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-const rc = require("rc-loader");
+const rcConfigLoader = require("rc-config-loader");
 const interopRequire = require("interop-require");
 export default function load(configFilePath, {configFileName, moduleResolver}) {
     // if specify Config module, use it 
@@ -13,6 +13,8 @@ export default function load(configFilePath, {configFileName, moduleResolver}) {
         }
     }
     // auto or specify path to config file
-    const config = configFilePath ? {config: configFilePath} : null;
-    return rc(configFileName, {}, config);
+    return rcConfigLoader(configFileName, {
+        configFileName: configFilePath,
+        defaultExtension: [".json", ".js", ".yml"]
+    });
 }

--- a/packages/textlint/test/config/config-as-example-test.js
+++ b/packages/textlint/test/config/config-as-example-test.js
@@ -5,12 +5,12 @@ import glob from "glob";
 import path from "path";
 import Config from "../../src/config/config";
 /* load config from "./config/" and match expected result */
-describe("config-as-example", function () {
-    const configList = glob.sync(__dirname + "/config-fixtures/**/.textlintrc");
+describe("config-as-example", function() {
+    const configList = glob.sync(path.join(__dirname, "/config-fixtures/**/.textlintrc*"));
     configList.forEach(textlintrcPath => {
         const projectDir = path.dirname(textlintrcPath);
         const dirName = projectDir.split("/").pop();
-        it(`test ${dirName}`, function () {
+        it(`test ${dirName}`, function() {
             let config;
             try {
                 config = Config.initWithAutoLoading({

--- a/packages/textlint/test/config/config-fixtures/yml-ext/.textlintrc.yml
+++ b/packages/textlint/test/config/config-fixtures/yml-ext/.textlintrc.yml
@@ -1,0 +1,5 @@
+---
+rules:
+  a: true
+  b: true
+  c: true

--- a/packages/textlint/test/config/config-fixtures/yml-ext/expect.json
+++ b/packages/textlint/test/config/config-fixtures/yml-ext/expect.json
@@ -1,0 +1,12 @@
+{
+  "rules": [
+    "a",
+    "b",
+    "c"
+  ],
+  "rulesConfig": {
+    "a": true,
+    "b": true,
+    "c": true
+  }
+}

--- a/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-a.js
+++ b/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-a.js
@@ -1,0 +1,7 @@
+module.exports = function (context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function (node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-b.js
+++ b/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-b.js
@@ -1,0 +1,7 @@
+module.exports = function (context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function (node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-c.js
+++ b/packages/textlint/test/config/config-fixtures/yml-ext/modules/textlint-rule-c.js
@@ -1,0 +1,7 @@
+module.exports = function (context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function (node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};


### PR DESCRIPTION
This is alternative PR #258 for #39 

- [azu/rc-config-loader: Load config from .{product}rc.{json,yml,js} file](https://github.com/azu/rc-config-loader "azu/rc-config-loader: Load config from .{product}rc.{json,yml,js} file")

fix #39
