### PR TITLE
feat(textlint): show available formatter in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Using stdin:
 Output:
   -o, --output-file path::String  Enable report to be written to a file.
   -f, --format String        Use a specific output format.
+                             Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
+                             Available formatter for fixer: compats, diff, json, stylish
   --no-color                 Disable color in piped output.
   --quiet                    Report errors only. - default: false
 
@@ -121,6 +123,7 @@ Caching:
 
 Experimental:
   --experimental             Enable experimental flag.Some feature use on experimental.
+  --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
 ```
 
 Allow to use glob as a target.

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -52,6 +52,7 @@
     "mocha": "^4.0.1",
     "npm-run-all": "^4.0.2",
     "power-assert": "^1.3.1",
+    "rimraf": "^2.6.2",
     "shelljs": "^0.7.7",
     "source-map-support": "^0.5.0",
     "textlint-plugin-html": "^0.1.2",

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -93,8 +93,8 @@ export const options = optionator({
             alias: "f",
             type: "String",
             description: `Use a specific output format.
-            Available formatter          : ${concatFormatterList(getFormatterList())}
-            Available formatter for fixer: ${concatFormatterList(getFixerFormatterList())}`,
+                             Available formatter          : ${concatFormatterList(getFormatterList())}
+                             Available formatter for fixer: ${concatFormatterList(getFixerFormatterList())}`,
             example: "--format pretty-error"
         },
         {

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -94,7 +94,7 @@ export const options = optionator({
             type: "String",
             description: `Use a specific output format.
                              Available formatter          : ${concatFormatterList(getFormatterList())}
-                             Available formatter for fixer: ${concatFormatterList(getFixerFormatterList())}`,
+                             Available formatter for --fix: ${concatFormatterList(getFixerFormatterList())}`,
             example: "--format pretty-error"
         },
         {

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,6 +1,18 @@
 // LICENSE : MIT
 "use strict";
+import { getFormatterList } from "textlint-formatter";
+import { getFormatterList as getFixerFormatterList } from "textlint-fixer-formatter";
+
 const optionator = require("optionator");
+
+const concatFormatterList = (formatterList: { name: string }[]) => {
+    return formatterList
+        .map(formatter => {
+            return formatter.name;
+        })
+        .join(", ");
+};
+
 export const options = optionator({
     prepend: "textlint [options] file.md [file|dir|glob*]",
     concatRepeatedArrays: true,
@@ -80,7 +92,9 @@ export const options = optionator({
             option: "format",
             alias: "f",
             type: "String",
-            description: "Use a specific output format.",
+            description: `Use a specific output format.
+            Available formatter          : ${concatFormatterList(getFormatterList())}
+            Available formatter for fixer: ${concatFormatterList(getFixerFormatterList())}`,
             example: "--format pretty-error"
         },
         {

--- a/packages/textlint/test/cli/cli-test.js
+++ b/packages/textlint/test/cli/cli-test.js
@@ -3,6 +3,7 @@
 const assert = require("assert");
 const cli = require("../../src/index").cli;
 const path = require("path");
+const fs = require("fs");
 const spawnSync = require("child_process").spawnSync;
 import { Logger } from "../../src/util/logger";
 
@@ -234,6 +235,17 @@ describe("cli-test", function() {
                 assert.equal(message, `v${pkg.version}`);
             };
             return cli.execute("--version").then(exitCode => {
+                assert.strictEqual(exitCode, 0);
+            });
+        });
+    });
+    describe("--help", function() {
+        it("should output expected help message", function() {
+            const expected = fs.readFileSync(path.join(__dirname, "fixtures/help.txt")).toString();
+            Logger.log = function mockLog(message) {
+                assert.equal(message + "\n", expected);
+            };
+            return cli.execute("--help").then(exitCode => {
                 assert.strictEqual(exitCode, 0);
             });
         });

--- a/packages/textlint/test/cli/fixtures/help.txt
+++ b/packages/textlint/test/cli/fixtures/help.txt
@@ -1,0 +1,36 @@
+textlint [options] file.md [file|dir|glob*]
+
+Options:
+  -h, --help                 Show help.
+  -c, --config path::String  Use configuration from this file or sharable config.
+  --init                     Create the config file if not existed. - default: false
+  --fix                      Automatically fix problems
+  --dry-run                  Enable dry-run mode for --fix. Only show result, don't change the file.
+  --debug                    Outputs debugging information
+  -v, --version              Outputs the version number.
+
+Using stdin:
+  --stdin                    Lint text provided on <STDIN>. - default: false
+  --stdin-filename String    Specify filename to process STDIN as
+
+Output:
+  -o, --output-file path::String  Enable report to be written to a file.
+  -f, --format String        Use a specific output format.
+                             Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
+                             Available formatter for fixer: compats, diff, json, stylish
+  --no-color                 Disable color in piped output.
+  --quiet                    Report errors only. - default: false
+
+Specifying rules and plugins:
+  --plugin [String]          Set plugin package name
+  --rule [path::String]      Set rule package name
+  --preset [path::String]    Set preset package name and load rules from preset package.
+  --rulesdir [path::String]  Set rules from this directory and set all default rules to off.
+
+Caching:
+  --cache                    Only check changed files - default: false
+  --cache-location path::String  Path to the cache file or directory
+
+Experimental:
+  --experimental             Enable experimental flag.Some feature use on experimental.
+  --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.

--- a/packages/textlint/test/cli/fixtures/help.txt
+++ b/packages/textlint/test/cli/fixtures/help.txt
@@ -17,7 +17,7 @@ Output:
   -o, --output-file path::String  Enable report to be written to a file.
   -f, --format String        Use a specific output format.
                              Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
-                             Available formatter for fixer: compats, diff, json, stylish
+                             Available formatter for --fix: compats, diff, json, stylish
   --no-color                 Disable color in piped output.
   --quiet                    Report errors only. - default: false
 


### PR DESCRIPTION
Hi, I implemented feature #85, choosing option 2 for its simplicity. Could you please review my implementation?

> ### Implementation Options
> 
> Which is better?
> 
> - `textlint -f -h` show formatter names?
>     - [generateHelpForOption(optionName)](https://github.com/gkz/optionator#generatehelpforoptionoptionname "generateHelpForOption(optionName)") and [longDescription](https://github.com/gkz/optionator#generatehelpforoptionoptionname "longDescription")
> - `textlint -h` show formatter names?
>     - simple