### PR TITLE
refactor(gulp-textlint): remove gulp-util

### DIFF
--- a/packages/gulp-textlint/index.js
+++ b/packages/gulp-textlint/index.js
@@ -1,4 +1,5 @@
-const gutil = require("gulp-util");
+const log = require("fancy-log");
+const PluginError = require("plugin-error");
 const through = require("through2");
 const TextLintEngine = require("textlint").TextLintEngine;
 
@@ -19,12 +20,12 @@ module.exports = function(options) {
                 .executeOnFiles(filePaths)
                 .then(function(results) {
                     if (textlint.isErrorResults(results)) {
-                        gutil.log(textlint.formatResults(results));
-                        that.emit("error", new gutil.PluginError("textlint", "Lint failed."));
+                        log(textlint.formatResults(results));
+                        that.emit("error", new PluginError("textlint", "Lint failed."));
                     }
                 })
                 .catch(function(error) {
-                    that.emit("error", new gutil.PluginError("textlint", `Lint failed. \n${error.message}`));
+                    that.emit("error", new PluginError("textlint", `Lint failed. \n${error.message}`));
                 })
                 .then(function() {
                     cb();

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -20,7 +20,8 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "gulp-util": "^3.0.6",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.1",
     "textlint": "^10.1.4",
     "through2": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,6 +213,12 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-colors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.0.1.tgz#e94c6c306005af8b482240241e2f3dea4b855ff3"
+  dependencies:
+    ansi-wrap "^0.1.0"
+
 ansi-escapes@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -245,7 +251,7 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-wrap@0.1.0:
+ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
 
@@ -2928,7 +2934,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.0:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   dependencies:
@@ -2974,7 +2980,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0:
+fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -3576,7 +3582,7 @@ growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
 
-gulp-util@^3.0.0, gulp-util@^3.0.6:
+gulp-util@^3.0.0:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:
@@ -5877,6 +5883,15 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+plugin-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
+  dependencies:
+    ansi-colors "^1.0.1"
+    arr-diff "^4.0.0"
+    arr-union "^3.1.0"
+    extend-shallow "^3.0.2"
 
 pluralize@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
[`gulp-util`](https://github.com/gulpjs/gulp-util) has been deprecated.  
Though this is not critical for gulp-textlint, it is recommended to transition to individual modules.

For more information, see [this post](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5).