### PR TITLE
feat(textlint-tester): support "index" expected param

### DIFF
--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -80,21 +80,34 @@ const rule = require("textlint-rule-no-todo");
 // ruleName, rule, { valid, invalid }
 tester.run("no-todo", rule, {
     valid: [
-        "this is test",
+        "This is ok",
         {
             // text with options
-            text: "this is test",
+            text: "This is test",
             options: {
                 "key": "value"
             }
         }
     ],
     invalid: [
+        // line, column
         {
             text: "- [ ] string",
             errors: [
                 {
-                    message: "found TODO: '- [ ] string'"
+                    message: "Found TODO: '- [ ] string'",
+                    line: 1,
+                    column: 3
+                }
+            ]
+        },
+        // index
+        {
+            text: "- [ ] string",
+            errors: [
+                {
+                    message: "Found TODO: '- [ ] string'",
+                    index: 2
                 }
             ]
         },

--- a/packages/textlint-tester/src/test-util.js
+++ b/packages/textlint-tester/src/test-util.js
@@ -1,6 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
+
 export function testInvalid(textlint, text, ext, errors) {
     const lines = text.split(/\n/);
     assert.strictEqual(
@@ -44,9 +45,10 @@ ${text}
 ==Result==:
 ${JSON.stringify(lintResult, null, 4)}`
         );
-        errors.forEach((error, index) => {
-            const { ruleId, message, line, column } = error;
-            const resultMessageObject = lintResult.messages[index];
+        errors.forEach((error, errorIndex) => {
+            const { ruleId, message, line, column, index } = error;
+            const resultMessageObject = lintResult.messages[errorIndex];
+            console.log(resultMessageObject);
             // check
             assert.ok(
                 resultMessageObject.line >= 1,
@@ -64,8 +66,8 @@ The result's line number should be less than ${lines.length}`
             );
             assert.ok(
                 resultMessageObject.column <= columnText.length + 1,
-                `lint result's column number is ${resultMessageObject.column}, but the length of the text @ line:${resultMessageObject.line} is ${columnText.length +
-                    1}.
+                `lint result's column number is ${resultMessageObject.column},` +
+                    `but the length of the text @ line:${resultMessageObject.line} is ${columnText.length + 1}.
 The result's column number should be less than ${columnText.length + 1}`
             );
             if (ruleId !== undefined) {
@@ -83,6 +85,10 @@ The result's column number should be less than ${columnText.length + 1}`
             if (column !== undefined) {
                 const resultColumn = resultMessageObject.column;
                 assert.strictEqual(resultColumn, column, `"column should be ${column}`);
+            }
+            if (index !== undefined) {
+                const resultIndex = resultMessageObject.index;
+                assert.strictEqual(resultIndex, index, `"index should be ${index}`);
             }
         });
     });

--- a/packages/textlint-tester/test/textlint-tester-test.js
+++ b/packages/textlint-tester/test/textlint-tester-test.js
@@ -16,6 +16,7 @@ tester.run("no-todo", noTodo, {
         }
     ],
     invalid: [
+        // line, column
         {
             text: "- [ ] string",
             errors: [
@@ -23,6 +24,16 @@ tester.run("no-todo", noTodo, {
                     message: "Found TODO: '- [ ] string'",
                     line: 1,
                     column: 3
+                }
+            ]
+        },
+        // index
+        {
+            text: "- [ ] string",
+            errors: [
+                {
+                    message: "Found TODO: '- [ ] string'",
+                    index: 2
                 }
             ]
         },


### PR DESCRIPTION
Allow to write following `index` based testing.
```js

        // index
        {
            text: "- [ ] string",
            errors: [
                {
                    message: "Found TODO: '- [ ] string'",
                    index: 2
                }
            ]
        },
```