### PR TITLE
feat(cli): Support quiet mode

### DIFF
--- a/packages/textlint/src/config/config.js
+++ b/packages/textlint/src/config/config.js
@@ -79,6 +79,8 @@ const defaultOptions = Object.freeze({
     // NOTE: default formatter is defined in Engine,
     // because There is difference between TextLintEngine and TextFixEngine.
     formatterName: undefined,
+    // --quiet
+    quiet: false,
     // --no-color
     color: true,
     // --cache : enable or disable
@@ -152,6 +154,7 @@ class Config {
         options.configFile = cliOptions.config ? cliOptions.config : defaultOptions.configFile;
         options.rulePaths = cliOptions.rulesdir ? cliOptions.rulesdir : defaultOptions.rulePaths;
         options.formatterName = cliOptions.format ? cliOptions.format : defaultOptions.formatterName;
+        options.quiet = cliOptions.quiet !== undefined ? cliOptions.quiet : defaultOptions.quiet;
         options.color = cliOptions.color !== undefined ? cliOptions.color : defaultOptions.color;
         // --cache
         options.cache = cliOptions.cache !== undefined ? cliOptions.cache : defaultOptions.cache;
@@ -296,6 +299,10 @@ class Config {
          * @type {string}
          */
         this.formatterName = options.formatterName ? options.formatterName : defaultOptions.formatterName;
+        /**
+         * @type {boolean}
+         */
+        this.quiet = options.quiet !== undefined ? options.quiet : defaultOptions.quiet;
         /**
          * @type {boolean}
          */

--- a/packages/textlint/src/messages/filter-severity-process.js
+++ b/packages/textlint/src/messages/filter-severity-process.js
@@ -1,0 +1,36 @@
+// LICENSE : MIT
+"use strict";
+import SeverityLevel from "../shared/type/SeverityLevel";
+
+/**
+ * Filter messages by their severity.
+ * @param {TextLintMessage[]} messages
+ * @returns {TextLintMessage[]} filtered messages
+ */
+function filterWarningMessages(messages = []) {
+    return messages.filter(message => {
+        return message.severity === SeverityLevel.error;
+    });
+}
+
+/**
+ * Pass through all messages.
+ * @param {TextLintMessage[]} messages
+ * @returns {TextLintMessage[]}
+ */
+function through(messages = []) {
+    return messages;
+}
+
+/**
+ * Create message filter by config.quiet.
+ * @param {Config} config
+ * @returns {Function} filter function for messages
+ */
+export default function createSeverityFilter(config) {
+    if (config.quiet) {
+        return filterWarningMessages;
+    } else {
+        return through;
+    }
+}

--- a/packages/textlint/src/textlint-core.js
+++ b/packages/textlint/src/textlint-core.js
@@ -21,6 +21,7 @@ import LinterProcessor from "./linter/linter-processor";
 import MessageProcessManager from "./messages/MessageProcessManager";
 import filterIgnoredProcess from "./messages/filter-ignored-process";
 import filterDuplicatedProcess from "./messages/filter-duplicated-process";
+import filterSeverityProcess from "./messages/filter-severity-process";
 import sortMessageProcess from "./messages/sort-messages-process";
 /**
  * add fileName to trailing of error message
@@ -59,6 +60,8 @@ export default class TextlintCore {
         this.messageProcessManager.add(filterIgnoredProcess);
         // filter duplicated messages
         this.messageProcessManager.add(filterDuplicatedProcess);
+        // filter by severity
+        this.messageProcessManager.add(filterSeverityProcess(this.config));
         this.messageProcessManager.add(sortMessageProcess);
     }
 

--- a/packages/textlint/test/cli/cli-test.js
+++ b/packages/textlint/test/cli/cli-test.js
@@ -201,6 +201,20 @@ describe("cli-test", function () {
             });
         });
     });
+    context("When run with --quiet", function () {
+        it("shows only errors, not warnings", function () {
+            let isCalled = false;
+            Logger.log = function mockLog() {
+                isCalled = true;
+            };
+            const targetFile = path.join(__dirname, "fixtures/todo.html");
+            const configFile = path.join(__dirname, "fixtures/.textlintrc.quiet");
+            return cli.execute(`${targetFile} -c ${configFile} --quiet ${targetFile}`).then(result => {
+                assert.equal(result, 0);
+                assert(!isCalled);
+            });
+        });
+    });
     context("When not set rules", function () {
         it("show suggestion message from FAQ", function () {
             Logger.log = function mockLog(message) {

--- a/packages/textlint/test/cli/fixtures/.textlintrc.quiet
+++ b/packages/textlint/test/cli/fixtures/.textlintrc.quiet
@@ -1,0 +1,8 @@
+{
+    "plugins": [
+        "html",
+    ],
+    "rules": {
+        "no-todo": { "severity": "warning" },
+    },
+}


### PR DESCRIPTION
# Problem
`--quiet` option is listed on the help, but it seems not working now.

![group](https://cloud.githubusercontent.com/assets/1403842/24899224/72950e8a-1eda-11e7-8eb1-201e398292ee.png)

# Changes
This PR includes 3 changes:

- Add `quiet` property to Config
- Add `packages/textlint/src/messages/filter-severity-process.js` 
- Add a test for CLI `--quiet` option
