### PR TITLE
feat(textlint): support shortcut scoped package name

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -38,9 +38,9 @@ Add rule name to `rules` field.
 - `true` means that enable `"no-todo"` rule
 - `false` means that disable `"very-nice-rule"` rule
 
-### Rule's config
+### Rule's options
 
-Each rule's config can accept a `object`.
+Each rule's options can accept a `object`.
 
 ```json
 {
@@ -67,6 +67,23 @@ export default function rule(contet, config){
     /* { "key" : "value" } */
 }
 ```
+
+### Rule name
+
+```json
+{
+  "rules": {
+    "<name>": true
+  }
+}
+```
+
+The rule `<name>` can be accept following patterns:
+
+- `textlint-rule-<name>`
+- `<name>`
+- `@scope/textlint-rule-<name>`
+- `@scope/<name>`
 
 ### Severity config of rules
 
@@ -171,31 +188,6 @@ One more example, `very-nice-rule` is useful, but you want to ignore some report
 ```
 
 :information_source: See [examples/filter](../examples/filter)
-
-## Plugin
-
-textlint plugin also has a set of rules and rulesConfig.
-
-It is similar to preset, but plugin's [main task is extension of feature](./plugin.md)
-
-To enable plugin, put the "plugin-name" into `.textlinrc`.
-
-```json
-{
-    "plugins": [
-        "plugin-name"
-    ],
-    // overwrite-plugins rules config
-    // <plugin>/<rule>
-    "rules": {
-        "plugin-name/rule-name" : false
-    }
-}
-```
-
-:information_source: See [docs/plugin.md](docs/plugin.md)
-
-## Sharable Configuration
 
 textlint support module of configuration.
 

--- a/docs/filter-rule.md
+++ b/docs/filter-rule.md
@@ -16,6 +16,23 @@ Add filter rule name to `filters` field.
 
 See [configuring.md](./configuring.md) for details.
 
+### Filter rule name
+
+```json
+{
+  "filters": {
+    "<name>": true
+  }
+}
+```
+
+The rule `<name>` can be accept following patterns:
+
+- `textlint-filter-rule-<name>`
+- `<name>`
+- `@scope/textlint-filter-rule-<name>`
+- `@scope/<name>`
+
 ## FilterRuleContext
 
 `shouldIgnore()` is core API of `FilterRuleContext`.
@@ -69,9 +86,9 @@ module.exports = function(context) {
 
 textlint's filter rule should use `textlint-filter-rule-` prefix.
 
-e.g.) `textlint-filter-rule-comments`
+For example, filtering by comment rule is `textlint-filter-rule-comments`.
 
-textlint user use it following:
+textlint user use it by setting following:
 
 ```json
 {
@@ -81,6 +98,6 @@ textlint user use it following:
 }
 ```
 
-Examples:
+### Example rules:
 
 - [textlint-filter-rule-comments](https://github.com/textlint/textlint-filter-rule-comments "textlint-filter-rule-comments")

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -97,7 +97,24 @@ export default class YourProcessor {
     // ...
 }
 ```
-### Example
+
+## Package name convention
+
+textlint's plugin should use `textlint-plugin-` prefix.
+
+For example, markdown plugins is named `textlint-plugin-markdown`.
+
+textlint user use it by setting following:
+
+```json
+{
+    "plugins": {
+        "markdown": true
+    }
+}
+```
+
+## Example
 
 (limited) XML plugin
 

--- a/packages/textlint/src/engine/textlint-module-resolver.js
+++ b/packages/textlint/src/engine/textlint-module-resolver.js
@@ -12,6 +12,31 @@ const validateConfigConstructor = ConfigConstructor => {
             ConfigConstructor.PLUGIN_NAME_PREFIX
     );
 };
+
+/**
+ * Create full package name and return
+ * @param {string} prefix
+ * @param {string} name
+ * @returns {string}
+ */
+export const createFullPackageName = (prefix, name) => {
+    if (name.charAt(0) === "@") {
+        /*
+         * it's a scoped package
+         * package name is "textlint-rule", or just a username
+         */
+        const scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`);
+        if (!scopedPackageNameRegex.test(name.split("/")[1])) {
+            // if @scope/<name> -> @scope/<prefix><name>
+            /*
+             * for scoped packages, insert the textlint-rule after the first / unless
+             * the path is already @scope/<name> or @scope/textlint-rule-<name>
+             */
+            return name.replace(/^@([^/]+)\/(.*)$/, `@$1/${prefix}$2`);
+        }
+    }
+    return `${prefix}${name}`;
+};
 /**
  * This class aim to resolve textlint's package name and get the module path.
  *
@@ -72,7 +97,7 @@ export default class TextLintModuleResolver {
     resolveRulePackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.RULE_NAME_PREFIX;
-        const fullPackageName = `${PREFIX}${packageName}`;
+        const fullPackageName = createFullPackageName(PREFIX, packageName);
         // <rule-name> or textlint-rule-<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
@@ -91,8 +116,8 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
     resolveFilterRulePackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.FILTER_RULE_NAME_PREFIX;
-        const fullPackageName = `${PREFIX}${packageName}`;
-        // <rule-name> or textlint-filter-rule-<rule-name>
+        const fullPackageName = createFullPackageName(PREFIX, packageName);
+        // <rule-name> or textlint-filter-rule-<rule-name> or @scope/<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
             throw new ReferenceError(`Failed to load textlint's filter rule module: "${packageName}" is not found.
@@ -110,7 +135,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
     resolvePluginPackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.PLUGIN_NAME_PREFIX;
-        const fullPackageName = `${PREFIX}${packageName}`;
+        const fullPackageName = createFullPackageName(PREFIX, packageName);
         // <plugin-name> or textlint-plugin-<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
@@ -129,10 +154,10 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
     resolvePresetPackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.RULE_PRESET_NAME_PREFIX;
-        const fullPackageName = `${PREFIX}${packageName}`;
+        const fullPackageName = createFullPackageName(PREFIX, packageName);
 
         /* Implementation Note
-        
+
         preset name is defined in config file:
         In the case, `packageName` is "preset-gizmo"
         TextLintModuleResolver resolve "preset-gizmo" to "textlint-rule-preset-gizmo"
@@ -171,7 +196,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
     resolveConfigPackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.CONFIG_PACKAGE_PREFIX;
-        const fullPackageName = `${PREFIX}${packageName}`;
+        const fullPackageName = createFullPackageName(PREFIX, packageName);
         // <plugin-name> or textlint-config-<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {

--- a/packages/textlint/src/engine/textlint-module-resolver.js
+++ b/packages/textlint/src/engine/textlint-module-resolver.js
@@ -21,13 +21,9 @@ const validateConfigConstructor = ConfigConstructor => {
  */
 export const createFullPackageName = (prefix, name) => {
     if (name.charAt(0) === "@") {
-        /*
-         * it's a scoped package
-         * package name is "textlint-rule", or just a username
-         */
         const scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`);
+        // if @scope/<name> -> @scope/<prefix><name>
         if (!scopedPackageNameRegex.test(name.split("/")[1])) {
-            // if @scope/<name> -> @scope/<prefix><name>
             /*
              * for scoped packages, insert the textlint-rule after the first / unless
              * the path is already @scope/<name> or @scope/textlint-rule-<name>

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-scoped-rule/index.js
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-scoped-rule/index.js
@@ -1,0 +1,12 @@
+// LICENSE : MIT
+"use strict";
+/**
+ * @param {RuleContext} context
+ */
+module.exports = function(context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function(node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-scoped-rule/package.json
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-scoped-rule/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@textlint/textlint-rule-scoped-rule",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+  },
+  "author": "azu",
+  "license": "MIT"
+}

--- a/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
+++ b/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
@@ -2,13 +2,32 @@
 "use strict";
 const path = require("path");
 import assert from "power-assert";
-import TextLintModuleResolver from "../../src/engine/textlint-module-resolver";
+import TextLintModuleResolver, { createFullPackageName } from "../../src/engine/textlint-module-resolver";
 import Config from "../../src/config/config";
+
 const FIXTURE_DIR = path.join(__dirname, "fixtures");
 const createResolve = ruleBaseDir => {
     return new TextLintModuleResolver(Config, ruleBaseDir);
 };
 describe("textlint-module-resolver", function() {
+    describe("createFullPackageName", () => {
+        const PREFIX = "textlint-rule-";
+        it("<name> -> textlint-rule-<name>", () => {
+            assert.equal(createFullPackageName(PREFIX, "name"), "textlint-rule-name");
+        });
+        it("textlint-rule-<name> -> textlint-rule-<name>", () => {
+            assert.equal(createFullPackageName(PREFIX, "textlint-rule-name"), "textlint-rule-textlint-rule-name");
+        });
+        it("@scope/<name> -> @scope/textlint-rule-<name>", () => {
+            assert.equal(createFullPackageName(PREFIX, "@scope/name"), "@scope/textlint-rule-name");
+        });
+        it("@scope/textlint-rule-<name> -> @scope/textlint-rule-<name>", () => {
+            assert.equal(
+                createFullPackageName(PREFIX, "@scope/textlint-rule-name"),
+                "@scope/textlint-rule-textlint-rule-name"
+            );
+        });
+    });
     describe("#resolveRulePackageName", function() {
         it("should resolve rule package name", function() {
             const resolver = createResolve();
@@ -18,12 +37,19 @@ describe("textlint-module-resolver", function() {
             assert.equal(typeof longPkg, "string");
             assert.equal(shortPkg, longPkg);
         });
+        it("should resolve scoped short style package", function() {
+            const resolver = createResolve(FIXTURE_DIR);
+            const shortPkg = resolver.resolveRulePackageName("@textlint/scoped-rule");
+            const longPkg = resolver.resolveRulePackageName("@textlint/textlint-rule-scoped-rule");
+            assert.equal(typeof longPkg, "string");
+            assert.equal(shortPkg, longPkg);
+        });
         it("should resolve rule file path", function() {
             const resolver = createResolve(FIXTURE_DIR);
             const packageName = "rule";
             const modulePath = resolver.resolveRulePackageName(packageName);
             assert.equal(typeof modulePath, "string");
-            assert.equal(modulePath, path.resolve(FIXTURE_DIR, packageName + ".js"));
+            assert.equal(modulePath, path.resolve(FIXTURE_DIR, `${packageName}.js`));
         });
         it("Not found, throw error", function() {
             const resolver = createResolve(FIXTURE_DIR);
@@ -39,7 +65,7 @@ describe("textlint-module-resolver", function() {
             const packageName = "filter-rule";
             const modulePath = resolver.resolveFilterRulePackageName(packageName);
             assert.equal(typeof modulePath, "string");
-            assert.equal(modulePath, path.resolve(FIXTURE_DIR, packageName + ".js"));
+            assert.equal(modulePath, path.resolve(FIXTURE_DIR, `${packageName}.js`));
         });
         it("Not found, throw error", function() {
             const resolver = createResolve(FIXTURE_DIR);
@@ -63,7 +89,7 @@ describe("textlint-module-resolver", function() {
             const packageName = "plugin";
             const modulePath = resolver.resolvePluginPackageName(packageName);
             assert.equal(typeof modulePath, "string");
-            assert.equal(modulePath, path.resolve(FIXTURE_DIR, packageName + ".js"));
+            assert.equal(modulePath, path.resolve(FIXTURE_DIR, `${packageName}.js`));
         });
         it("Not found, throw error", function() {
             const resolver = createResolve(FIXTURE_DIR);
@@ -106,7 +132,7 @@ describe("textlint-module-resolver", function() {
             const packageName = "preset";
             const modulePath = resolver.resolvePresetPackageName(packageName);
             assert.equal(typeof modulePath, "string");
-            assert.equal(modulePath, path.resolve(FIXTURE_DIR, packageName + ".js"));
+            assert.equal(modulePath, path.resolve(FIXTURE_DIR, `${packageName}.js`));
         });
         it("Not found, throw error", function() {
             const resolver = createResolve(FIXTURE_DIR);
@@ -135,7 +161,7 @@ describe("textlint-module-resolver", function() {
             const packageName = "config";
             const modulePath = resolver.resolveConfigPackageName(packageName);
             assert.equal(typeof modulePath, "string");
-            assert.equal(modulePath, path.resolve(FIXTURE_DIR, packageName + ".js"));
+            assert.equal(modulePath, path.resolve(FIXTURE_DIR, `${packageName}.js`));
         });
         it("Not found, throw error", function() {
             const resolver = createResolve(FIXTURE_DIR);


### PR DESCRIPTION
`@scope/name` -> `@scope/textlint-rule-name`.

fix #271 