### PR TITLE
chore(yarn): add yarn-check scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 - npm install -g yarn@latest
 install:
 - yarn install
+- yarn run yarn-check
 - yarn run bootstrap
 script:
 - yarn test:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_install:
 - npm install -g npm@4
 - npm install -g yarn@latest
 install:
-- yarn install
-- yarn run yarn-check
+- yarn install --frozon-lockfile
 - yarn run bootstrap
 script:
 - yarn test:all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # install modules
   - npm i -g yarn
-  - yarn install
+  - yarn install --frozon-lockfile
   - yarn run bootstrap
 
 # Post-install test scripts.

--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
     "textlint": "node packages/textlint/bin/textlint.js --cache -c docs/.textlintrc docs/ .github/ README.md -f pretty-error",
     "textlint:fix": "node packages/textlint/bin/textlint.js --fix --cache -c docs/.textlintrc docs/ .github/ README.md",
     "perf": "cd ./examples/perf && npm run test:ci",
-    "precommit": "lint-staged",
+    "precommit": "yarn run yarn-check && lint-staged",
     "postcommit": "git reset",
-    "prepush": "yarn run yarn-check",
     "prettier": "prettier --write 'packages/**/*.{js,jsx,ts,tsx,css}'"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "publish:canary": "lerna publish --canary",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build",
+    "yarn-check": "yarn check --integrity || (echo '=> Please run `$ yarn bootstrap`' && exit 1)",
     "pretest": "npm run build",
     "test": "npm-run-all --parallel lint test:packages",
     "test:all": "npm-run-all test test:examples test:integration",
@@ -29,6 +30,7 @@
     "perf": "cd ./examples/perf && npm run test:ci",
     "precommit": "lint-staged",
     "postcommit": "git reset",
+    "prepush": "yarn run yarn-check",
     "prettier": "prettier --write 'packages/**/*.{js,jsx,ts,tsx,css}'"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,7 +6692,7 @@ textlint-rule-eslint@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/textlint-rule-eslint/-/textlint-rule-eslint-2.0.1.tgz#d5dfb359b1e7df3ffa5002cf9067949d6cf988f6"
 
-textlint-rule-helper@^1.1.2, textlint-rule-helper@^1.1.3:
+textlint-rule-helper@^1.1.2, textlint-rule-helper@^1.1.3, textlint-rule-helper@^1.1.5:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz#be68d47a5146b16dd116278c9aeb7bd35631ccda"
   dependencies:
@@ -6766,6 +6766,13 @@ textlint-rule-max-ten@^1.1.0:
   dependencies:
     object-assign "^4.0.1"
     textlint-rule-helper "^1.1.3"
+
+textlint-rule-no-exclamation-question-mark@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/textlint-rule-no-exclamation-question-mark/-/textlint-rule-no-exclamation-question-mark-1.0.2.tgz#f3d812cfbaddc8224ca497d9b38b70dac554891c"
+  dependencies:
+    match-index "^1.0.1"
+    textlint-rule-helper "^1.1.5"
 
 textlint-rule-no-mix-dearu-desumasu@^1.0.1:
   version "1.4.0"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19714/34367263-a8fa137a-eaeb-11e7-8f1d-a008cc434e56.png)

> [yarn install --frozen-lockfile](https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile "yarn install --frozen-lockfile")
> Don’t generate a yarn.lock lockfile and fail if an update is needed.

> [yarn check --integrity](https://yarnpkg.com/en/docs/cli/check "yarn check --integrity")
> Verifies that versions and hashed value of the package contents in the project’s package.json matches that of yarn’s lock file. This helps to verify that the package dependencies have not been altered.

- [x] Add `precommit` hook instread of `prepush`
- [x] Add `yarn install --frozon-lockfile` to `travis.yml` 
- [x] Add `yarn install --frozon-lockfile` to `appveyor.yml`

fix #386 