### PR TITLE
docs(getting-started.md): use -D instead of -g

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ npm init --yes
 
 ### Installation of textlint
    
-You can install `textlint` using npm. We recommend that you install `textlint` locally by running npm command with `--save-dev` option. This means that npm installs `textlint` in the <your-workspace>/node_modules folder.
+You can install `textlint` using npm. We recommend that you install `textlint` locally by running npm command with `--save-dev` option. This means that npm installs `textlint` in the `<your-workspace>/node_modules` folder.
 
 ```
 # Installed textlint locally

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,31 +2,50 @@
 
 **textlint** does the following steps:
 
-1. textlint load rules, every single rule is a plugin and you can add more at runtime.
-2. textlint parse *texts* using Markdown/Text/HTML parser plugin.
+1. textlint loads rules, every single rule is a plugin and you can add more at runtime.
+2. textlint parses *texts* using Markdown/Text/HTML parser plugin.
 3. textlint uses an AST([Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree "Abstract syntax tree")) to evaluate patterns in *texts*.
-4. textlint report errors/warning if exist.
+4. textlint reports errors/warning if exist.
 
+## Installation and Usage
 
-## Installation
+NOTICE: If you run the following procedures on Windows, please use PowerShell.
+
+### Create new workspace
+
+Create `<your-workspace>` directory and `package.json` file. A [package.json](https://docs.npmjs.com/files/package.json "package.json") manages dependencies of packages that include `textlint`:
+
+```
+# Create your workspace directory and move to it.
+mkdir your-workspace
+cd your-workspace
+
+# `npm init` command creates `package.json` file.
+npm init --yes
+```
+
+### Installation of textlint
    
-You can install `textlint` using npm:
+You can install `textlint` using npm. We recommend installing `textlint` locally:
 
-```sh
-$ npm install -D textlint
+```
+# Installed textlint locally
+npm install --save-dev textlint
 ```
 
-## Installation of rules
+### Installation of rules
 
-You can find a rule in [A Collection of textlint rule](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule "A Collection of textlint rule")
+You can find a rule in [A Collection of textlint rule](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule "A Collection of textlint rule").
 
-As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo").
+As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo"). We recommend installing a rule locally:
 
-```sh
-$ npm install -D textlint-rule-no-todo
+```
+npm install --save-dev textlint-rule-no-todo
 ```
 
-## Usage
+### Usage
+
+You can run `textlint` on any Markdown files:
 
 ``` markdown
 # file.md
@@ -37,25 +56,23 @@ $ npm install -D textlint-rule-no-todo
 
 ```
 
-You can run textlint on any Markdown files:
-
-```sh
-$ $(npm bin)/textlint --rule no-todo file.md
+```
+./node_modules/.bin/textlint --rule no-todo file.md
 ```
 
 ![screenshot lint error](./resources/screenshot-lint-error.png)
 
-We recommended that use textlint with `.textlintrc` configuration file.
-
 ## Configuration
 
-Create a `.textlintrc` file in your directory. 
+We recommend using `textlint` with `.textlintrc` configuration file.
 
-```sh
-$ $(npm bin)/textlint --init
+Create a `.textlintrc` file in your workspace:
+
+```
+./node_modules/.bin/textlint --init
 ```
 
-In it, you'll see some rules configured like this:
+In this file, you'll see some rules configured like this:
 
 ```json
 {
@@ -66,11 +83,10 @@ In it, you'll see some rules configured like this:
 }
 ```
 
-You can run textlint without any command line options:
+If there is a `.textlintrc` file in your workspace, `textlint` loads `.textlintrc` automatically. So you can run textlint without any command line options:
 
-```sh
-$ $(npm bin)/textlint file.md
-# Automatically, load `.textlintrc` in your directory
+```
+./node_modules/.bin/textlint file.md
 ```
 
 ## Next Steps

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ npm init --yes
 
 ### Installation of textlint
    
-You can install `textlint` using npm. We recommend installing `textlint` locally:
+You can install `textlint` using npm. We recommend that you install `textlint` locally by running npm command with `--save-dev` option. This means that npm installs `textlint` in the <your-workspace>/node_modules folder.
 
 ```
 # Installed textlint locally
@@ -37,7 +37,7 @@ npm install --save-dev textlint
 
 You can find a rule in [A Collection of textlint rule](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule "A Collection of textlint rule").
 
-As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo"). We recommend installing a rule locally:
+As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo"). If you have installed `textlint` locally, you must install each rule locally as well.
 
 ```
 npm install --save-dev textlint-rule-no-todo

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@
 You can install `textlint` using npm:
 
 ```sh
-$ npm install -g textlint
+$ npm install -D textlint
 ```
 
 ## Installation of rules
@@ -23,7 +23,7 @@ You can find a rule in [A Collection of textlint rule](https://github.com/textli
 As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo").
 
 ```sh
-$ npm install -g textlint-rule-no-todo
+$ npm install -D textlint-rule-no-todo
 ```
 
 ## Usage
@@ -40,7 +40,7 @@ $ npm install -g textlint-rule-no-todo
 You can run textlint on any Markdown files:
 
 ```sh
-$ textlint --rule no-todo file.md
+$ $(npm bin)/textlint --rule no-todo file.md
 ```
 
 ![screenshot lint error](./resources/screenshot-lint-error.png)
@@ -52,23 +52,24 @@ We recommended that use textlint with `.textlintrc` configuration file.
 Create a `.textlintrc` file in your directory. 
 
 ```sh
-$ textlint --init
+$ $(npm bin)/textlint --init
 ```
 
 In it, you'll see some rules configured like this:
 
 ```json
 {
-    "rules": {
-        "no-todo": true
-    }
+  "filters": {},
+  "rules": {
+    "no-todo": true
+  }
 }
 ```
 
 You can run textlint without any command line options:
 
 ```sh
-$ textlint file.md
+$ $(npm bin)/textlint file.md
 # Automatically, load `.textlintrc` in your directory
 ```
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "prettier": "prettier --write 'packages/**/*.{js,jsx,ts,tsx,css}'"
   },
   "devDependencies": {
-    "cross-env": "^5.1.3",
     "eslint": "^4.7.2",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "prettier": "prettier --write 'packages/**/*.{js,jsx,ts,tsx,css}'"
   },
   "devDependencies": {
+    "cross-env": "^5.1.3",
     "eslint": "^4.7.2",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",


### PR DESCRIPTION
This PR changes global install to local install in the installation of textlint. This PR is related to #191 