### PR TITLE
docs(CONTRIBUTING): Add option to git clone/submodule

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -111,7 +111,7 @@ We use yarn as package manager.
 Please [install yarn](https://yarnpkg.com/lang/en/docs/install/) before starting development.
 
 ```sh
-git clone {YOUR_FORKED_REPOSITORY}
+git clone --recursive {YOUR_FORKED_REPOSITORY}
 cd {YOUR_FORKED_REPOSITORY}
 yarn install
 yarn run bootstrap
@@ -156,7 +156,7 @@ This test is heavy.
 
 ```sh
 # Require git submodule
-git submodule update
+git submodule update --init
 # Run test
 yarn run test:integration
 ```


### PR DESCRIPTION
For first time contributors, following changes should be added in order
to finish integration test without error. Will fix textlint/textlint#377.

- Add `--recursive` to `git clone` on [Install](https://github.com/textlint/textlint/blob/a4688b99896aba26a064a081c34115acb943295e/.github/CONTRIBUTING.md#install) section.
- Add `--init` to `git submodule update` on [Integration Test](https://github.com/textlint/textlint/blob/a4688b99896aba26a064a081c34115acb943295e/.github/CONTRIBUTING.md#integration-test) section.