### PR TITLE
feat(kernel): support plugin options

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -5,7 +5,7 @@ For example, `textlint-plugin-english`.
 
 ## Create a Plugin
 
-**Deprecated**: Use [preset](./rule-preset.md) insteadof plugin.
+**Deprecated**: Plugin should have `Processor`. Use [preset](./rule-preset.md) insteadof plugin for collecting rules.
 
 - [Drop "rules" and "rulesConfig" in plugin · Issue #291 · textlint/textlint](https://github.com/textlint/textlint/issues/291 "Drop &#34;rules&#34; and &#34;rulesConfig&#34; in plugin · Issue #291 · textlint/textlint")
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -5,6 +5,10 @@ For example, `textlint-plugin-english`.
 
 ## Create a Plugin
 
+**Deprecated**: Use [preset](./rule-preset.md) insteadof plugin.
+
+- [Drop "rules" and "rulesConfig" in plugin · Issue #291 · textlint/textlint](https://github.com/textlint/textlint/issues/291 "Drop &#34;rules&#34; and &#34;rulesConfig&#34; in plugin · Issue #291 · textlint/textlint")
+
 Plugin is a set of `rules` and `rulesConfig`.
 
 If your plugin has rules, then it must export an object with a rules property.
@@ -50,7 +54,7 @@ export default {
 };
 ```
 
-## Processor(optional) 
+## Processor
 
 Plugin has a `Processor` that is optional.
 
@@ -75,8 +79,8 @@ textlint already support `.txt` and `.md`. These are implemented by `Processor`
 // TextProcessor.js
 import { parse } from "txt-to-ast";
 export default class TextProcessor {
-    constructor(config) {
-        this.config = config;
+    constructor(options) {
+        this.options = options;
     }
     // available ".ext" list
     static availableExtensions() {
@@ -116,6 +120,29 @@ You can use Processor plugin in the same way a plugin.
 Your Processor plugins's `preProcess` method should return `TxtAST` object.
 
 :information_source: Please see document about `TxtAST` before implementing Processor/Parser.
+
+## Processor options
+
+You can pass a options to your plugin from `.textlintrc`.
+
+```
+{
+    "plugins": {
+        pluginName: processorOption
+    }
+}
+```
+
+You can receive the `processorOption` via constructor arguments.
+
+```js
+export default class YourProcessor {
+    constructor(options) {
+        this.options = options; // <= processorOption!
+    }
+    // ...
+}
+```
 
 ## Testing
 

--- a/packages/textlint-kernel/src/core/filter-rule-context.ts
+++ b/packages/textlint-kernel/src/core/filter-rule-context.ts
@@ -18,7 +18,7 @@ const assert = require("assert");
  * @param {SourceCode} sourceCode
  * @param {ReportCallback} report
  * @param {Config} textLintConfig
- * @param {Object|boolean} ruleOptions
+ * @param {Object|boolean|undefined} ruleOptions
  * @param {string} [configBaseDir]
  * @constructor
  */

--- a/packages/textlint-kernel/src/core/rule-context.ts
+++ b/packages/textlint-kernel/src/core/rule-context.ts
@@ -22,7 +22,7 @@ const ruleFixer = new RuleFixer();
  * @param {SourceCode} sourceCode
  * @param {ReportCallback} report
  * @param {Config} textLintConfig
- * @param {Object|boolean} ruleOptions
+ * @param {Object|boolean|undefined} ruleOptions
  * @param {string} [configBaseDir]
  * @constructor
  */

--- a/packages/textlint-kernel/src/task/textlint-core-task.ts
+++ b/packages/textlint-kernel/src/task/textlint-core-task.ts
@@ -199,7 +199,7 @@ export default abstract class TextLintCoreTask extends EventEmitter {
      * try to get rule object
      * @param {Function} ruleCreator
      * @param {RuleContext|FilterRuleContext} ruleContext
-     * @param {Object|boolean} ruleOptions
+     * @param {Object|boolean|undefined} ruleOptions
      * @returns {Object}
      * @throws
      */
@@ -220,7 +220,7 @@ export default abstract class TextLintCoreTask extends EventEmitter {
      * add all the node types as listeners of the rule
      * @param {Function} ruleCreator
      * @param {RuleContext|FilterRuleContext} ruleContext
-     * @param {Object|boolean} ruleOptions
+     * @param {Object|boolean|undefined} ruleOptions
      * @returns {Object}
      */
     tryToAddListenRule(

--- a/packages/textlint-kernel/src/textlint-kernel.ts
+++ b/packages/textlint-kernel/src/textlint-kernel.ts
@@ -27,12 +27,17 @@ import {
  * @returns {TextlintKernelPlugin|undefined} PluginConstructor
  */
 function findPluginWithExt(plugins: TextlintKernelPlugin[] = [], ext: string) {
-    const matchPlugins = plugins.filter(kernelPlugin => {
+    const availablePlugins = plugins.filter(kernelPlugin => {
         const plugin = kernelPlugin.plugin;
         assert.ok(
             plugin !== undefined,
             `Processor(${kernelPlugin.pluginId} should have { "pluginId": string, "plugin": plugin }.`
         );
+        const options = kernelPlugin.options;
+        return options !== false;
+    });
+    const matchPlugins = availablePlugins.filter(kernelPlugin => {
+        const plugin = kernelPlugin.plugin;
         // static availableExtensions() method
         const textlintKernelProcessor: TextlintKernelProcessorConstructor = plugin.Processor;
         assert.ok(
@@ -109,8 +114,9 @@ export class TextlintKernel {
                 throw new Error(`Not found available plugin for ${ext}`);
             }
             const Processor = plugin.plugin.Processor;
+            const pluginOptions = plugin.options;
             assert(Processor !== undefined, `This plugin has not Processor: ${plugin}`);
-            const processor = new Processor(this.config);
+            const processor = new Processor(pluginOptions);
             return this._parallelProcess({
                 processor,
                 text,
@@ -133,8 +139,9 @@ export class TextlintKernel {
                 throw new Error(`Not found available plugin for ${ext}`);
             }
             const Processor = plugin.plugin.Processor;
+            const pluginOptions = plugin.options;
             assert(Processor !== undefined, `This plugin has not Processor: ${plugin}`);
-            const processor = new Processor(this.config);
+            const processor = new Processor(pluginOptions);
             return this._sequenceProcess({
                 processor,
                 text,

--- a/packages/textlint-kernel/test/helper/ExamplePlugin.ts
+++ b/packages/textlint-kernel/test/helper/ExamplePlugin.ts
@@ -3,12 +3,16 @@ import { TextlintKernelProcessor, TextLintPluginCreator } from "../../src/textli
 
 const parse = require("markdown-to-ast").parse;
 
-export class Processor implements TextlintKernelProcessor {
+export interface ExampleProcessorOptions {
+    testOption: string;
+}
+
+export class ExampleProcessor implements TextlintKernelProcessor {
     static availableExtensions() {
         return [".md"];
     }
 
-    constructor(_option = {}) {}
+    constructor(public options: ExampleProcessorOptions) {}
 
     processor(_extension: string) {
         return {
@@ -26,5 +30,24 @@ export class Processor implements TextlintKernelProcessor {
 }
 
 export const plugin: TextLintPluginCreator = {
-    Processor: Processor
+    Processor: ExampleProcessor
+};
+
+export const createPluginStub = () => {
+    let assignedOptions: undefined | ExampleProcessorOptions;
+    return {
+        getOptions() {
+            return assignedOptions;
+        },
+        getPlugin(): TextLintPluginCreator {
+            return {
+                Processor: class MockProcessor extends ExampleProcessor {
+                    constructor(options: ExampleProcessorOptions) {
+                        super(options);
+                        assignedOptions = options;
+                    }
+                }
+            };
+        }
+    };
 };

--- a/packages/textlint-kernel/test/textlint-kernel-test.ts
+++ b/packages/textlint-kernel/test/textlint-kernel-test.ts
@@ -3,6 +3,8 @@
 const assert = require("assert");
 import { TextlintKernel } from "../src/textlint-kernel";
 import { errorRule } from "./helper/ErrorRule";
+import { createPluginStub, ExampleProcessorOptions } from "./helper/ExamplePlugin";
+
 describe("textlint-kernel", () => {
     describe("#lintText", () => {
         it("should return messages", () => {
@@ -34,6 +36,34 @@ describe("textlint-kernel", () => {
             return kernel.lintText("text", options).then(result => {
                 assert.ok(typeof result.filePath === "string");
                 assert.ok(result.messages.length === 1);
+            });
+        });
+        it("should pass pluginOptions to plugin", () => {
+            const kernel = new TextlintKernel();
+            const { getOptions, getPlugin } = createPluginStub();
+            const expectedPluginOptions: ExampleProcessorOptions = {
+                testOption: "test"
+            };
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [
+                    {
+                        pluginId: "example",
+                        plugin: getPlugin(),
+                        options: expectedPluginOptions
+                    }
+                ],
+                rules: [
+                    {
+                        ruleId: "error",
+                        rule: errorRule
+                    }
+                ]
+            };
+            return kernel.lintText("text", options).then(_result => {
+                const actualPluginOptions = getOptions();
+                assert.deepEqual(actualPluginOptions, expectedPluginOptions);
             });
         });
         context("when pass invalid options", () => {
@@ -84,6 +114,34 @@ describe("textlint-kernel", () => {
             return kernel.fixText("text", options).then(result => {
                 assert.ok(typeof result.filePath === "string");
                 assert.ok(result.messages.length === 1);
+            });
+        });
+        it("should pass pluginOptions to plugin", () => {
+            const kernel = new TextlintKernel();
+            const { getOptions, getPlugin } = createPluginStub();
+            const expectedPluginOptions: ExampleProcessorOptions = {
+                testOption: "test"
+            };
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [
+                    {
+                        pluginId: "example",
+                        plugin: getPlugin(),
+                        options: expectedPluginOptions
+                    }
+                ],
+                rules: [
+                    {
+                        ruleId: "error",
+                        rule: errorRule
+                    }
+                ]
+            };
+            return kernel.lintText("text", options).then(_result => {
+                const actualPluginOptions = getOptions();
+                assert.deepEqual(actualPluginOptions, expectedPluginOptions);
             });
         });
         context("when pass invalid options", () => {

--- a/packages/textlint/src/config/plugin-loader.js
+++ b/packages/textlint/src/config/plugin-loader.js
@@ -5,6 +5,7 @@ const ObjectAssign = require("object-assign");
 const debug = require("debug")("textlint:plugin-loader");
 const assert = require("assert");
 import TextLintModuleMapper from "../engine/textlint-module-mapper";
+
 export function mapRulesConfig(rulesConfig, pluginName) {
     const mapped = {};
     if (rulesConfig === undefined || typeof rulesConfig !== "object") {
@@ -12,6 +13,78 @@ export function mapRulesConfig(rulesConfig, pluginName) {
     }
     return TextLintModuleMapper.createMappedObject(rulesConfig, pluginName);
 }
+
+/**
+ * get plugin names from `configFileRaw` object
+ * @param configFileRaw
+ * @returns {Array}
+ */
+export function getPluginNames(configFileRaw) {
+    const plugins = configFileRaw.plugins;
+    if (!plugins) {
+        return [];
+    }
+    if (Array.isArray(plugins)) {
+        return plugins;
+    }
+    return Object.keys(plugins);
+}
+
+/**
+ * get pluginConfig object from `configFileRaw` that is loaded .textlintrc
+ * @param {Object} configFileRaw
+ * @returns {Object}
+ * @example
+ * ```js
+ * "plugins": {
+ *   "pluginA": {},
+ *   "pluginB": {}
+ * }
+ * ```
+ *
+ * to
+ *
+ * ```js
+ * {
+ *   "pluginA": {},
+ *   "pluginB": {}
+ * }
+ * ```
+ *
+ *
+ *
+ * ```js
+ * "plugins": ["pluginA", "pluginB"]
+ * ```
+ *
+ * to
+ *
+ * ```
+ * // `true` means turn on
+ * {
+ *   "pluginA": true,
+ *   "pluginB": true
+ * }
+ * ```
+ */
+export function getPluginConfig(configFileRaw) {
+    const plugins = configFileRaw.plugins;
+    if (!plugins) {
+        return {};
+    }
+    if (Array.isArray(plugins)) {
+        if (plugins.length === 0) {
+            return {};
+        }
+        // { "pluginA": true, "pluginB": true }
+        return plugins.reduce((results, pluginName) => {
+            results[pluginName] = true;
+            return results;
+        }, {});
+    }
+    return plugins;
+}
+
 // load rulesConfig from plugins
 /**
  *

--- a/packages/textlint/src/core/plugin-creator-set.js
+++ b/packages/textlint/src/core/plugin-creator-set.js
@@ -12,9 +12,10 @@ const getPlugins = rawPluginObject => {
 export default class PluginCreatorSet {
     /**
      * @param {Object} [pluginObject]
+     * @param {Object} [pluginOptionObject]
      * @constructor
      */
-    constructor(pluginObject = {}) {
+    constructor(pluginObject = {}, pluginOptionObject = {}) {
         this.rawPlugins = pluginObject;
         /**
          * available rule object
@@ -26,6 +27,11 @@ export default class PluginCreatorSet {
          * @type {Array}
          */
         this.pluginNames = Object.keys(this.rawPlugins);
+
+        /**
+         * @type {Object}
+         */
+        this.pluginsOption = pluginOptionObject;
     }
 
     get availableExtensions() {
@@ -48,7 +54,8 @@ export default class PluginCreatorSet {
         return this.pluginNames.map(pluginName => {
             return {
                 pluginId: pluginName,
-                plugin: this.rawPlugins[pluginName]
+                plugin: this.rawPlugins[pluginName],
+                options: this.pluginsOption[pluginName]
             };
         });
     }

--- a/packages/textlint/src/engine/textlint-engine-core.js
+++ b/packages/textlint/src/engine/textlint-engine-core.js
@@ -170,7 +170,7 @@ new TextLintEngine({
         this.textlint.setupRules(this.ruleMap.getAllRules(), textlintConfig.rulesConfig);
         this.textlint.setupFilterRules(this.filterRuleMap.getAllRules(), textlintConfig.filterRulesConfig);
         // set Processor
-        this.textlint.setupPlugins(this.pluginMap.toJSON());
+        this.textlint.setupPlugins(this.pluginMap.toJSON(), textlintConfig.pluginsConfig);
         // execute files that are filtered by availableExtensions.
         // TODO: it very hackable way, should be fixed
         // it is depend on textlintCore's state

--- a/packages/textlint/src/textlint-core.js
+++ b/packages/textlint/src/textlint-core.js
@@ -61,9 +61,10 @@ export default class TextlintCore {
     /**
      * register Processors
      * @param {Object} plugins
+     * @param {Object} [pluginsConfig]
      */
-    setupPlugins(plugins = {}) {
-        this.pluginCreatorSet = new PluginCreatorSet(ObjectAssign({}, this.defaultPlugins, plugins));
+    setupPlugins(plugins = {}, pluginsConfig = {}) {
+        this.pluginCreatorSet = new PluginCreatorSet(ObjectAssign({}, this.defaultPlugins, plugins), pluginsConfig);
     }
 
     /**

--- a/packages/textlint/test/config/config-fixtures/plugin-config/.textlintrc
+++ b/packages/textlint/test/config/config-fixtures/plugin-config/.textlintrc
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "textlint-plugin-pl-example": {
+      "flag": true
+    }
+  }
+}

--- a/packages/textlint/test/config/config-fixtures/plugin-config/expect.json
+++ b/packages/textlint/test/config/config-fixtures/plugin-config/expect.json
@@ -5,7 +5,9 @@
     "textlint-plugin-pl-example"
   ],
   "pluginsConfig": {
-    "textlint-plugin-pl-example": true
+    "textlint-plugin-pl-example": {
+      "flag": true
+    }
   },
   "extensions": [
     ".test1",

--- a/packages/textlint/test/config/config-fixtures/plugin-config/modules/textlint-plugin-pl-example/index.js
+++ b/packages/textlint/test/config/config-fixtures/plugin-config/modules/textlint-plugin-pl-example/index.js
@@ -1,0 +1,24 @@
+// LICENSE : MIT
+"use strict";
+class TestProcessor {
+    static availableExtensions() {
+        return [".test1", ".test2"];
+    }
+
+    processor(ext) {
+        return {
+            preProcess(text, filePath) {
+                return text;
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath
+                };
+            }
+        };
+    }
+}
+module.exports = {
+    Processor: TestProcessor
+};

--- a/packages/textlint/test/config/config-fixtures/plugin-config/modules/textlint-plugin-pl-example/package.json
+++ b/packages/textlint/test/config/config-fixtures/plugin-config/modules/textlint-plugin-pl-example/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "textlint-plugin-pl-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "azu",
+  "license": "MIT"
+}

--- a/packages/textlint/test/plugin-loader/plugin-loader-test.js
+++ b/packages/textlint/test/plugin-loader/plugin-loader-test.js
@@ -3,10 +3,41 @@
 const assert = require("power-assert");
 const path = require("path");
 import Config from "../../src/config/config";
-import { loadRulesConfig, loadAvailableExtensions } from "../../src/config/plugin-loader";
+import { loadRulesConfig, loadAvailableExtensions, getPluginConfig } from "../../src/config/plugin-loader";
 import TextLintModuleResolver from "../../src/engine/textlint-module-resolver";
+
 const moduleResolver = new TextLintModuleResolver(Config, path.join(__dirname, "fixtures"));
 describe("plugin-loader", function() {
+    describe("#getPluginConfig", () => {
+        it("should return {} when plugins is empty", () => {
+            const pluginsConfig = getPluginConfig({});
+            assert.deepStrictEqual(pluginsConfig, {});
+        });
+
+        it("should return { name: config } map when plugins is array", () => {
+            const pluginsConfig = getPluginConfig({
+                plugins: ["a", "b"]
+            });
+            assert.deepStrictEqual(pluginsConfig, {
+                a: true,
+                b: true
+            });
+        });
+        it("should return { name: config } map when plugins is object", () => {
+            const setPluginsConfig = {
+                a: {
+                    bFlag: "a"
+                },
+                b: {
+                    bFlag: "b"
+                }
+            };
+            const pluginsConfig = getPluginConfig({
+                plugins: setPluginsConfig
+            });
+            assert.deepStrictEqual(pluginsConfig, setPluginsConfig);
+        });
+    });
     describe("#loadRulesConfig", function() {
         context("when the plugin has not {rulesConfig}", function() {
             it("should return empty object", function() {

--- a/packages/textlint/test/pluguins/PluginOption-test.js
+++ b/packages/textlint/test/pluguins/PluginOption-test.js
@@ -1,0 +1,53 @@
+// MIT © 2017 azu
+"use strict";
+const assert = require("power-assert");
+import { TextLintCore } from "../../src/index";
+import { createPluginStub } from "./fixtures/example-plugin";
+
+describe("plugin-option", () => {
+    it("should load plugin options if match ext", () => {
+        const textlintCore = new TextLintCore();
+        const { getPlugin, getOptions } = createPluginStub();
+        const expectedOptions = {
+            test: "expected"
+        };
+        textlintCore.setupPlugins(
+            {
+                example: getPlugin()
+            },
+            {
+                example: expectedOptions
+            }
+        );
+        textlintCore.setupRules({
+            "example-rule": require("./fixtures/example-rule")
+        });
+        return textlintCore.lintText("test", ".example").then(results => {
+            const actualOptions = getOptions();
+            assert.deepStrictEqual(actualOptions, expectedOptions);
+        });
+    });
+    it("should not load plugin options if does't match ext", () => {
+        const textlintCore = new TextLintCore();
+        const { getPlugin, getOptions } = createPluginStub();
+        const expectedOptions = {
+            test: "expected"
+        };
+        textlintCore.setupPlugins(
+            {
+                example: getPlugin()
+            },
+            {
+                example: expectedOptions
+            }
+        );
+        textlintCore.setupRules({
+            "example-rule": require("./fixtures/example-rule")
+        });
+        // .md is built-in
+        return textlintCore.lintText("test", ".md").then(results => {
+            const actualOptions = getOptions();
+            assert.ok(actualOptions === undefined);
+        });
+    });
+});

--- a/packages/textlint/test/pluguins/fixtures/example-plugin.js
+++ b/packages/textlint/test/pluguins/fixtures/example-plugin.js
@@ -1,0 +1,57 @@
+// MIT © 2017 azu
+export class ExampleProcessor {
+    static availableExtensions() {
+        return [".example"];
+    }
+
+    constructor(options) {
+        this.options = options;
+    }
+
+    processor(_extension) {
+        return {
+            preProcess(text, _filePath) {
+                return {
+                    type: "Document",
+                    children: [],
+                    range: [0, 0],
+                    loc: {
+                        start: {
+                            line: 0,
+                            column: 0
+                        },
+                        end: {
+                            line: 0,
+                            column: 0
+                        }
+                    }
+                };
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath: filePath || "unknown"
+                };
+            }
+        };
+    }
+}
+
+export const createPluginStub = () => {
+    let assignedOptions;
+    return {
+        getOptions() {
+            return assignedOptions;
+        },
+        getPlugin() {
+            return {
+                Processor: class MockProcessor extends ExampleProcessor {
+                    constructor(options) {
+                        super(options);
+                        assignedOptions = options;
+                    }
+                }
+            };
+        }
+    };
+};


### PR DESCRIPTION
## Feature

- `kernel` support plugin option via `{ pluginId, plugin, options }`.
- `textlint` support plugin option via `TextlintCore#setupPlugins(plugins, pluginsConfig)`

You can pass a options to your plugin from `.textlintrc`.

```
{
    "plugins": {
        pluginName: processorOption
    }
}
```

You can receive the `processorOption` via constructor arguments.

```js
export default class YourProcessor {
    constructor(options) {
        this.options = options; // <= processorOption!
    }
    // ...
}
```


## Test Plan

- [x] Unit Tests

## Issue

fix #296 