### PR TITLE
fix(ast-node-types): Make TxtNode non-weak type

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -17,25 +17,48 @@ Each node of the tree has same interface, is called `TxtNode`.
 `TxtNode` has these properties.
 
 ```typescript
+/**
+ * Basic TxtNode
+ * Probably, Real TxtNode implementation has more properties.
+ */
 interface TxtNode {
     type: string;
     raw: string;
-    range: [number, number]
-    loc: LineLocation;
+    range: TextNodeRange;
+    loc: TxtNodeLineLocation;
     // parent is runtime information
     // Not need in AST
+    // For example, top Root Node like `Document` has not parent.
     parent?: TxtNode;
+
+    [index: string]: any;
 }
-interface LineLocation {
-    start: Position;
-    end: Position;
+
+
+/**
+ * Location
+ */
+interface TxtNodeLineLocation {
+    start: TxtNodePosition;
+    end: TxtNodePosition;
 }
-interface Position {
+
+/**
+ * Position's line start with 1.
+ * Position's column start with 0.
+ * This is for compatibility with JavaScript AST.
+ * https://gist.github.com/azu/8866b2cb9b7a933e01fe
+ */
+interface TxtNodePosition {
     line: number; // start with 1
-    column: number;// start with 0
-    // This is for compatibility with JavaScript AST.
-    // https://gist.github.com/azu/8866b2cb9b7a933e01fe
+    column: number; // start with 0
 }
+
+/**
+ * Range start with 0
+ */
+type TextNodeRange = [number, number];
+
 ```
 
 - `type`: type of Node
@@ -50,8 +73,13 @@ interface Position {
 `TxtInlineNode` is inherit the `TxtNode` abstract interface.
 
 ```typescript
+/**
+ * Text Node.
+ * Text Node has inline value.
+ * For example, `Str` Node is an TxtTextNode.
+ */
 interface TxtTextNode extends TxtNode {
-    value: string
+    value: string;
 }
 ```
 
@@ -62,8 +90,12 @@ interface TxtTextNode extends TxtNode {
 `TxtParentNode` is inherit the `TxtNode` abstract interface.
 
 ```typescript
+/**
+ * Parent Node.
+ * Parent Node has children that are consist of TxtNode or TxtTextNode
+ */
 interface TxtParentNode extends TxtNode {
-    children: TxtNode[] | TxtTextNode[];
+    children: Array<TxtNode | TxtTextNode>;
 }
 ```
 
@@ -186,7 +218,7 @@ In other word, textlint's rule handle `TxtNode`, but [formatter](./formatter.md 
 
 Input: `*text*`
 
-Output: AST by [markdown-to-ast](https://github.com/textlint/markdown-to-ast "markdown-to-ast")
+Output: The AST by [AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") + Markdown
 
 ```json
 {

--- a/packages/@textlint/ast-node-types/src/TextLintASTNodeTypes.ts
+++ b/packages/@textlint/ast-node-types/src/TextLintASTNodeTypes.ts
@@ -36,6 +36,7 @@ export type TxtNodeType = keyof typeof ASTNodeTypes | string;
 
 /**
  * Basic TxtNode
+ * Probably, Real TxtNode implementation has more properties.
  */
 export interface TxtNode {
     type: TxtNodeType;
@@ -44,33 +45,10 @@ export interface TxtNode {
     loc: TxtNodeLineLocation;
     // parent is runtime information
     // Not need in AST
+    // For example, top Root Node like `Document` has not parent.
     parent?: TxtNode;
-}
 
-/**
- * Inline Text Node.
- * For example, Str Node.
- */
-export interface TxtTextNode extends TxtNode {
-    value: string;
-}
-
-/**
- * Parent Node.
- * For example, Paragraph Node
- */
-export interface TxtParentNode extends TxtNode {
-    children: TxtNode[] | TxtTextNode[];
-}
-
-/**
- * Root Node.
- * Root Node is only one in the document.
- * In other words, Root Node is Document Node.
- */
-export interface TxtRootNode extends TxtNode {
-    type: "Document";
-    children: TxtNode[];
+    [index: string]: any;
 }
 
 /**
@@ -96,3 +74,20 @@ export interface TxtNodePosition {
  * Range start with 0
  */
 export type TextNodeRange = [number, number];
+
+/**
+ * Text Node.
+ * Text Node has inline value.
+ * For example, `Str` Node is an TxtTextNode.
+ */
+export interface TxtTextNode extends TxtNode {
+    value: string;
+}
+
+/**
+ * Parent Node.
+ * Parent Node has children that are consist of TxtNode or TxtTextNode
+ */
+export interface TxtParentNode extends TxtNode {
+    children: Array<TxtNode | TxtTextNode>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,10 @@
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
+"@types/node@^8.0.58":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
+
 "@types/source-map-support@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@types/source-map-support/-/source-map-support-0.4.0.tgz#a62a1866614af68c888173c001481f242aaf148b"
@@ -6229,6 +6233,10 @@ preserve@^0.2.0:
 prettier@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+
+prettier@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
 
 pretty-format@^21.1.0:
   version "21.1.0"


### PR DESCRIPTION
- `TxtNode` allow to set optional property
- Update txtnode.md
- Remove `TxtRootNode` from `@textlint/ast-node-types`

`@textlint/ast-node-types`'s scope is Abstract Syntax Tree.
It is inspiered by [unist](https://github.com/syntax-tree/unist "unist").
`@textlint/ast-node-types` does not include detailed Node interface like `StrNode`.