### PR TITLE
chore(ast-node-types): Make ASTNodeTypes string enum

### DIFF
--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -6,29 +6,30 @@
  * Constant value of types
  * @see https://github.com/textlint/textlint/blob/master/docs/txtnode.md
  */
-export const ASTNodeTypes: { [key: string]: string } = {
-    Document: "Document",
-    Paragraph: "Paragraph",
-    BlockQuote: "BlockQuote",
-    ListItem: "ListItem",
-    List: "List",
-    Header: "Header",
-    CodeBlock: "CodeBlock",
-    HtmlBlock: "HtmlBlock",
-    ReferenceDef: "ReferenceDef",
-    HorizontalRule: "HorizontalRule",
-    Comment: "Comment",
+export enum ASTNodeTypes {
+    Document = "Document",
+    Paragraph = "Paragraph",
+    BlockQuote = "BlockQuote",
+    ListItem = "ListItem",
+    List = "List",
+    Header = "Header",
+    CodeBlock = "CodeBlock",
+    HtmlBlock = "HtmlBlock",
+    ReferenceDef = "ReferenceDef",
+    HorizontalRule = "HorizontalRule",
+    Comment = "Comment",
     // inline
-    Str: "Str",
-    Break: "Break", // well-known Hard Break
-    Emphasis: "Emphasis",
-    Strong: "Strong",
-    Html: "Html",
-    Link: "Link",
-    Image: "Image",
-    Code: "Code",
-    Delete: "Delete"
-};
+    Str = "Str",
+    Break = "Break", // well-known Hard Break
+    Emphasis = "Emphasis",
+    Strong = "Strong",
+    Html = "Html",
+    Link = "Link",
+    Image = "Image",
+    Code = "Code",
+    Delete = "Delete"
+}
+
 /**
  * Key of ASTNodeTypes or any string
  * For example, TxtNodeType is "Document".

--- a/packages/@textlint/kernel/src/core/filter-rule-context.ts
+++ b/packages/@textlint/kernel/src/core/filter-rule-context.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import SourceCode from "./source-code";
-import { TxtNode } from "@textlint/ast-node-types";
+import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import RuleError from "./rule-error";
 import { ShouldIgnoreFunction } from "../task/textlint-core-task";
 import { BaseRuleContext } from "./BaseRuleContext";
@@ -61,7 +61,7 @@ export default class FilterRuleContext implements BaseRuleContext {
      * Node's type values
      * @type {TextLintNodeType}
      */
-    get Syntax() {
+    get Syntax(): typeof ASTNodeTypes {
         return this._sourceCode.getSyntax();
     }
 

--- a/packages/@textlint/kernel/src/core/rule-context.ts
+++ b/packages/@textlint/kernel/src/core/rule-context.ts
@@ -4,7 +4,7 @@
 import { BaseRuleContext } from "./BaseRuleContext";
 
 const assert = require("assert");
-import { TxtNode } from "@textlint/ast-node-types";
+import { TxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
 import RuleFixer from "../fixer/rule-fixer";
 import RuleError from "./rule-error";
 import SeverityLevel from "../shared/type/SeverityLevel";
@@ -75,9 +75,9 @@ export default class RuleContext implements BaseRuleContext {
 
     /**
      * Node's type values
-     * @type {TextLintNodeType}
+     * @type {ASTNodeTypes}
      */
-    get Syntax() {
+    get Syntax(): typeof ASTNodeTypes {
         return this._sourceCode.getSyntax();
     }
 


### PR DESCRIPTION
BREAKING CHANGE: TypeScript need to use it as enum

String enum has benefit

- Iterable for of
- Support Index signature

Details desription in japanese.
http://blog.yux3.net/entry/2017/12/05/102528

fix #422 