### PR TITLE
fix(textlint-formatter): disable color in testing

### DIFF
--- a/packages/textlint-formatter/README.md
+++ b/packages/textlint-formatter/README.md
@@ -65,6 +65,16 @@ $ textlint -f json README.md --rule no-todo | textlint-formatter -f pretty-error
 - [azu/textlint-formatter-codecov: textlint formatter for codecov json.](https://github.com/azu/textlint-formatter-codecov)
 - [azu/textlint-formatter-lcov: textlint formatter for lcov format](https://github.com/azu/textlint-formatter-lcov)
 
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm test
+
+:memo: Note: Disable chalk coloring by `--no-color` option in testing.
+For more details, see <https://github.com/textlint/textlint/issues/402#issuecomment-352808734>
+
 ## Contributing
 
 1. Fork it!

--- a/packages/textlint-formatter/test/mocha.opts
+++ b/packages/textlint-formatter/test/mocha.opts
@@ -1,2 +1,2 @@
---no-color
+--no-colors
 --require intelli-espower-loader

--- a/packages/textlint-formatter/test/mocha.opts
+++ b/packages/textlint-formatter/test/mocha.opts
@@ -1,1 +1,2 @@
+--no-color
 --require intelli-espower-loader


### PR DESCRIPTION
Add `--no-color` to `mocha.opts`.
This was introduced in https://github.com/textlint/textlint/pull/403, but it was reverted in https://github.com/textlint/textlint/pull/407.
We have disabled color in testing again.

## Test plan

In local env.

```
cd packages/textlint-formatter
yarn run test # pass
```
