### PR TITLE
docs: fix multiple broken links and stale type interface

### DIFF
--- a/docs/filter-rule.md
+++ b/docs/filter-rule.md
@@ -42,7 +42,7 @@ The rule `<name>` can be accept following patterns:
     - `context.shouldIgnore(node.range, { ruleId: "rule-id" });` filter messages that are reported `"rule-id"` rule. 
 - `Syntax.*` is const values of [TxtNode type](./txtnode.md).
     - e.g.) `context.Syntax.Str`
-    - [src/shared/type/NodeType.js](../src/shared/type/NodeType.js)
+    - [packages/@textlint/ast-node-types/src/index.ts](../packages/@textlint/ast-node-types/src/index.ts)
 - `getSource(<node>)`  is a method gets the source code for the given node.
     - e.g.) `context.getSource(node); // => "text"`
 - `getFilePath()` return file path that is linting target.

--- a/docs/formatter.md
+++ b/docs/formatter.md
@@ -2,7 +2,7 @@
 
 ## Result of linting
 
-Pass following array of [TextLintResult](https://github.com/textlint/textlint/blob/master/typings/textlint.d.ts "TextLintResult") to reporter module.
+Pass following array of `TextLintResult` to reporter module.
 
 ```js
 // results of linting
@@ -24,9 +24,45 @@ const results = [
 ];
 ```
 
-`TextLintMessage` and `TextLintResult` are defined in [textlint.d.ts](https://github.com/textlint/textlint/blob/master/typings/textlint.d.ts "textlint.d.ts").
+`TextLintMessage` and `TextLintResult` are defined as follows.
 
-It is compatible for [ESLint formatter](http://eslint.org/docs/developer-guide/working-with-custom-formatters "Documentation - ESLint - Pluggable JavaScript linter"). 
+```typescript
+export class TextlintMessage {
+    // See src/shared/type/MessageType.js
+    // Message Type
+    type: string;
+    // Rule Id
+    ruleId: string;
+    message: string;
+    // optional data
+    data?: any;
+    // FixCommand
+    fix?: TextlintFixCommand;
+    // location info
+    // Text -> AST TxtNode(0-based columns) -> textlint -> TextlintMessage(**1-based columns**)
+    line: number; // start with 1
+    column: number; // start with 1
+    // indexed-location
+    index: number; // start with 0
+    // Severity Level
+    // See src/shared/type/SeverityLevel.js
+    severity: number;
+}
+
+// Linting result
+export interface TextlintResult {
+    filePath: string;
+    messages: TextlintMessage[];
+}
+
+// "range" will be replaced by "text"
+export class TextlintFixCommand {
+    text: string;
+    range: [number, number];
+}
+```
+
+It is compatible for [ESLint formatter](https://eslint.org/docs/developer-guide/working-with-custom-formatters "Documentation - ESLint - Pluggable JavaScript linter"). 
 
 ### Simple usage from Command line
 
@@ -79,8 +115,24 @@ const results = [
 ];
 ```
 
-`TextLintFixResult` and `TextLintResult` are defined in [textlint.d.ts](https://github.com/textlint/textlint/blob/master/typings/textlint.d.ts "textlint.d.ts").
+`TextLintFixResult` is defined as follows.
 
+```typescript
+// Fixing result
+export interface TextlintFixResult {
+    filePath: string;
+    // fixed content
+    output: string;
+    // all messages = pre-applyingMessages + remainingMessages
+    // it is same with one of `TextlintResult`
+    messages: TextlintMessage[];
+    // applied fixable messages
+    applyingMessages: TextlintMessage[];
+    // original means original for applyingMessages and remainingMessages
+    // pre-applyingMessages + remainingMessages
+    remainingMessages: TextlintMessage[];
+}
+```
 It is not compatible for ESLint.
 
 ### Simple usage from Command line
@@ -109,7 +161,7 @@ You can read the source code from `filePath` property.
 
 textlint use `textlint-formatter` module as built-in formatter.
 
-- [textlint-formatter](/packages/textlint-formatter "textlint-formatter")
+- [textlint-formatter](../packages/textlint-formatter/README.md "textlint-formatter")
 
 ## Custom Formatter
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ $ textlint file.md
 ## Next Steps
    
 - Learn about advanced [configuring](./configuring.md) of textlint.
-- Explore [textlint's rules](https://github.com/azu/textlint/wiki/Collection-of-textlint-rule)
+- Explore [textlint's rules](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule)
 - Can't find just the right rule? Make your own [custom rule](./rule.md).
 - Can't handling `.ext` file? Make your own [custom plugin](./plugin.md).
 - Make textlint even better by [contributing](../.github/CONTRIBUTING.md).

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -18,8 +18,8 @@ export default {
 
 textlint support `.txt` and `.md` by default. These are implemented as `Processor` plugin.
 
-- [textlint/textlint-plugin-markdown](/packages/textlint-plugin-markdown)
-- [textlint/textlint-plugin-text](/packages/textlint-plugin-text)
+- [textlint/textlint-plugin-markdown](../packages/textlint-plugin-markdown)
+- [textlint/textlint-plugin-text](../packages/textlint-plugin-text)
 - [textlint/textlint-plugin-html](https://github.com/textlint/textlint-plugin-html)
 
 `Processor` class example code:
@@ -126,5 +126,5 @@ For more plugins, See [Processor Plugin List](https://github.com/textlint/textli
 
 textlint has built-in plugins
 
-- [`textlint-plugin-text`](/packages/textlint-plugin-text)
-- [`textlint-plugin-markdown`](/packages/textlint-plugin-markdown)
+- [`textlint-plugin-text`](../packages/textlint-plugin-text)
+- [`textlint-plugin-markdown`](../packages/textlint-plugin-markdown)

--- a/docs/rule-advanced.md
+++ b/docs/rule-advanced.md
@@ -29,7 +29,7 @@ These library are used in the module.
 
 ## Terms
 
-- **Paragraph** is a type of [`TxtParentNode`](./txtnode.md).
+- **Paragraph** is a type of [`TxtParentNode`](./txtnode.md#txtparentnode).
     - Paragraph has `children` nodes.
 - **Sentence** is not defined in textlint.
     - It has language dependency.
@@ -96,7 +96,7 @@ How do you handle `Code` node?
 
 In this case, We select *Case 2*.
 
-Replace `Code` to dummy object that is a single **word** Using [unist-util-map](https://github.com/azu/unist-util-map "unist-util-map").
+Replace `Code` to dummy object that is a single **word** Using [unist-util-map](https://github.com/syntax-tree/unist-util-map "unist-util-map").
 
 ```js
 // Helper for creating new AST using map function

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -1,9 +1,8 @@
 # Creating Rules
 
-textlint's AST(Abstract Syntax Tree) is defined these pages.
+textlint's AST(Abstract Syntax Tree) is defined at the page.
 
-- [txtnode.d.ts](../typings/txtast.d.ts)
-- [txtnode.md](../typings/txtast.d.ts)
+- [txtnode.md](./txtnode.md)
     - If you want to know AST of a text, use [Online Parsing Demo](./txtnode.md#online-parsing-demo)
 
 Each rules are represented by a object with some properties.
@@ -94,7 +93,7 @@ RuleContext object has following property:
 - `Syntax.*` 
     - This is const values of [TxtNode type](./txtnode.md).
     - e.g.) `context.Syntax.Str`
-    - [src/shared/type/NodeType.js](../src/shared/type/NodeType.js)
+    - [packages/@textlint/ast-node-types/src/index.ts](../packages/@textlint/ast-node-types/src/index.ts)
 - `report(<node>, <ruleError>): void`
     - This method is a method that reports a message from one of the rules.
     - e.g.) `context.report(node, new context.RuleError("found rule error"));`
@@ -111,7 +110,7 @@ RuleContext object has following property:
     - `getConfigBaseDir()` return `"/path/to/dir/"`.
 - `fixer`
     - This is creator object of fix command.
-    - See [How to create Fixable Rule?](./rule-fixer.md) for details
+    - See [How to create Fixable Rule?](./rule-fixable.md) for details
 
 ## RuleError
 
@@ -605,7 +604,7 @@ Example rules:
 
 Reference
 
-- [Working with Rules - ESLint - Pluggable JavaScript linter](http://eslint.org/docs/developer-guide/working-with-rules#rule-naming-conventions "Working with Rules - ESLint - Pluggable JavaScript linter")
+- [Working with Rules - ESLint - Pluggable JavaScript linter](https://eslint.org/docs/developer-guide/working-with-rules "Working with Rules - ESLint - Pluggable JavaScript linter")
 
 ### FAQ: Publishing
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -4,7 +4,7 @@ TxtAST define AST(Abstract Syntax Tree) for processing in textlint.
 
 ## What is AST?
 
-[Abstract syntax tree](http://en.wikipedia.org/wiki/Abstract_syntax_tree "Abstract syntax tree - Wikipedia, the free encyclopedia") is a tree representation of the abstract syntactic structure of text.
+[Abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree "Abstract syntax tree - Wikipedia, the free encyclopedia") is a tree representation of the abstract syntactic structure of text.
 
 Each node of the tree has same interface, is called `TxtNode`.
 
@@ -150,7 +150,7 @@ Following parsers are built-in.
 | [`markdown-to-ast`](../packages/markdown-to-ast) | [![npm](https://img.shields.io/npm/v/markdown-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/markdown-to-ast) | markdown parser |
 | [`txt-to-ast`](../packages/txt-to-ast) | [![npm](https://img.shields.io/npm/v/txt-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/txt-to-ast) | plain text parser |
 
-If you want to get other type, please [create new issue](https://github.com/textlint/textlint/issues/new).
+If you want to get other type, please [create new issue](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Ftextlint%2Ftextlint%2Fissues%2Fnew).
 
 ## Package
 
@@ -323,7 +323,7 @@ Illustration
 
 ## Unist
 
-`TxtAST` have a minimum of compatibility for [unist: Universal Syntax Tree](https://github.com/wooorm/unist "wooorm/unist: Universal Syntax Tree").
+`TxtAST` have a minimum of compatibility for [unist: Universal Syntax Tree](https://github.com/syntax-tree/unist "wooorm/unist: Universal Syntax Tree").
 
 We discuss about Unist in [Compliances tests for TxtNode #141](https://github.com/textlint/textlint/issues/141 "Compliances tests for TxtNode #141").
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -150,7 +150,7 @@ Following parsers are built-in.
 | [`markdown-to-ast`](../packages/markdown-to-ast) | [![npm](https://img.shields.io/npm/v/markdown-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/markdown-to-ast) | markdown parser |
 | [`txt-to-ast`](../packages/txt-to-ast) | [![npm](https://img.shields.io/npm/v/txt-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/txt-to-ast) | plain text parser |
 
-If you want to get other type, please [create new issue](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Ftextlint%2Ftextlint%2Fissues%2Fnew).
+If you want to get other type, please [create new issue](https://github.com/textlint/textlint/issues/new).
 
 ## Package
 

--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -5,7 +5,7 @@
 ![overview](./resources/architecture.png)
 
 
-`textlint` module expose these header at [index.js](../src/index.js)
+`textlint` module expose these header at [index.js](../packages/textlint/src/index.ts)
 
 ```js
 // Level of abstraction(descending order)
@@ -39,7 +39,7 @@ Recommend to use `TextLintEngine`.
 
 ## Architecture
 
-See [src/README.md](../src/README.md) for details.
+See [README.md](../README.md) for details.
 
 ### CLI(Command Line Interface)
 
@@ -69,50 +69,38 @@ textlint's core
 
 Lint files using `TextLintEngine`:
 
-See [example/node-module/lint-file.js](example/node-module/lint-file.js)
+See [examples/use-as-module/index.js](../examples/use-as-module/index.js)
 
 ```js
-const TextLintEngine = require("textlint").TextLintEngine;
-const path = require("path");
+// LICENSE : MIT
+"use strict";
+var TextLintEngine = require("textlint").TextLintEngine;
+var path = require("path");
 function lintFile(filePath) {
     /**
-     * TextlintConfig
-     * See https://github.com/textlint/textlint/blob/master/typings/textlint.d.ts
+     * See lib/_typing/textlint.d.ts
      */
-    const options = {
+    var options = {
         // load rules from [../rules]
-        rulePaths: [path.join(__dirname, "..", "rules/")],
+        rules: ["no-todo"],
         formatterName: "pretty-error"
     };
-    const engine = new TextLintEngine(options);
-    const filePathList = [path.resolve(process.cwd(), filePath)];
-    engine
-        .executeOnFiles(filePathList)
-        .then(function(results) {
-            /* 
-        See https://github.com/textlint/textlint/blob/master/typings/textlint.d.ts
-        messages are TextLintMessage` array.
-        [
-            "filePath": "path/to/file",
-            "messages" :[
-                {
-                    id: "rule-name",
-                    message:"lint message",
-                    line: 1, // 1-based columns(TextLintMessage)
-                    column:1 // 1-based columns(TextLintMessage)
-                }
-            ]
-        ]
-         */
-            if (engine.isErrorResults(results)) {
-                const output = engine.formatResults(results);
-                console.log(output);
-            }
-        })
-        .catch(function(error) {
-            console.error(error);
-        });
+    var engine = new TextLintEngine(options);
+    var filePathList = [path.resolve(process.cwd(), filePath)];
+    return engine.executeOnFiles(filePathList).then(function(results) {
+        if (engine.isErrorResults(results)) {
+            var output = engine.formatResults(results);
+            console.log(output);
+        } else {
+            console.log("All Passed!");
+        }
+    });
 }
+
+lintFile(__dirname + "/README.md").catch(function(error) {
+    console.error(error);
+    process.exit(1);
+});
 ```
 
 ## Testing
@@ -124,4 +112,4 @@ You can use [textlint-tester](https://www.npmjs.com/package/textlint-tester "tex
 
 Consult link: 
 
-- [spellcheck-tech-word-textlint-rule/test.js at master · azu/spellcheck-tech-word-textlint-rule](https://github.com/azu/spellcheck-tech-word-textlint-rule/blob/master/test/test.js "spellcheck-tech-word-textlint-rule/test.js at master · azu/spellcheck-tech-word-textlint-rule")
+- [spellcheck-tech-word-textlint-rule/test.js at master · azu/spellcheck-tech-word-textlint-rule](https://github.com/azu/textlint-rule-spellcheck-tech-word/blob/master/test/test.js "spellcheck-tech-word-textlint-rule/test.js at master · azu/spellcheck-tech-word-textlint-rule")

--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -74,22 +74,22 @@ See [examples/use-as-module/index.js](../examples/use-as-module/index.js)
 ```js
 // LICENSE : MIT
 "use strict";
-var TextLintEngine = require("textlint").TextLintEngine;
-var path = require("path");
+const TextLintEngine = require("textlint").TextLintEngine;
+const path = require("path");
 function lintFile(filePath) {
     /**
      * See lib/_typing/textlint.d.ts
      */
-    var options = {
+    const options = {
         // load rules from [../rules]
         rules: ["no-todo"],
         formatterName: "pretty-error"
     };
-    var engine = new TextLintEngine(options);
-    var filePathList = [path.resolve(process.cwd(), filePath)];
+    const engine = new TextLintEngine(options);
+    const filePathList = [path.resolve(process.cwd(), filePath)];
     return engine.executeOnFiles(filePathList).then(function(results) {
         if (engine.isErrorResults(results)) {
-            var output = engine.formatResults(results);
+            const output = engine.formatResults(results);
             console.log(output);
         } else {
             console.log("All Passed!");
@@ -97,7 +97,7 @@ function lintFile(filePath) {
     });
 }
 
-lintFile(__dirname + "/README.md").catch(function(error) {
+lintFile(`${__dirname}/README.md`).catch(function(error) {
     console.error(error);
     process.exit(1);
 });


### PR DESCRIPTION
- [Advanced: Paragraph rule](https://github.com/textlint/textlint/blob/master/docs/rule-advanced.md)
- [Creating Rules](https://github.com/textlint/textlint/blob/master/docs/rule.md)
- [Filter rule](https://github.com/textlint/textlint/blob/master/docs/filter-rule.md)
- [Formatter](https://github.com/textlint/textlint/blob/master/docs/formatter.md)
- [Getting Started with textlint](https://github.com/textlint/textlint/blob/master/docs/getting-started.md)
- [Plugin](https://github.com/textlint/textlint/blob/master/docs/plugin.md)
- [TxtAST interface](https://github.com/textlint/textlint/blob/master/docs/txtnode.md)
- [Use as node modules](https://github.com/textlint/textlint/blob/master/docs/use-as-modules.md)

Closes #424. As discussed at #434, documentation could be improved but focused dead link and stale type declaration at this moment.