### PR TITLE
fix(textlint): don't use error.code when catch error

### DIFF
--- a/packages/textlint/bin/textlint.js
+++ b/packages/textlint/bin/textlint.js
@@ -40,7 +40,7 @@ Promise.resolve()
     })
     .catch(function(error) {
         showError(error);
-        process.exit(error.code || 1);
+        process.exit(1);
     });
 
 // Catch throw error


### PR DESCRIPTION
error.code is a string, not a number.

https://nodejs.org/api/errors.html#errors_error_code