### PR TITLE
fix(textlint): support scoped preset module 

### DIFF
--- a/packages/textlint-kernel/package.json
+++ b/packages/textlint-kernel/package.json
@@ -56,7 +56,7 @@
     "shelljs": "^0.7.7",
     "textlint-plugin-markdown": "^3.0.2",
     "ts-node": "^3.3.0",
-    "typescript": "^2.5.2",
+    "typescript": "~2.5.2",
     "typescript-json-schema": "^0.11.0"
   },
   "dependencies": {

--- a/packages/textlint/src/engine/textlint-module-resolver.js
+++ b/packages/textlint/src/engine/textlint-module-resolver.js
@@ -145,19 +145,17 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
     /**
      * Take package name, and return path to module.
      * @param {string} packageName
+     * The user must specify preset- prefix to these `packageName`.
      * @returns {string} return path to module
      */
     resolvePresetPackageName(packageName) {
         const baseDir = this.baseDirectory;
         const PREFIX = this.RULE_PRESET_NAME_PREFIX;
-        const fullPackageName = createFullPackageName(PREFIX, packageName);
-
         /* Implementation Note
 
         preset name is defined in config file:
         In the case, `packageName` is "preset-gizmo"
         TextLintModuleResolver resolve "preset-gizmo" to "textlint-rule-preset-gizmo"
-
         {
             "rules": {
                 "preset-gizmo": {
@@ -166,8 +164,14 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
             }
         }
          */
-        // <preset-name> or textlint-rule-preset-<rule-name>
-        const packageNameWithoutPreset = packageName.replace(/^preset-/, "");
+        // preset-<name> or textlint-rule-preset-<name>
+        // @scope/preset-<name> or @scope/textlint-rule-preset-<name>
+        const packageNameWithoutPreset = packageName
+            // preset-<name> -> <name>
+            .replace(/^preset-/, "")
+            // @scope/preset-<name> -> @scope/<name>
+            .replace(/^@([^/]+)\/preset-(.*)$/, `@$1/$2`);
+        const fullPackageName = createFullPackageName(PREFIX, packageNameWithoutPreset);
         const fullFullPackageName = `${PREFIX}${packageNameWithoutPreset}`;
         // preset-<preset-name> or textlint-rule-preset-<preset-name>
         const pkgPath =

--- a/packages/textlint/src/engine/textlint-module-resolver.js
+++ b/packages/textlint/src/engine/textlint-module-resolver.js
@@ -3,6 +3,7 @@
 const assert = require("assert");
 const path = require("path");
 const tryResolve = require("try-resolve");
+const debug = require("debug")("textlint:module-resolver");
 const validateConfigConstructor = ConfigConstructor => {
     assert(
         ConfigConstructor.CONFIG_PACKAGE_PREFIX &&
@@ -97,6 +98,7 @@ export default class TextLintModuleResolver {
         // <rule-name> or textlint-rule-<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
+            debug(`rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load textlint's rule module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
 `);
@@ -116,6 +118,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         // <rule-name> or textlint-filter-rule-<rule-name> or @scope/<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
+            debug(`filter rule fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load textlint's filter rule module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
 `);
@@ -135,6 +138,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         // <plugin-name> or textlint-plugin-<rule-name>
         const pkgPath = tryResolve(path.join(baseDir, fullPackageName)) || tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
+            debug(`plugin fullPackageName: ${fullPackageName}`);
             throw new ReferenceError(`Failed to load textlint's plugin module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
 `);
@@ -181,6 +185,8 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
             tryResolve(path.join(baseDir, fullPackageName)) ||
             tryResolve(path.join(baseDir, packageName));
         if (!pkgPath) {
+            debug(`preset fullPackageName: ${fullPackageName}`);
+            debug(`preset fullFullPackageName: ${fullFullPackageName}`);
             throw new ReferenceError(`Failed to load textlint's preset module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
 `);

--- a/packages/textlint/src/util/config-util.js
+++ b/packages/textlint/src/util/config-util.js
@@ -1,5 +1,6 @@
 // LICENSE : MIT
 "use strict";
+
 export function isPluginRuleKey(key) {
     // @<owner>/<plugin><>rule>
     if (key[0] === "@" && key.indexOf("/textlint-plugin") !== -1) {
@@ -9,13 +10,11 @@ export function isPluginRuleKey(key) {
     // <plugin>/<rule>
     return key[0] !== "@" && key.indexOf("/") !== -1;
 }
+
 export function isPresetRuleKey(key) {
-    if (/^preset/.test(key)) {
+    if (/^preset-/.test(key)) {
         return true;
     }
     // scoped module: @textlint/textlint-rule-preset-foo
-    if (key[0] === "@" && key.indexOf("/textlint-rule-preset") !== -1) {
-        return true;
-    }
-    return false;
+    return key[0] === "@" && (key.indexOf("/textlint-rule-preset-") !== -1 || key.indexOf("/preset-") !== -1);
 }

--- a/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/.textlintrc
+++ b/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/.textlintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@textlint/preset-foo": true
+  }
+}

--- a/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/expect.js
+++ b/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/expect.js
@@ -1,0 +1,9 @@
+const path = require("path");
+module.exports = {
+    rules: [],
+    presets: ["@textlint/preset-foo"],
+    rulesConfig: {
+        "@textlint/preset-foo/a": true
+    },
+    configFile: path.join(__dirname, ".textlintrc")
+};

--- a/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/index.js
+++ b/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/index.js
@@ -1,0 +1,10 @@
+// LICENSE : MIT
+"use strict";
+module.exports = {
+    rules: {
+        a: require("./rules/textlint-rule-a")
+    },
+    rulesConfig: {
+        a: true
+    }
+};

--- a/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/package.json
+++ b/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "textlint-rule-preset-foo",
+  "main": "index.js",
+  "private": true
+}

--- a/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/rules/textlint-rule-a.js
+++ b/packages/textlint/test/config/config-fixtures/preset-short-scoped-module/modules/@textlint/textlint-rule-preset-foo/rules/textlint-rule-a.js
@@ -1,0 +1,7 @@
+module.exports = function(context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function(node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/index.js
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/index.js
@@ -1,0 +1,12 @@
+// LICENSE : MIT
+"use strict";
+module.exports = {
+    rules: {
+        a: require("./rules/textlint-rule-a"),
+        b: require("./rules/textlint-rule-b")
+    },
+    rulesConfig: {
+        a: true,
+        b: true
+    }
+};

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/package.json
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@textlint/textlint-rule-preset-example",
+  "main": "index.js",
+  "private": true
+}

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/rules/textlint-rule-a.js
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/rules/textlint-rule-a.js
@@ -1,0 +1,7 @@
+module.exports = function(context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function(node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/rules/textlint-rule-b.js
+++ b/packages/textlint/test/textlint-module-resolver/fixtures/@textlint/textlint-rule-preset-example/rules/textlint-rule-b.js
@@ -1,0 +1,7 @@
+module.exports = function(context) {
+    var exports = {};
+    exports[context.Syntax.Str] = function(node) {
+        context.report(node, new context.RuleError("found error message"));
+    };
+    return exports;
+};

--- a/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
+++ b/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
@@ -27,6 +27,9 @@ describe("textlint-module-resolver", function() {
                 "@scope/textlint-rule-textlint-rule-name"
             );
         });
+        it("@scope/preset-<name> -> @scope/textlint-rule-preset-<name>", () => {
+            assert.equal(createFullPackageName(PREFIX, "@scope/preset-name"), "@scope/textlint-rule-preset-name");
+        });
     });
     describe("#resolveRulePackageName", function() {
         it("should resolve rule package name", function() {
@@ -101,15 +104,6 @@ describe("textlint-module-resolver", function() {
     });
     describe("#resolvePresetPackageName", function() {
         context("In Configuration", function() {
-            /*
-             {
-             "rules": {
-             "preset-gizmo": {
-             "ruleA": false
-             }
-             }
-             }
-             */
             it("should resolve plugin package name", function() {
                 const resolver = createResolve();
                 const shortPkg = resolver.resolvePresetPackageName("preset-jtf-style");
@@ -119,11 +113,19 @@ describe("textlint-module-resolver", function() {
                 assert.equal(shortPkg, longPkg);
             });
         });
-        it("should resolve plugin package name", function() {
+        it("should not resolve package name without preset- prefix", function() {
             const resolver = createResolve();
             const shortPkg = resolver.resolvePresetPackageName("jtf-style");
             assert.equal(typeof shortPkg, "string");
             const longPkg = resolver.resolvePresetPackageName("textlint-rule-preset-jtf-style");
+            assert.equal(typeof longPkg, "string");
+            assert.equal(shortPkg, longPkg);
+        });
+        it("should resolve scoped package name", function() {
+            const resolver = createResolve(FIXTURE_DIR);
+            const shortPkg = resolver.resolvePresetPackageName("@textlint/preset-example");
+            assert.equal(typeof shortPkg, "string");
+            const longPkg = resolver.resolvePresetPackageName("@textlint/textlint-rule-preset-example");
             assert.equal(typeof longPkg, "string");
             assert.equal(shortPkg, longPkg);
         });

--- a/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
+++ b/packages/textlint/test/textlint-module-resolver/textlint-module-resolver-test.js
@@ -113,7 +113,7 @@ describe("textlint-module-resolver", function() {
                 assert.equal(shortPkg, longPkg);
             });
         });
-        it("should not resolve package name without preset- prefix", function() {
+        it("should resolve package name without preset- prefix", function() {
             const resolver = createResolve();
             const shortPkg = resolver.resolvePresetPackageName("jtf-style");
             assert.equal(typeof shortPkg, "string");


### PR DESCRIPTION
Follow up #326 
fix #327 

Work following config.

```
{
  "filters": {
    "comments": true
  },
  "rules": {
    "@textlint-rule/preset-google": true
}
```

