### PR TITLE
feat(textlint-formatter): add getFormatterList function

### DIFF
--- a/packages/textlint-formatter/README.md
+++ b/packages/textlint-formatter/README.md
@@ -10,9 +10,9 @@ npm install textlint-formatter
 
 ## Usage
 
-See [formatters/](lib/formatters).
+See [formatters/](src/formatters).
 
-Currently, you can use "stylish" (defaults), "compact", "checkstyle", "jslint-xml", "junit", "tap", "pretty-error".
+Currently, you can use "stylish" (defaults), "checkstyle", "compact", "jslint-xml", "json", "junit", "pretty-error", "table", "tap", and "unix".
 
 ```js
 const createFormatter = require("textlint-formatter").createFormatter;
@@ -46,12 +46,14 @@ console.log(output);
 
 See [lib/_typing/textlint-formatter.d.ts](lib/_typing/textlint-formatter.d.ts)
 
-```
-// createFormatter(options)
-interface options {
+```typescript
+function createFormatter(formatterConfig: FormatterConfig) {/*...*/}
+type FormatterConfig = {
     // formatter file name
-    formatterName?: string;
-}
+    formatterName: string
+    // enable coloring if supported (default: true)
+    color?: boolean;
+};
 ```
 
 ## CLI

--- a/packages/textlint-formatter/src/cli.ts
+++ b/packages/textlint-formatter/src/cli.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import * as fs from "fs";
-import { createFormatter } from "./textlint-formatter";
+import { createFormatter, getFormatterList } from "./textlint-formatter";
 
 module.exports = function run(argv: string[], text: string) {
     return new Promise(function(resolve) {
@@ -23,6 +23,12 @@ module.exports = function run(argv: string[], text: string) {
                     example: "textlint -f json README.md | textlint-formatter -f pretty-error"
                 },
                 {
+                    option: "list",
+                    alias: "l",
+                    type: "Boolean",
+                    description: "print available formatters"
+                },
+                {
                     option: "stdin",
                     type: "Boolean",
                     default: "false",
@@ -32,6 +38,16 @@ module.exports = function run(argv: string[], text: string) {
         });
         const options = optionator.parseArgv(argv);
         const files = options._;
+        if (options.list) {
+            return resolve(
+                "Available formatters:\n" +
+                    getFormatterList()
+                        .map((formatter: { name: string }) => {
+                            return `- ${formatter.name}`;
+                        })
+                        .join("\n")
+            );
+        }
         if (options.help || (!files.length && !text)) {
             return resolve(optionator.generateHelp());
         }

--- a/packages/textlint-formatter/src/textlint-formatter.ts
+++ b/packages/textlint-formatter/src/textlint-formatter.ts
@@ -42,3 +42,14 @@ ${ex}`);
         return formatter(results, formatterConfig);
     };
 }
+
+export function getFormatterList() {
+    return fs
+        .readdirSync(path.join(__dirname, "formatters"))
+        .filter((file: string) => {
+            return path.extname(file) === ".js";
+        })
+        .map((file: string) => {
+            return { name: path.basename(file, ".js") };
+        });
+}

--- a/packages/textlint-formatter/test/textlint-formatter-test.ts
+++ b/packages/textlint-formatter/test/textlint-formatter-test.ts
@@ -1,31 +1,33 @@
 // LICENSE : MIT
 "use strict";
-import { createFormatter } from "../src/textlint-formatter";
+import { createFormatter, getFormatterList } from "textlint-formatter";
 
-var path = require("path");
+import * as path from "path";
 import * as assert from "assert";
 
 describe("textlint-formatter-test", function() {
     describe("createFormatter", function() {
         it("should return formatter function", function() {
-            var formatter = createFormatter({
+            const formatter = createFormatter({
                 formatterName: "stylish"
             });
             assert(typeof formatter === "function");
         });
         context("formatter", function() {
             it("should return output text", function() {
-                var formatter = createFormatter({
+                const formatter = createFormatter({
                     formatterName: "stylish"
                 });
-                var output = formatter([
+                const output = formatter([
                     {
                         filePath: "./myfile.js",
                         messages: [
                             {
+                                type: "lint",
                                 ruleId: "semi",
                                 line: 1,
                                 column: 23,
+                                index: 0,
                                 message: "Expected a semicolon."
                             }
                         ]
@@ -35,7 +37,7 @@ describe("textlint-formatter-test", function() {
             });
         });
         it("run all formatter", function() {
-            var formatterNames = [
+            const formatterNames = [
                 "checkstyle",
                 "compact",
                 "jslint-xml",
@@ -46,36 +48,44 @@ describe("textlint-formatter-test", function() {
                 "json"
             ];
             formatterNames.forEach(function(name) {
-                var formatter = createFormatter({
+                const formatter = createFormatter({
                     formatterName: name
                 });
                 const ckjFile = path.join(__dirname, "./fixtures", "ckj.md");
-                var output = formatter([
+                const output = formatter([
                     {
                         filePath: __dirname + "/fixtures/myfile.js",
                         messages: [
                             {
+                                type: "lint",
                                 ruleId: "semi",
                                 line: 1,
                                 column: 1,
+                                index: 0,
                                 message: "0 pattern."
                             },
                             {
+                                type: "lint",
                                 ruleId: "semi",
                                 line: 2,
                                 column: 26,
+                                index: 0,
                                 message: "Expected a semicolon."
                             },
                             {
+                                type: "lint",
                                 ruleId: "semi",
                                 line: 1,
                                 column: 21,
+                                index: 0,
                                 message: "Expected a semicolon."
                             },
                             {
+                                type: "lint",
                                 ruleId: "semi",
                                 line: 2,
                                 column: 26,
+                                index: 0,
                                 message: "Expected a semicolon."
                             }
                         ]
@@ -84,14 +94,17 @@ describe("textlint-formatter-test", function() {
                         filePath: ckjFile,
                         messages: [
                             {
+                                type: "lint",
                                 message: "Unexpected !!!.",
                                 severity: 2,
                                 line: 2,
                                 column: 16,
+                                index: 0,
                                 ruleId: "foo",
                                 fix: {
                                     range: [40, 45],
-                                    text: "fixed 1"
+                                    text: "fixed 1",
+                                    isAbsolute: false
                                 }
                             }
                         ]
@@ -99,6 +112,22 @@ describe("textlint-formatter-test", function() {
                 ]);
                 assert(output.length > 0);
             });
+        });
+    });
+    describe("getFormatterList", function() {
+        it("should return list of formatter(s)", function() {
+            assert.deepEqual(getFormatterList(), [
+                { name: "checkstyle" },
+                { name: "compact" },
+                { name: "jslint-xml" },
+                { name: "json" },
+                { name: "junit" },
+                { name: "pretty-error" },
+                { name: "stylish" },
+                { name: "table" },
+                { name: "tap" },
+                { name: "unix" }
+            ]);
         });
     });
 });


### PR DESCRIPTION
Hi, could you review my pull request for for textlint-formatter?

References:

- [show available formatter in help · Issue #85 · textlint/textlint](https://github.com/textlint/textlint/issues/85)
- [formatter: Add `getFormatterList` function · Issue #399 · textlint/textlint](https://github.com/textlint/textlint/issues/399)
- [feat(textlint-fixer-formatter): add getFormatterList function by 0x6b · Pull Request #412 · textlint/textlint](https://github.com/textlint/textlint/pull/412)

