### PR TITLE
chore(travis): remove duplicated "prepare" scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
     node_js: "stable"
 
 script:
-  - yarn run prepare
   - if [[ "$TEST_TYPE" == "unit" ]]; then yarn test; fi
   - if [[ "$TEST_TYPE" == "unit" ]]; then yarn run example; fi
   - if [[ "$TEST_TYPE" == "e2e" ]]; then yarn run test:integration; fi


### PR DESCRIPTION
`yarn run prepare` is called twice.