### PR TITLE
chore(test): use `ts-node-test-register` for TypeScript testing

### DIFF
--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -28,6 +28,7 @@
     "mocha": "^4.0.1",
     "rimraf": "^2.6.2",
     "ts-node": "^4.1.0",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "^2.6.2"
   }
 }

--- a/packages/@textlint/ast-node-types/test/mocha.opts
+++ b/packages/@textlint/ast-node-types/test/mocha.opts
@@ -1,1 +1,1 @@
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/@textlint/ast-node-types/test/ts-setup.js
+++ b/packages/@textlint/ast-node-types/test/ts-setup.js
@@ -1,3 +1,0 @@
-require("ts-node").register({
-    project: __dirname
-});

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -42,6 +42,7 @@
     "mocha": "^4.0.1",
     "rimraf": "^2.6.2",
     "ts-node": "^4.0.2",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/@textlint/ast-traverse/test/mocha.opts
+++ b/packages/@textlint/ast-traverse/test/mocha.opts
@@ -1,1 +1,1 @@
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/@textlint/ast-traverse/test/ts-setup.js
+++ b/packages/@textlint/ast-traverse/test/ts-setup.js
@@ -1,3 +1,0 @@
-require("ts-node").register({
-    project: __dirname
-});

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -52,6 +52,7 @@
     "mocha": "^4.0.1",
     "rimraf": "^2.6.2",
     "ts-node": "^4.0.1",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/@textlint/fixer-formatter/test/mocha.opts
+++ b/packages/@textlint/fixer-formatter/test/mocha.opts
@@ -1,1 +1,1 @@
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/@textlint/fixer-formatter/test/ts-setup.js
+++ b/packages/@textlint/fixer-formatter/test/ts-setup.js
@@ -1,3 +1,0 @@
-require("ts-node").register({
-    project: __dirname
-});

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -55,6 +55,7 @@
     "rimraf": "^2.6.2",
     "shelljs": "^0.7.7",
     "ts-node": "^3.3.0",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "~2.6.1",
     "unist-util-select": "^1.5.0"
   }

--- a/packages/@textlint/kernel/test/mocha.opts
+++ b/packages/@textlint/kernel/test/mocha.opts
@@ -1,1 +1,1 @@
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/@textlint/kernel/test/ts-setup.js
+++ b/packages/@textlint/kernel/test/ts-setup.js
@@ -1,3 +1,0 @@
-require("ts-node").register({
-    project: __dirname
-});

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -58,6 +58,7 @@
     "rimraf": "^2.6.2",
     "sinon": "^1.17.3",
     "ts-node": "^4.0.1",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/@textlint/linter-formatter/test/mocha.opts
+++ b/packages/@textlint/linter-formatter/test/mocha.opts
@@ -1,2 +1,2 @@
---require test/ts-setup.js
+--require ts-node-test-register
 --no-colors

--- a/packages/@textlint/linter-formatter/test/ts-setup.js
+++ b/packages/@textlint/linter-formatter/test/ts-setup.js
@@ -1,4 +1,0 @@
-require("ts-node").register({
-    project: __dirname,
-    typeCheck: true
-});

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -58,6 +58,7 @@
     "textlint-rule-max-number-of-lines": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.0",
     "ts-node": "^4.1.0",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "^2.6.2"
   },
   "email": "azuciao@gmail.com"

--- a/packages/textlint-tester/test/mocha.opts
+++ b/packages/textlint-tester/test/mocha.opts
@@ -1,1 +1,1 @@
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/textlint-tester/test/ts-setup.js
+++ b/packages/textlint-tester/test/ts-setup.js
@@ -1,4 +1,0 @@
-require("ts-node").register({
-    project: __dirname,
-    typeCheck: true
-});

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -94,6 +94,7 @@
     "textlint-rule-preset-ja-spacing": "^2.0.0",
     "textlint-rule-preset-jtf-style": "^2.3.0",
     "ts-node": "^3.3.0",
+    "ts-node-test-register": "^1.0.1",
     "typescript": "~2.6.1"
   }
 }

--- a/packages/textlint/test/mocha.opts
+++ b/packages/textlint/test/mocha.opts
@@ -1,2 +1,2 @@
 --timeout 5000
---require test/ts-setup.js
+--require ts-node-test-register

--- a/packages/textlint/test/ts-setup.js
+++ b/packages/textlint/test/ts-setup.js
@@ -1,3 +1,0 @@
-require("ts-node").register({
-    project: __dirname
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7925,6 +7925,12 @@ try-resolve@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/try-resolve/-/try-resolve-1.0.1.tgz#cfde6fabd72d63e5797cfaab873abbe8e700e912"
 
+ts-node-test-register@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node-test-register/-/ts-node-test-register-1.0.1.tgz#2496000aabcaca96973ece6164ffd6f1c2f6a82d"
+  dependencies:
+    read-pkg "^3.0.0"
+
 ts-node@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"


### PR DESCRIPTION
In order to improve credibility and stability of tests, use
`ts-node-test-register` to:

- Load `tsconfig.json` from `test` directory
- Enforce `typeCheck` always

replacing `ts-setup.js` with `ts-node-test-register` in following
packages:

- `textlint-tester`
- `ast-node-types`
- `ast-traverse`
- `fixer-formatter`
- `kernel`
- `linter-formatter`
- `textlint`

https://www.npmjs.com/package/ts-node-test-register

Closes #451.