### PR TITLE
feat(textlint-tester): support `inputPath` option

### DIFF
--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -15,13 +15,15 @@
 
 #### TextLintTester#run(ruleName, rule, {valid=[], invalid=[]})
 
+##### valid object
+
 - `{string} ruleName` ruleName is a name of the rule.
 - `{Function} rule` rule is the exported function of the rule.
 - `{string[]|object[]} valid` valid is an array of text which should be passed.
     - You can use `object` if you want to specify some options. `object` can have the following properties:
         - `{string} text`: a text to be linted
         - `{string} ext`: an extension key. Default: `.md` (Markdown)
-        - `{string} filePath`: a test text filePath that prefer to `text` property
+        - `{string} inputPath`: a test text filePath that prefer to `text` property
         - `{object} options`: options to be passed to the rule
 
 `valid` object example:
@@ -43,9 +45,13 @@
 ]
 ```
 
+
+##### invalid object
+
 - `{object[]} invalid` invalid is an array of object which should be failed.
     - `object` can have the following properties:
         - `{string} text`: a text to be linted.
+        - `{string} inputPath`: a test text filePath that prefer to `text` property.
         - `{string} output`: a fixed text.
         - `{string} ext`: an extension key.
         - `{object[]} errors`: an array of error objects which should be raised againt the text.

--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -20,8 +20,9 @@
 - `{string[]|object[]} valid` valid is an array of text which should be passed.
     - You can use `object` if you want to specify some options. `object` can have the following properties:
         - `{string} text`: a text to be linted
-        - `{object} options`: options to be passed to the rule
         - `{string} ext`: an extension key. Default: `.md` (Markdown)
+        - `{string} filePath`: a test text filePath that prefer to `text` property
+        - `{object} options`: options to be passed to the rule
 
 `valid` object example:
 

--- a/packages/textlint-tester/src/test-util.js
+++ b/packages/textlint-tester/src/test-util.js
@@ -6,30 +6,30 @@ const fs = require("fs");
 /**
  *
  * @param {string} [text]
- * @param {string} [filePath]
+ * @param {string} [inputPath]
  * @returns {string}
  */
-function getTestText({ text, filePath }) {
+function getTestText({ text, inputPath }) {
     if (text !== undefined) {
         return text;
     }
-    if (filePath === undefined) {
-        throw new Error("should be defined { text } or { filePath }");
+    if (inputPath === undefined) {
+        throw new Error("should be defined { text } or { inputPath }");
     }
-    return fs.readFileSync(filePath, "utf-8");
+    return fs.readFileSync(inputPath, "utf-8");
 }
 
 /**
  * @param {TextLintCore} textlint
  * @param {string} [text]
  * @param {string} [ext]
- * @param {string} [filePath]
+ * @param {string} [inputPath]
  * @param {*[]} errors
  */
-export function testInvalid({ textlint, filePath, text, ext, errors }) {
-    const lines = getTestText({ text, filePath }).split(/\n/);
+export function testInvalid({ textlint, inputPath, text, ext, errors }) {
+    const lines = getTestText({ text, inputPath }).split(/\n/);
     assert.strictEqual(
-        typeof (filePath || text),
+        typeof (inputPath || text),
         "string",
         `invalid property should have text string
 e.g.)
@@ -58,7 +58,7 @@ invalid : [
             `
     );
     const errorLength = errors.length;
-    const promise = filePath !== undefined ? textlint.lintFile(filePath) : textlint.lintText(text, ext);
+    const promise = inputPath !== undefined ? textlint.lintFile(inputPath) : textlint.lintText(text, ext);
     return promise.then(lintResult => {
         assert.strictEqual(
             lintResult.messages.length,
@@ -120,13 +120,13 @@ The result's column number should be less than ${columnText.length + 1}`
 
 /**
  * @param {TextLintCore} textlint
- * @param {string} [filePath]
+ * @param {string} [inputPath]
  * @param {string} [text]
  * @param {string} [ext]
  */
-export function testValid({ textlint, filePath, text, ext }) {
-    assert.strictEqual(typeof (filePath || text), "string", "valid should has string of text.");
-    const promise = filePath !== undefined ? textlint.lintFile(filePath) : textlint.lintText(text, ext);
+export function testValid({ textlint, inputPath, text, ext }) {
+    assert.strictEqual(typeof (inputPath || text), "string", "valid should has string of text.");
+    const promise = inputPath !== undefined ? textlint.lintFile(inputPath) : textlint.lintText(text, ext);
     return promise.then(results => {
         assert.strictEqual(
             results.messages.length,

--- a/packages/textlint-tester/src/test-util.js
+++ b/packages/textlint-tester/src/test-util.js
@@ -1,11 +1,35 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("assert");
+const fs = require("fs");
 
-export function testInvalid(textlint, text, ext, errors) {
-    const lines = text.split(/\n/);
+/**
+ *
+ * @param {string} [text]
+ * @param {string} [filePath]
+ * @returns {string}
+ */
+function getTestText({ text, filePath }) {
+    if (text !== undefined) {
+        return text;
+    }
+    if (filePath === undefined) {
+        throw new Error("should be defined { text } or { filePath }");
+    }
+    return fs.readFileSync(filePath, "utf-8");
+}
+
+/**
+ * @param {TextLintCore} textlint
+ * @param {string} [text]
+ * @param {string} [ext]
+ * @param {string} [filePath]
+ * @param {*[]} errors
+ */
+export function testInvalid({ textlint, filePath, text, ext, errors }) {
+    const lines = getTestText({ text, filePath }).split(/\n/);
     assert.strictEqual(
-        typeof text,
+        typeof (filePath || text),
         "string",
         `invalid property should have text string
 e.g.)
@@ -34,7 +58,8 @@ invalid : [
             `
     );
     const errorLength = errors.length;
-    return textlint.lintText(text, ext).then(lintResult => {
+    const promise = filePath !== undefined ? textlint.lintFile(filePath) : textlint.lintText(text, ext);
+    return promise.then(lintResult => {
         assert.strictEqual(
             lintResult.messages.length,
             errorLength,
@@ -93,9 +118,16 @@ The result's column number should be less than ${columnText.length + 1}`
     });
 }
 
-export function testValid(textlint, text, ext) {
-    assert.strictEqual(typeof text, "string", "valid should has string of text.");
-    return textlint.lintText(text, ext).then(results => {
+/**
+ * @param {TextLintCore} textlint
+ * @param {string} [filePath]
+ * @param {string} [text]
+ * @param {string} [ext]
+ */
+export function testValid({ textlint, filePath, text, ext }) {
+    assert.strictEqual(typeof (filePath || text), "string", "valid should has string of text.");
+    const promise = filePath !== undefined ? textlint.lintFile(filePath) : textlint.lintText(text, ext);
+    return promise.then(results => {
         assert.strictEqual(
             results.messages.length,
             0,

--- a/packages/textlint-tester/src/textlint-tester.js
+++ b/packages/textlint-tester/src/textlint-tester.js
@@ -44,7 +44,7 @@ export default class TextLintTester {
     }
 
     testValidPattern(ruleName, rule, valid) {
-        const filePath = typeof valid === "object" ? valid.filePath : undefined;
+        const inputPath = typeof valid === "object" ? valid.inputPath : undefined;
         const text = valid.text !== undefined ? valid.text : valid;
         const options = valid.options || {};
         const ext = valid.ext !== undefined ? valid.ext : ".md";
@@ -57,14 +57,14 @@ export default class TextLintTester {
                 [ruleName]: options
             }
         );
-        it(filePath || text, () => {
-            return testValid({ textlint, filePath, text, ext });
+        it(inputPath || text, () => {
+            return testValid({ textlint, inputPath, text, ext });
         });
     }
 
     testInvalidPattern(ruleName, rule, invalid) {
         const errors = invalid.errors;
-        const filePath = invalid.filePath;
+        const inputPath = invalid.inputPath;
         const text = invalid.text;
         const options = invalid.options || {};
         const ext = invalid.ext !== undefined ? invalid.ext : ".md";
@@ -77,14 +77,15 @@ export default class TextLintTester {
                 [ruleName]: options
             }
         );
-        it(filePath || text, () => {
-            return testInvalid({ textlint, filePath, text, ext, errors });
+        it(inputPath || text, () => {
+            return testInvalid({ textlint, inputPath, text, ext, errors });
         });
         // --fix
         if (invalid.hasOwnProperty("output")) {
-            it(`Fixer: ${text}`, () => {
+            it(`Fixer: ${inputPath || text}`, () => {
                 assertHasFixer(rule, ruleName);
-                return textlint.fixText(text, ext).then(result => {
+                const promise = inputPath !== undefined ? textlint.fixFile(inputPath) : textlint.fixText(text, ext);
+                return promise.then(result => {
                     const output = invalid.output;
                     assert.strictEqual(result.output, output);
                 });

--- a/packages/textlint-tester/src/textlint-tester.js
+++ b/packages/textlint-tester/src/textlint-tester.js
@@ -18,6 +18,7 @@ const it =
         : function(text, method) {
               return method.apply(this);
           };
+
 /* eslint-enable no-invalid-this */
 /**
  * get fixer function from ruleCreator
@@ -34,6 +35,7 @@ function assertHasFixer(ruleCreator, ruleName) {
     }
     throw new Error(`Not found \`fixer\` function in the ruleCreator: ${ruleName}`);
 }
+
 export default class TextLintTester {
     constructor() {
         if (typeof coreFlags === "object") {
@@ -42,6 +44,7 @@ export default class TextLintTester {
     }
 
     testValidPattern(ruleName, rule, valid) {
+        const filePath = typeof valid === "object" ? valid.filePath : undefined;
         const text = valid.text !== undefined ? valid.text : valid;
         const options = valid.options || {};
         const ext = valid.ext !== undefined ? valid.ext : ".md";
@@ -54,13 +57,14 @@ export default class TextLintTester {
                 [ruleName]: options
             }
         );
-        it(text, () => {
-            return testValid(textlint, text, ext);
+        it(filePath || text, () => {
+            return testValid({ textlint, filePath, text, ext });
         });
     }
 
     testInvalidPattern(ruleName, rule, invalid) {
         const errors = invalid.errors;
+        const filePath = invalid.filePath;
         const text = invalid.text;
         const options = invalid.options || {};
         const ext = invalid.ext !== undefined ? invalid.ext : ".md";
@@ -73,8 +77,8 @@ export default class TextLintTester {
                 [ruleName]: options
             }
         );
-        it(text, () => {
-            return testInvalid(textlint, text, ext, errors);
+        it(filePath || text, () => {
+            return testInvalid({ textlint, filePath, text, ext, errors });
         });
         // --fix
         if (invalid.hasOwnProperty("output")) {

--- a/packages/textlint-tester/test/fixtures/text/fixture-rule-add.md
+++ b/packages/textlint-tester/test/fixtures/text/fixture-rule-add.md
@@ -1,0 +1,1 @@
+This is fixed

--- a/packages/textlint-tester/test/fixtures/text/ng.md
+++ b/packages/textlint-tester/test/fixtures/text/ng.md
@@ -1,0 +1,1 @@
+- [ ] This is NG

--- a/packages/textlint-tester/test/fixtures/text/ok.md
+++ b/packages/textlint-tester/test/fixtures/text/ok.md
@@ -1,0 +1,1 @@
+This is OK.

--- a/packages/textlint-tester/test/textlint-tester-fixer-test.js
+++ b/packages/textlint-tester/test/textlint-tester-fixer-test.js
@@ -1,6 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const TextLintTester = require("../src/index");
+const path = require("path");
 const fixerRule = require("./fixtures/rule/fixer-rule-add");
 const tester = new TextLintTester();
 tester.run("fixer-rule-add", fixerRule, {
@@ -9,6 +10,17 @@ tester.run("fixer-rule-add", fixerRule, {
         {
             text: "This is fixed",
             output: "This is fixed.",
+            errors: [
+                {
+                    message: "Please add . to end of a sentence.",
+                    line: 1,
+                    column: 14
+                }
+            ]
+        },
+        {
+            inputPath: path.join(__dirname, "fixtures/text/fixture-rule-add.md"),
+            output: "This is fixed.\n",
             errors: [
                 {
                     message: "Please add . to end of a sentence.",

--- a/packages/textlint-tester/test/textlint-tester-invalid-test.js
+++ b/packages/textlint-tester/test/textlint-tester-invalid-test.js
@@ -13,7 +13,12 @@ describe("Broken Rule", function() {
             const fixtureRule = path.join(fixturesDir, caseName);
             const textlint = new TextLintCore();
             textlint.setupRules({ "broken-rule": require(fixtureRule) });
-            return testInvalid(textlint, "text", ".md", [{ message: "Found TODO: '- [ ] string'", line: 1, column: 3 }])
+            return testInvalid({
+                textlint,
+                text: "text",
+                ext: ".md",
+                errors: [{ message: "Found TODO: '- [ ] string'", line: 1, column: 3 }]
+            })
                 .then(() => {
                     throw new Error("WRONG");
                 })

--- a/packages/textlint-tester/test/textlint-tester-test.js
+++ b/packages/textlint-tester/test/textlint-tester-test.js
@@ -16,7 +16,7 @@ tester.run("no-todo", noTodo, {
             ext: ".txt"
         },
         {
-            filePath: path.join(__dirname, "fixtures/text/ok.md")
+            inputPath: path.join(__dirname, "fixtures/text/ok.md")
         }
     ],
     invalid: [
@@ -63,7 +63,7 @@ tester.run("no-todo", noTodo, {
             ]
         },
         {
-            filePath: path.join(__dirname, "fixtures/text/ng.md"),
+            inputPath: path.join(__dirname, "fixtures/text/ng.md"),
             errors: [
                 {
                     message: "Found TODO: '- [ ] This is NG'",

--- a/packages/textlint-tester/test/textlint-tester-test.js
+++ b/packages/textlint-tester/test/textlint-tester-test.js
@@ -1,9 +1,10 @@
 // LICENSE : MIT
 "use strict";
-var TextLintTester = require("../src/index");
-var noTodo = require("textlint-rule-no-todo");
-var maxNumberOfLine = require("textlint-rule-max-number-of-lines");
-var tester = new TextLintTester();
+const path = require("path");
+const TextLintTester = require("../src/index");
+const noTodo = require("textlint-rule-no-todo");
+const maxNumberOfLine = require("textlint-rule-max-number-of-lines");
+const tester = new TextLintTester();
 tester.run("no-todo", noTodo, {
     valid: [
         "string, test desu",
@@ -13,6 +14,9 @@ tester.run("no-todo", noTodo, {
         {
             text: "- [ ] This text is parsed as plain text.",
             ext: ".txt"
+        },
+        {
+            filePath: path.join(__dirname, "fixtures/text/ok.md")
         }
     ],
     invalid: [
@@ -55,6 +59,15 @@ tester.run("no-todo", noTodo, {
                     message: "Found TODO: 'TODO: this text is parsed as plain text.'",
                     line: 1,
                     column: 7
+                }
+            ]
+        },
+        {
+            filePath: path.join(__dirname, "fixtures/text/ng.md"),
+            errors: [
+                {
+                    message: "Found TODO: '- [ ] This is NG'",
+                    index: 2
                 }
             ]
         }


### PR DESCRIPTION
#390 https://github.com/textlint-rule/textlint-rule-no-dead-link/issues/94

Add `inputPath` option for valid and invalid option.
We will need to add `outputPath` support.

fix #390 