### PR TITLE
refactor(textlint-fixer-formatter): make `getFormatterList()` return type explicit 

### DIFF
--- a/packages/textlint-fixer-formatter/src/index.ts
+++ b/packages/textlint-fixer-formatter/src/index.ts
@@ -46,7 +46,11 @@ ${ex}`);
     };
 }
 
-export function getFormatterList() {
+export interface FormatterDetail {
+    name: string;
+}
+
+export function getFormatterList(): FormatterDetail[] {
     return fs
         .readdirSync(path.join(__dirname, "formatters"))
         .filter((file: string) => {

--- a/packages/textlint-fixer-formatter/src/index.ts
+++ b/packages/textlint-fixer-formatter/src/index.ts
@@ -49,7 +49,7 @@ export interface FixerFormatterDetail {
     name: string;
 }
 
-export function getFormatterList(): FixerFormatterDetail[] {
+export function getFixerFormatterList(): FixerFormatterDetail[] {
     return fs
         .readdirSync(path.join(__dirname, "formatters"))
         .filter((file: string) => {

--- a/packages/textlint-fixer-formatter/src/index.ts
+++ b/packages/textlint-fixer-formatter/src/index.ts
@@ -21,7 +21,6 @@ export function createFormatter(formatterConfig: FormatterConfig) {
     } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
         formatterPath = path.resolve(process.cwd(), formatterName);
     } else {
-        // FIXME: Move textfix-formatter to pacakges/
         if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.js`)) {
             formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.js`;
         } else if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.ts`)) {
@@ -46,11 +45,11 @@ ${ex}`);
     };
 }
 
-export interface FormatterDetail {
+export interface FixerFormatterDetail {
     name: string;
 }
 
-export function getFormatterList(): FormatterDetail[] {
+export function getFormatterList(): FixerFormatterDetail[] {
     return fs
         .readdirSync(path.join(__dirname, "formatters"))
         .filter((file: string) => {

--- a/packages/textlint-fixer-formatter/test/textlint-fixer-formatter-test.ts
+++ b/packages/textlint-fixer-formatter/test/textlint-fixer-formatter-test.ts
@@ -1,12 +1,12 @@
 // LICENSE : MIT
 "use strict";
-import { getFormatterList } from "textlint-fixer-formatter";
+import { getFixerFormatterList } from "textlint-fixer-formatter";
 import assert from "power-assert";
 
 describe("textlint-fixer-formatter-test", function() {
     describe("getFormatterList", function() {
         it("should return list of formatter(s)", function() {
-            assert.deepEqual(getFormatterList(), [
+            assert.deepEqual(getFixerFormatterList(), [
                 { name: "compats" },
                 { name: "diff" },
                 { name: "json" },

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,11 +1,11 @@
 // LICENSE : MIT
 "use strict";
-import { getFormatterList } from "textlint-formatter";
+import { getFormatterList, FormatterDetail } from "textlint-formatter";
 import { getFormatterList as getFixerFormatterList } from "textlint-fixer-formatter";
 
 const optionator = require("optionator");
 
-const concatFormatterList = (formatterList: { name: string }[]) => {
+const concatFormatterList = (formatterList: FormatterDetail[]) => {
     return formatterList
         .map(formatter => {
             return formatter.name;

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import { getFormatterList, FormatterDetail } from "textlint-formatter";
-import { getFormatterList as getFixerFormatterList } from "textlint-fixer-formatter";
+import { getFixerFormatterList } from "textlint-fixer-formatter";
 
 const optionator = require("optionator");
 

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,11 +1,11 @@
 // LICENSE : MIT
 "use strict";
 import { getFormatterList, FormatterDetail } from "textlint-formatter";
-import { getFixerFormatterList } from "textlint-fixer-formatter";
+import { getFixerFormatterList, FixerFormatterDetail } from "textlint-fixer-formatter";
 
 const optionator = require("optionator");
 
-const concatFormatterList = (formatterList: FormatterDetail[]) => {
+const concatFormatterList = (formatterList: FormatterDetail[] | FixerFormatterDetail[]) => {
     return formatterList
         .map(formatter => {
             return formatter.name;


### PR DESCRIPTION
## Breaking Change

- Renamed `getFormatterList` to `getFixerFormatterList`

## Refactor

- make `getFormatterList()` function return type explicit
  - Define `FixerFormatterDetail[]`
  - `textlint-formatter` already support `FormatterDetail`
- textlint use the `FormatterDetail` and `FixerFormatterDetail`

