### PR TITLE
fix(textlint-formatter): run all tests

### DIFF
--- a/packages/textlint-formatter/package.json
+++ b/packages/textlint-formatter/package.json
@@ -16,7 +16,7 @@
     "bin/"
   ],
   "scripts": {
-    "test": "mocha test/*.js"
+    "test": "mocha test/**/*.js"
   },
   "directories": {
     "test": "test/"

--- a/packages/textlint-formatter/package.json
+++ b/packages/textlint-formatter/package.json
@@ -16,7 +16,7 @@
     "bin/"
   ],
   "scripts": {
-    "test": "mocha test/**/*.js"
+    "test": "mocha --no-colors test/**/*.js"
   },
   "directories": {
     "test": "test/"


### PR DESCRIPTION
Correct mocha test glob pattern to run all tests. Closes #402.