### PR TITLE
fix(textlint): use `path.basename` instead of slice

### DIFF
--- a/packages/textlint/src/engine/rule-loader.js
+++ b/packages/textlint/src/engine/rule-loader.js
@@ -21,7 +21,7 @@ export function loadFromDir(rulesDir, extname = ".js") {
         if (path.extname(file) !== extname) {
             return;
         }
-        const withoutExt = file.slice(0, -3);
+        const withoutExt = path.basename(file, extname);
         rules[withoutExt] = interopRequire(path.join(rulesDirAbsolutePath, file));
     });
     return rules;


### PR DESCRIPTION
fix #272