### PR TITLE
Upgrade mocha 4

### DIFF
--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -24,6 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "@textlint/monorepo-scripts": "^2.0.0",
-    "mocha": "^3.3.0"
+    "mocha": "^4.0.1"
   }
 }

--- a/packages/@textlint/feature-flag/package.json
+++ b/packages/@textlint/feature-flag/package.json
@@ -14,7 +14,7 @@
   "description": "textlint internal feature flag manager.",
   "main": "lib/textlint-feature-flag.js",
   "scripts": {
-    "test": "mocha test/",
+    "test": "mocha \"test/**/*.{js,ts}\"",
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build"

--- a/packages/@textlint/feature-flag/package.json
+++ b/packages/@textlint/feature-flag/package.json
@@ -37,7 +37,7 @@
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.24.1",
     "cross-env": "^5.0.0",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.2"
   },
   "dependencies": {

--- a/packages/@textlint/feature-flag/test/mocha.opts
+++ b/packages/@textlint/feature-flag/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "scripts": {
-    "test": "mocha test",
+    "test": "mocha \"test/**/*.{js,ts}\"",
     "clean": "rimraf out/ lib/ es_modules/",
     "build": "npm-run-all build:src",
     "build:src": "cross-env NODE_ENV=production tsc -p .",

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -38,7 +38,7 @@
     "cpx": "^1.5.0",
     "cross-env": "^5.0.5",
     "markdown-to-ast": "^6.0.0",
-    "mocha": "^3.5.3",
+    "mocha": "^4.0.1",
     "npm-run-all": "^4.1.1",
     "rimraf": "^2.6.2",
     "shelljs": "^0.7.7",

--- a/packages/@textlint/kernel/test/mocha.opts
+++ b/packages/@textlint/kernel/test/mocha.opts
@@ -1,2 +1,1 @@
---recursive
 --require test/ts-setup.js

--- a/packages/@textlint/kernel/test/rule-fixer/rule-fixer-test.ts
+++ b/packages/@textlint/kernel/test/rule-fixer/rule-fixer-test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import { TxtNode } from "../../src/textlint-kernel-interface";
+import { TxtNode } from "@textlint/ast-node-types";
 
 const assert = require("assert");
 import RuleFixer from "../../src/fixer/rule-fixer";

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "textlint-rule-prh": "^3.1.3"
   }
 }

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/textlint/textlint/issues"
   },
   "scripts": {
-    "test": "mocha test/"
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "dependencies": {

--- a/packages/markdown-to-ast/package.json
+++ b/packages/markdown-to-ast/package.json
@@ -43,7 +43,7 @@
     "browserify": "^14.3.0",
     "cross-env": "^4.0.0",
     "mkdirp": "^0.5.1",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.2",
     "textlint-ast-test": "^2.0.0",
     "txt-ast-traverse": "^2.0.0"

--- a/packages/markdown-to-ast/package.json
+++ b/packages/markdown-to-ast/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "example:build": "browserify example/js/index.js -o example/app/app.js",
-    "test": "mocha test/",
+    "test": "mocha \"test/**/*.{js,ts}\"",
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build"

--- a/packages/markdown-to-ast/test/mocha.opts
+++ b/packages/markdown-to-ast/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/textlint-ast-test/package.json
+++ b/packages/textlint-ast-test/package.json
@@ -24,7 +24,7 @@
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
-    "test": "mocha"
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "keywords": [
     "textlint",

--- a/packages/textlint-ast-test/package.json
+++ b/packages/textlint-ast-test/package.json
@@ -42,7 +42,7 @@
     "babel-register": "^6.7.2",
     "cross-env": "^5.1.1",
     "markdown-to-ast": "^3.2.3",
-    "mocha": "^2.4.5",
+    "mocha": "^4.0.1",
     "power-assert": "^1.3.1",
     "txt-to-ast": "^1.1.0"
   }

--- a/packages/textlint-ast-test/test/mocha.opts
+++ b/packages/textlint-ast-test/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/textlint-fixer-formatter/package.json
+++ b/packages/textlint-fixer-formatter/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf lib/",
     "prepublish": "npm run build",
     "build": "cross-env NODE_ENV=production tsc -p .",
-    "test": "mocha test"
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "files": [
     "lib/textlint-fixer-formatter",

--- a/packages/textlint-fixer-formatter/test/mocha.opts
+++ b/packages/textlint-fixer-formatter/test/mocha.opts
@@ -1,2 +1,1 @@
---recursive
 --require test/ts-setup.js

--- a/packages/textlint-formatter/package.json
+++ b/packages/textlint-formatter/package.json
@@ -46,7 +46,7 @@
     "chai": "^3.5.0",
     "espower-loader": "^1.0.0",
     "intelli-espower-loader": "^1.0.0",
-    "mocha": "^2.1.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.1.0",
     "proxyquire": "^1.7.4",
     "sinon": "^1.17.3"

--- a/packages/textlint-formatter/package.json
+++ b/packages/textlint-formatter/package.json
@@ -16,7 +16,7 @@
     "bin/"
   ],
   "scripts": {
-    "test": "mocha --no-colors \"test/**/*.{js,ts}\""
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "directories": {
     "test": "test/"

--- a/packages/textlint-formatter/package.json
+++ b/packages/textlint-formatter/package.json
@@ -16,7 +16,7 @@
     "bin/"
   ],
   "scripts": {
-    "test": "mocha --no-colors test/**/*.js"
+    "test": "mocha --no-colors \"test/**/*.{js,ts}\""
   },
   "directories": {
     "test": "test/"

--- a/packages/textlint-plugin-markdown/package.json
+++ b/packages/textlint-plugin-markdown/package.json
@@ -39,7 +39,7 @@
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.9.0",
     "cross-env": "^4.0.0",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.1",
     "textlint": "^10.0.1",
     "textlint-rule-no-todo": "^2.0.0"

--- a/packages/textlint-plugin-markdown/package.json
+++ b/packages/textlint-plugin-markdown/package.json
@@ -25,7 +25,7 @@
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
-    "test": "mocha"
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "keywords": [
     "textlint",

--- a/packages/textlint-plugin-markdown/test/mocha.opts
+++ b/packages/textlint-plugin-markdown/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/textlint-plugin-text/package.json
+++ b/packages/textlint-plugin-text/package.json
@@ -37,7 +37,7 @@
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.24.1",
     "cross-env": "^4.0.0",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.2",
     "textlint": "^10.0.1",
     "textlint-rule-no-todo": "^2.0.0"

--- a/packages/textlint-plugin-text/package.json
+++ b/packages/textlint-plugin-text/package.json
@@ -14,7 +14,7 @@
   "version": "3.0.1",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha test/",
+    "test": "mocha \"test/**/*.{js,ts}\"",
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build"

--- a/packages/textlint-plugin-text/test/mocha.opts
+++ b/packages/textlint-plugin-text/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -25,7 +25,7 @@
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build",
-    "test": "mocha"
+    "test": "mocha \"test/**/*.{js,ts}\""
   },
   "keywords": [
     "textlint",

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -45,7 +45,7 @@
     "babel-register": "^6.9.0",
     "cross-env": "^4.0.0",
     "match-index": "^1.0.1",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.1",
     "textlint": "^10.0.1",
     "textlint-rule-helper": "^2.0.0",

--- a/packages/textlint-tester/test/mocha.opts
+++ b/packages/textlint-tester/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -p . --watch",
     "prepublish": "npm run build",
     "test": "npm-run-all test:unit",
-    "test:unit": "mocha test"
+    "test:unit": "mocha \"test/**/*.{js,ts}\""
   },
   "directories": {
     "test": "test/"

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -49,7 +49,7 @@
     "clone": "^2.0.0",
     "cpx": "^1.5.0",
     "cross-env": "^4.0.0",
-    "mocha": "^3.0.2",
+    "mocha": "^4.0.1",
     "npm-run-all": "^4.0.2",
     "power-assert": "^1.3.1",
     "shelljs": "^0.7.7",

--- a/packages/textlint/test/mocha.opts
+++ b/packages/textlint/test/mocha.opts
@@ -1,3 +1,2 @@
---recursive
 --timeout 5000
 --require test/ts-setup.js

--- a/packages/txt-to-ast/package.json
+++ b/packages/txt-to-ast/package.json
@@ -43,7 +43,7 @@
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.24.1",
     "cross-env": "^4.0.0",
-    "mocha": "^3.3.0",
+    "mocha": "^4.0.1",
     "power-assert": "^1.4.2",
     "textlint-ast-test": "^2.0.0"
   }

--- a/packages/txt-to-ast/package.json
+++ b/packages/txt-to-ast/package.json
@@ -15,7 +15,7 @@
   "version": "3.0.0",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha test/",
+    "test": "mocha \"test/**/*.{js,ts}\"",
     "build": "cross-env NODE_ENV=production babel src --out-dir lib --source-maps",
     "watch": "babel src --out-dir lib --watch --source-maps",
     "prepublish": "npm run --if-present build"

--- a/packages/txt-to-ast/test/mocha.opts
+++ b/packages/txt-to-ast/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:babel-register
+--require babel-register

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,17 +1584,9 @@ command-join@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/command-join/-/command-join-2.0.0.tgz#52e8b984f4872d952ff1bdc8b98397d27c7144cf"
 
-commander@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
-
 commander@2.11.0, commander@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
-
-commander@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
 
 commander@2.9.0:
   version "2.9.0"
@@ -2007,12 +1999,6 @@ dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
 
-debug@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  dependencies:
-    ms "0.7.1"
-
 debug@2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
@@ -2160,10 +2146,6 @@ detective@^4.0.0:
 diff-match-patch@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.0.tgz#1cc3c83a490d67f95d91e39f6ad1f2e086b63048"
-
-diff@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
 
 diff@3.2.0:
   version "3.2.0"
@@ -2419,10 +2401,6 @@ escallmatch@^1.5.0:
 escape-html@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-
-escape-string-regexp@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -3131,13 +3109,6 @@ glob2base@^0.0.12:
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
   dependencies:
     find-index "^0.1.1"
-
-glob@3.2.11:
-  version "3.2.11"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
-  dependencies:
-    inherits "2"
-    minimatch "0.3"
 
 glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
@@ -3945,13 +3916,6 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jade@0.26.3:
-  version "0.26.3"
-  resolved "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c"
-  dependencies:
-    commander "0.6.1"
-    mkdirp "0.3.0"
-
 japanese-numerals-to-number@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/japanese-numerals-to-number/-/japanese-numerals-to-number-1.0.2.tgz#cbfcb18ca6e93a51b062f33a5e5d29d9d7693d94"
@@ -4758,13 +4722,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@0.3:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
-  dependencies:
-    lru-cache "2"
-    sigmund "~1.0.0"
-
 minimatch@^2.0.1:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
@@ -4802,32 +4759,13 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
-
 mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
-mocha@^2.1.0, mocha@^2.4.5:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
-  dependencies:
-    commander "2.3.0"
-    debug "2.2.0"
-    diff "1.4.0"
-    escape-string-regexp "1.0.2"
-    glob "3.2.11"
-    growl "1.9.2"
-    jade "0.26.3"
-    mkdirp "0.5.1"
-    supports-color "1.2.0"
-    to-iso-string "0.0.2"
-
-mocha@^3.0.2, mocha@^3.3.0, mocha@^3.5.3:
+mocha@^3.3.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:
@@ -4896,10 +4834,6 @@ moji@^0.5.1:
 moment@^2.6.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
-
-ms@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@0.7.3:
   version "0.7.3"
@@ -6818,10 +6752,6 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-supports-color@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
-
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -7251,10 +7181,6 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-
-to-iso-string@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
 
 to-vfile@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This PR closes #405 

- Update mocha `^4.0.1`
- Use `--require` instead of `--compilers`
- Use glob pattern instead of `--recursive`

### Other changes
- Use `@textlint/ast-node-types` instead of relative path
