### PR TITLE
chore(perf): `yarn test` ignore `perf` test

### DIFF
--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,7 +1,6 @@
 {
   "scripts": {
-    "perf": "node perf.js",
-    "test": "npm run perf"
+    "perf": "node perf.js"
   },
   "private": true,
   "version": "2.0.2",


### PR DESCRIPTION
`textlint-example-perf` is not parts of test.


fix  #433