### PR TITLE
 refactor(textlint): export as ES module

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -11,29 +11,28 @@
 // Level of abstraction(descending order)
 // cli > TextLintEngine > TextLintCore(textlint)
 // See: https://github.com/textlint/textlint/blob/master/docs/use-as-modules.md
-module.exports = {
-    // Command line interface
-    cli,
-    // TextLintEngine is a wrapper around `textlint` for linting **multiple** files
-    // include formatter, detecting utils
-    // <Recommend>: It is easy to use
-    // You can see engine/textlint-engine-core.js for more detail
-    TextLintEngine,
-    // TextFixEngine is a wrapper around `textlint` for linting **multiple** files
-    // include formatter, detecting utils
-    // <Recommend>: It is easy to use
-    // You can see engine/textlint-engine-core.js for more detail
-    TextFixEngine,
-    // It is a singleton object of TextLintCore
-    // Recommend: use TextLintCore
-    textlint,
-    // Core API for linting a **single** text or file.
-    TextLintCore,
-    // Constant Types
-    TextLintMessageType: MessageType,
-    TextLintMessageSeverityLevel: SeverityLevel,
-    TextLintNodeType
-};
+
+// Command line interface
+export { cli } from "./cli";
+
+// It is a singleton object of TextLintCore
+// Recommend: use TextLintCore
+export { textlint } from "./textlint";
+
+// TextLintEngine is a wrapper around `textlint` for linting **multiple** files
+// include formatter, detecting utils
+// <Recommend>: It is easy to use
+// You can see engine/textlint-engine-core.js for more detail
+export { TextLintEngine } from "./textlint-engine";
+
+// TextFixEngine is a wrapper around `textlint` for linting **multiple** files
+// include formatter, detecting utils
+// <Recommend>: It is easy to use
+// You can see engine/textlint-engine-core.js for more detail
+export { TextFixEngine } from "./textfix-engine";
+
+// Core API for linting a **single** text or file.
+export { TextLintCore } from "./textlint-core";
 ```
 
 Recommend to use `TextLintEngine`.

--- a/packages/textlint/src/index.ts
+++ b/packages/textlint/src/index.ts
@@ -1,37 +1,34 @@
 // LICENSE : MIT
 "use strict";
-import { cli } from "./cli";
-import { textlint } from "./textlint";
-import { TextLintEngine } from "./textlint-engine";
-import { TextFixEngine } from "./textfix-engine";
-import { TextLintCore } from "./textlint-core";
-// FIXME: will be removed
-import { MessageType } from "./shared/type/MessageType";
-import { SeverityLevel } from "./shared/type/SeverityLevel";
-import { ASTNodeTypes } from "@textlint/ast-node-types";
+
 // Level of abstraction(descending order)
 // cli > TextLintEngine > TextLintCore(textlint)
 // See: https://github.com/textlint/textlint/blob/master/docs/use-as-modules.md
-module.exports = {
-    // Command line interface
-    cli,
-    // TextLintEngine is a wrapper around `textlint` for linting **multiple** files
-    // include formatter, detecting utils
-    // <Recommend>: It is easy to use
-    // You can see engine/textlint-engine-core.js for more detail
-    TextLintEngine,
-    // TextFixEngine is a wrapper around `textlint` for linting **multiple** files
-    // include formatter, detecting utils
-    // <Recommend>: It is easy to use
-    // You can see engine/textlint-engine-core.js for more detail
-    TextFixEngine,
-    // It is a singleton object of TextLintCore
-    // Recommend: use TextLintCore
-    textlint,
-    // Core API for linting a **single** text or file.
-    TextLintCore,
-    // Constant Types
-    TextLintMessageType: MessageType,
-    TextLintMessageSeverityLevel: SeverityLevel,
-    TextLintNodeType: ASTNodeTypes
-};
+
+// Command line interface
+export { cli } from "./cli";
+
+// It is a singleton object of TextLintCore
+// Recommend: use TextLintCore
+export { textlint } from "./textlint";
+
+// TextLintEngine is a wrapper around `textlint` for linting **multiple** files
+// include formatter, detecting utils
+// <Recommend>: It is easy to use
+// You can see engine/textlint-engine-core.js for more detail
+export { TextLintEngine } from "./textlint-engine";
+
+// TextFixEngine is a wrapper around `textlint` for linting **multiple** files
+// include formatter, detecting utils
+// <Recommend>: It is easy to use
+// You can see engine/textlint-engine-core.js for more detail
+export { TextFixEngine } from "./textfix-engine";
+
+// Core API for linting a **single** text or file.
+export { TextLintCore } from "./textlint-core";
+
+// Constant Types
+// FIXME: will be removed
+export { MessageType as TextLintMessageType } from "./shared/type/MessageType";
+export { SeverityLevel as TextLintMessageSeverityLevel } from "./shared/type/SeverityLevel";
+export { ASTNodeTypes as TextLintNodeType } from "@textlint/ast-node-types";

--- a/packages/textlint/src/index.ts
+++ b/packages/textlint/src/index.ts
@@ -26,9 +26,3 @@ export { TextFixEngine } from "./textfix-engine";
 
 // Core API for linting a **single** text or file.
 export { TextLintCore } from "./textlint-core";
-
-// Constant Types
-// FIXME: will be removed
-export { MessageType as TextLintMessageType } from "./shared/type/MessageType";
-export { SeverityLevel as TextLintMessageSeverityLevel } from "./shared/type/SeverityLevel";
-export { ASTNodeTypes as TextLintNodeType } from "@textlint/ast-node-types";


### PR DESCRIPTION
This PR closes #337 

## Additional changes
- Fixed `FIXME` comment because test passed even if remove constant types.
- Update Use as module documentation