### PR TITLE
fix(kernel): pass the file path to preProcess() that is on FixerProcessor

### DIFF
--- a/packages/@textlint/kernel/src/fixer/fixer-processor.ts
+++ b/packages/@textlint/kernel/src/fixer/fixer-processor.ts
@@ -76,7 +76,7 @@ export default class FixerProcessor {
                     // create new SourceCode object
                     const newSourceCode = new SourceCode({
                         text: sourceText,
-                        ast: preProcess(sourceText),
+                        ast: preProcess(sourceText, sourceCode.filePath),
                         filePath: resultFilePath,
                         ext: sourceCode.ext
                     });


### PR DESCRIPTION
It makes processors to be able to use the filePath on a preProcess phase of fixing.

Before
--

`textlint --fix` is died if any processors use the filePath on preProcess phase.

After
--

`textlint --fix` works certainly even if any processors use the filePath on preProcess phase.