### PR TITLE
refactor(textlint-formatter): remove reference to always empty string

### DIFF
--- a/packages/textlint-formatter/lib/formatters/jslint-xml.js
+++ b/packages/textlint-formatter/lib/formatters/jslint-xml.js
@@ -25,7 +25,9 @@ module.exports = function(results) {
         messages.forEach(function(message) {
             output += "<issue line=\"" + message.line + "\" " +
                 "char=\"" + message.column + "\" " +
-                "evidence=\"" + lodash.escape(message.source || "") + "\" " +
+                // TODO: evidence is always empty string
+                // See: https://github.com/textlint/textlint/issues/400
+                "evidence=\"\" " +
                 "reason=\"" + lodash.escape(message.message || "") +
                 (message.ruleId ? " (" + message.ruleId + ")" : "") + "\" />";
         });

--- a/packages/textlint-formatter/test/formatters/jslint-xml.js
+++ b/packages/textlint-formatter/test/formatters/jslint-xml.js
@@ -38,7 +38,7 @@ describe("formatter:jslint-xml", function() {
             var result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="foo" reason="Unexpected foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>'
             );
         });
     });
@@ -64,7 +64,7 @@ describe("formatter:jslint-xml", function() {
             var result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="foo" reason="Unexpected foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>'
             );
         });
     });
@@ -98,7 +98,7 @@ describe("formatter:jslint-xml", function() {
             var result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="foo" reason="Unexpected foo. (foo)" /><issue line="6" char="11" evidence="bar" reason="Unexpected bar. (bar)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>'
             );
         });
     });
@@ -137,7 +137,7 @@ describe("formatter:jslint-xml", function() {
             var result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="foo" reason="Unexpected foo. (foo)" /></file><file name="bar.js"><issue line="6" char="11" evidence="bar" reason="Unexpected bar. (bar)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file><file name="bar.js"><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>'
             );
         });
     });
@@ -163,7 +163,7 @@ describe("formatter:jslint-xml", function() {
             var result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="foo" reason="Unexpected &lt;&amp;&quot;&#39;&gt; foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected &lt;&amp;&quot;&#39;&gt; foo. (foo)" /></file></jslint>'
             );
         });
     });


### PR DESCRIPTION
Modify test case as well. Closes #400.

Please note that commit 72136e3 (#407) reverts commit 1548585 (#403) and causes failed test in local.

```sh
cd packages/textlint-formatter
yarn run test # fail
yarn run test --no-color # success
```