### PR TITLE
Release textlint@10.1.5

### DIFF
--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.7...textlint-example-cli@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.6...textlint-example-cli@2.0.7) (2018-01-27)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-cli",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint --rule no-todo '*.md'"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/config-file/CHANGELOG.md
+++ b/examples/config-file/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.7...textlint-example-config-file@2.0.8) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package textlint-example-config-file
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.6...textlint-example-config-file@2.0.7) (2018-01-27)
 

--- a/examples/config-file/package.json
+++ b/examples/config-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-file",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/filter/CHANGELOG.md
+++ b/examples/filter/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.7...textlint-example-filter@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.6...textlint-example-filter@2.0.7) (2018-01-27)
 

--- a/examples/filter/package.json
+++ b/examples/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-filter",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "filter rule example",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.0"
   }

--- a/examples/fix-dry-run/CHANGELOG.md
+++ b/examples/fix-dry-run/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.7...textlint-example-fix-dry-run@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.6...textlint-example-fix-dry-run@2.0.7) (2018-01-27)
 

--- a/examples/fix-dry-run/package.json
+++ b/examples/fix-dry-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix-dry-run",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix --dry-run README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-prh": "^5.0.1"
   }
 }

--- a/examples/fix/CHANGELOG.md
+++ b/examples/fix/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.7...textlint-example-fix@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.6...textlint-example-fix@2.0.7) (2018-01-27)
 

--- a/examples/fix/package.json
+++ b/examples/fix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-prh": "^5.0.1"
   }
 }

--- a/examples/html-plugin/CHANGELOG.md
+++ b/examples/html-plugin/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.7...textlint-example-html-plugin@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.6...textlint-example-html-plugin@2.0.7) (2018-01-27)
 

--- a/examples/html-plugin/package.json
+++ b/examples/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-html-plugin",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "textlint": "textlint -f pretty-error index.html"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-sentence-length": "^2.0.2"
   }

--- a/examples/perf/CHANGELOG.md
+++ b/examples/perf/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.7...textlint-perf-test@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.6...textlint-perf-test@2.0.7) (2018-01-27)
 

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-perf-test",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "shelljs": "^0.8.1",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-plugin-jtf-style": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",

--- a/examples/preset/CHANGELOG.md
+++ b/examples/preset/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.7...textlint-example-preset@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update `rule-preset-jtf-style` to ^2.3.1 ([f77f869](https://github.com/textlint/textlint/commit/f77f869))
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.6...textlint-example-preset@2.0.7) (2018-01-27)
 

--- a/examples/preset/package.json
+++ b/examples/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-preset",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-preset-jtf-style": "^2.3.1"
   }
 }

--- a/examples/rulesdir/CHANGELOG.md
+++ b/examples/rulesdir/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.7...textlint-example-rulesdir@2.0.8) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package textlint-example-rulesdir
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.6...textlint-example-rulesdir@2.0.7) (2018-01-27)
 

--- a/examples/rulesdir/package.json
+++ b/examples/rulesdir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-rulesdir",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,6 +12,6 @@
     "textlint": "textlint --rulesdir ./rules README.md"
   },
   "devDependencies": {
-    "textlint": "^10.1.4"
+    "textlint": "^10.1.5"
   }
 }

--- a/examples/use-as-module/CHANGELOG.md
+++ b/examples/use-as-module/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.7...textlint-example-use-as-module@2.0.8) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.6...textlint-example-use-as-module@2.0.7) (2018-01-27)
 

--- a/examples/use-as-module/package.json
+++ b/examples/use-as-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-module",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/use-as-ts-module/CHANGELOG.md
+++ b/examples/use-as-ts-module/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.5"></a>
+## [2.1.5](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.4...textlint-example-use-as-ts-module@2.1.5) (2018-03-25)
+
+
+### Chores
+
+* **examples:** update dependencies ([ab4960b](https://github.com/textlint/textlint/commit/ab4960b)), closes [textlint/textlint#493](https://github.com/textlint/textlint/issues/493) [azu/sentence-splitter#9](https://github.com/azu/sentence-splitter/issues/9) [azu/sentence-splitter#11](https://github.com/azu/sentence-splitter/issues/11) [textlint-rule/textlint-rule-sentence-length#10](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/10) [textlint-rule/textlint-rule-sentence-length#11](https://github.com/textlint-rule/textlint-rule-sentence-length/issues/11)
+
+
+
+
 <a name="2.1.4"></a>
 ## [2.1.4](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.3...textlint-example-use-as-ts-module@2.1.4) (2018-01-27)
 

--- a/examples/use-as-ts-module/package.json
+++ b/examples/use-as-ts-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-ts-module",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "private": true,
   "license": "MIT",
   "author": "0x6b",
@@ -14,7 +14,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.0"
   },

--- a/packages/@textlint/ast-node-types/CHANGELOG.md
+++ b/packages/@textlint/ast-node-types/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.2"></a>
+## [4.0.2](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.0.1...@textlint/ast-node-types@4.0.2) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="4.0.1"></a>
 ## [4.0.1](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.0.0...@textlint/ast-node-types@4.0.1) (2018-01-18)
 

--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-node-types",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "textlint AST node type definition.",
   "keywords": [
     "textlint"

--- a/packages/@textlint/ast-tester/CHANGELOG.md
+++ b/packages/@textlint/ast-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.5"></a>
+## [2.0.5](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.4...@textlint/ast-tester@2.0.5) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package @textlint/ast-tester
+
 <a name="2.0.4"></a>
 ## [2.0.4](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.3...@textlint/ast-tester@2.0.4) (2018-01-27)
 

--- a/packages/@textlint/ast-tester/package.json
+++ b/packages/@textlint/ast-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-tester",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Compliance tests for textlint's AST(Abstract Syntax Tree).",
   "keywords": [
     "ast",
@@ -35,8 +35,8 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.5",
-    "@textlint/text-to-ast": "^3.0.5",
+    "@textlint/markdown-to-ast": "^6.0.6",
+    "@textlint/text-to-ast": "^3.0.6",
     "babel-cli": "^6.6.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",

--- a/packages/@textlint/ast-traverse/CHANGELOG.md
+++ b/packages/@textlint/ast-traverse/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.6"></a>
+## [2.0.6](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.0.5...@textlint/ast-traverse@2.0.6) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="2.0.5"></a>
 ## 2.0.5 (2018-01-27)
 

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-traverse",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "TxtNode traverse library",
   "keywords": [
     "AST",
@@ -32,10 +32,10 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.1"
+    "@textlint/ast-node-types": "^4.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.5",
+    "@textlint/markdown-to-ast": "^6.0.6",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.5.1",
     "cross-env": "^5.1.1",

--- a/packages/@textlint/fixer-formatter/CHANGELOG.md
+++ b/packages/@textlint/fixer-formatter/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.5"></a>
+## [3.0.5](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.4...@textlint/fixer-formatter@3.0.5) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="3.0.4"></a>
 ## [3.0.4](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.3...@textlint/fixer-formatter@3.0.4) (2018-01-27)
 

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/fixer-formatter",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "textlint output formatter for fixer",
   "keywords": [
     "AST",
@@ -34,7 +34,7 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/kernel": "^2.0.6",
+    "@textlint/kernel": "^2.0.7",
     "chalk": "^1.1.3",
     "debug": "^2.1.0",
     "diff": "^2.2.2",

--- a/packages/@textlint/kernel/CHANGELOG.md
+++ b/packages/@textlint/kernel/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.7"></a>
+## [2.0.7](https://github.com/textlint/textlint/compare/@textlint/kernel@2.0.6...@textlint/kernel@2.0.7) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="2.0.6"></a>
 ## [2.0.6](https://github.com/textlint/textlint/compare/@textlint/kernel@2.0.5...@textlint/kernel@2.0.6) (2018-01-27)
 

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/kernel",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "textlint kernel is core logic by pure JavaScript.",
   "keywords": [
     "textlint"
@@ -33,8 +33,8 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.1",
-    "@textlint/ast-traverse": "^2.0.5",
+    "@textlint/ast-node-types": "^4.0.2",
+    "@textlint/ast-traverse": "^2.0.6",
     "@textlint/feature-flag": "^3.0.4",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.5.1",
@@ -44,8 +44,8 @@
     "structured-source": "^3.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.5",
-    "@textlint/textlint-plugin-markdown": "^4.0.7",
+    "@textlint/markdown-to-ast": "^6.0.6",
+    "@textlint/textlint-plugin-markdown": "^4.0.8",
     "@types/mocha": "^2.2.43",
     "@types/node": "^8.0.28",
     "cpx": "^1.5.0",

--- a/packages/@textlint/linter-formatter/CHANGELOG.md
+++ b/packages/@textlint/linter-formatter/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.5"></a>
+## [3.0.5](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.4...@textlint/linter-formatter@3.0.5) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="3.0.4"></a>
 ## [3.0.4](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.3...@textlint/linter-formatter@3.0.4) (2018-01-27)
 

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/linter-formatter",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "textlint output formatter",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/linter-formatter",
   "bugs": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azu/format-text": "^1.0.1",
     "@azu/style-format": "^1.0.0",
-    "@textlint/kernel": "^2.0.6",
+    "@textlint/kernel": "^2.0.7",
     "chalk": "^1.0.0",
     "concat-stream": "^1.5.1",
     "js-yaml": "^3.2.4",

--- a/packages/@textlint/markdown-to-ast/CHANGELOG.md
+++ b/packages/@textlint/markdown-to-ast/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="6.0.6"></a>
+## [6.0.6](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.5...@textlint/markdown-to-ast@6.0.6) (2018-03-25)
+
+
+### Chores
+
+* format ([d8f44db](https://github.com/textlint/textlint/commit/d8f44db))
+
+
+
+
 <a name="6.0.5"></a>
 ## [6.0.5](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.4...@textlint/markdown-to-ast@6.0.5) (2018-01-27)
 

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/markdown-to-ast",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Parse Markdown to AST with location info.",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast/",
   "bugs": {
@@ -29,15 +29,15 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.1",
+    "@textlint/ast-node-types": "^4.0.2",
     "debug": "^2.1.3",
     "remark": "^7.0.1",
     "structured-source": "^3.0.2",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.4",
-    "@textlint/ast-traverse": "^2.0.5",
+    "@textlint/ast-tester": "^2.0.5",
+    "@textlint/ast-traverse": "^2.0.6",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/text-to-ast/CHANGELOG.md
+++ b/packages/@textlint/text-to-ast/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.6"></a>
+## [3.0.6](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.5...@textlint/text-to-ast@3.0.6) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package @textlint/text-to-ast
+
 <a name="3.0.5"></a>
 ## [3.0.5](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.4...@textlint/text-to-ast@3.0.5) (2018-01-27)
 

--- a/packages/@textlint/text-to-ast/package.json
+++ b/packages/@textlint/text-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/text-to-ast",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Parse plain text to AST with location info.",
   "keywords": [
     "ast",
@@ -35,10 +35,10 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.1"
+    "@textlint/ast-node-types": "^4.0.2"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.4",
+    "@textlint/ast-tester": "^2.0.5",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.8"></a>
+## [4.0.8](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@4.0.7...@textlint/textlint-plugin-markdown@4.0.8) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package @textlint/textlint-plugin-markdown
+
 <a name="4.0.7"></a>
 ## 4.0.7 (2018-01-27)
 

--- a/packages/@textlint/textlint-plugin-markdown/package.json
+++ b/packages/@textlint/textlint-plugin-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-markdown",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Markdown support for textlint.",
   "keywords": [
     "markdown",
@@ -33,7 +33,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/markdown-to-ast": "^6.0.5"
+    "@textlint/markdown-to-ast": "^6.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -45,7 +45,7 @@
     "mocha": "^4.0.1",
     "power-assert": "^1.4.1",
     "rimraf": "^2.6.2",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-todo": "^2.0.0"
   },
   "email": "azuciao@gmail.com",

--- a/packages/@textlint/textlint-plugin-text/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-text/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.8"></a>
+## [3.0.8](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@3.0.7...@textlint/textlint-plugin-text@3.0.8) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package @textlint/textlint-plugin-text
+
 <a name="3.0.7"></a>
 ## 3.0.7 (2018-01-27)
 

--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-text",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "plain text plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/textlint-plugin-text/",
   "bugs": {
@@ -29,7 +29,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/text-to-ast": "^3.0.5"
+    "@textlint/text-to-ast": "^3.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -41,7 +41,7 @@
     "mocha": "^4.0.1",
     "power-assert": "^1.4.2",
     "rimraf": "^2.6.2",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-rule-no-todo": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/gulp-textlint/CHANGELOG.md
+++ b/packages/gulp-textlint/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.0.8"></a>
+## [5.0.8](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.7...gulp-textlint@5.0.8) (2018-03-25)
+
+
+### Code Refactoring
+
+* **gulp-textlint:** remove gulp-util ([7899ecf](https://github.com/textlint/textlint/commit/7899ecf))
+
+
+
+
 <a name="5.0.7"></a>
 ## [5.0.7](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.6...gulp-textlint@5.0.7) (2018-01-27)
 

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-textlint",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "description": "gulp plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "bugs": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.1",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/textlint-tester/CHANGELOG.md
+++ b/packages/textlint-tester/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.1"></a>
+## [4.1.1](https://github.com/textlint/textlint/compare/textlint-tester@4.1.0...textlint-tester@4.1.1) (2018-03-25)
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+* format ([d8f44db](https://github.com/textlint/textlint/commit/d8f44db))
+
+
+
+
 <a name="4.1.0"></a>
 # [4.1.0](https://github.com/textlint/textlint/compare/textlint-tester@4.0.6...textlint-tester@4.1.0) (2018-01-27)
 

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-tester",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "testing tool for textlint rule.",
   "keywords": [
     "test",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@textlint/feature-flag": "^3.0.4",
-    "@textlint/kernel": "^2.0.6",
-    "textlint": "^10.1.4"
+    "@textlint/kernel": "^2.0.7",
+    "textlint": "^10.1.5"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.46",
@@ -52,7 +52,7 @@
     "mocha": "^4.1.0",
     "power-assert": "^1.4.1",
     "rimraf": "^2.6.2",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-helper": "^2.0.0",
     "textlint-rule-max-number-of-lines": "^1.0.2",

--- a/packages/textlint/CHANGELOG.md
+++ b/packages/textlint/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.1.5"></a>
+## [10.1.5](https://github.com/textlint/textlint/compare/textlint@10.1.4...textlint@10.1.5) (2018-03-25)
+
+
+### Bug Fixes
+
+* **textlint:** remove utf-8-validate ([7668c1b](https://github.com/textlint/textlint/commit/7668c1b))
+
+
+### Chores
+
+* **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)
+
+
+
+
 <a name="10.1.4"></a>
 ## [10.1.4](https://github.com/textlint/textlint/compare/textlint@10.1.3...textlint@10.1.4) (2018-01-27)
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint",
-  "version": "10.1.4",
+  "version": "10.1.5",
   "description": "The pluggable linting tool for text and markdown.",
   "keywords": [
     "AST",
@@ -44,14 +44,14 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.1",
-    "@textlint/ast-traverse": "^2.0.5",
+    "@textlint/ast-node-types": "^4.0.2",
+    "@textlint/ast-traverse": "^2.0.6",
     "@textlint/feature-flag": "^3.0.4",
-    "@textlint/fixer-formatter": "^3.0.4",
-    "@textlint/kernel": "^2.0.6",
-    "@textlint/linter-formatter": "^3.0.4",
-    "@textlint/textlint-plugin-markdown": "^4.0.7",
-    "@textlint/textlint-plugin-text": "^3.0.7",
+    "@textlint/fixer-formatter": "^3.0.5",
+    "@textlint/kernel": "^2.0.7",
+    "@textlint/linter-formatter": "^3.0.5",
+    "@textlint/textlint-plugin-markdown": "^4.0.8",
+    "@textlint/textlint-plugin-text": "^3.0.8",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.0.5",
     "debug": "^2.1.0",

--- a/scripts/release/CHANGELOG.md
+++ b/scripts/release/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.1.1"></a>
+## [1.1.1](https://github.com/textlint/textlint/compare/textlint-script-release@1.1.0...textlint-script-release@1.1.1) (2018-03-25)
+
+
+### Bug Fixes
+
+* **release:** fix release scripts ([00470f4](https://github.com/textlint/textlint/commit/00470f4))
+
+
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2018-01-27)
 

--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "textlint-script-release",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Release script",
   "main": "./release.js",
   "bin": {

--- a/test/integration-test/CHANGELOG.md
+++ b/test/integration-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/integration-test@2.0.7...integration-test@2.0.8) (2018-03-25)
+
+
+
+
+**Note:** Version bump only for package integration-test
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/integration-test@2.0.6...integration-test@2.0.7) (2018-01-27)
 

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-test",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "private": true,
   "description": "textlint testbot sandbox.",
   "keywords": [
@@ -35,7 +35,7 @@
   "devDependencies": {
     "json5": "^0.5.1",
     "shelljs": "^0.7.7",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlintrc-to-pacakge-list": "^1.2.0"
   },
   "email": "azuciao@gmail.com"

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.3.0"></a>
+# [10.3.0](https://github.com/textlint/textlint/compare/textlint-website@10.2.1...textlint-website@10.3.0) (2018-03-25)
+
+
+### Bug Fixes
+
+* **website:** add paddint-top ([fc5eb2f](https://github.com/textlint/textlint/commit/fc5eb2f))
+* **website:** introduce transition header ([c1347c8](https://github.com/textlint/textlint/commit/c1347c8))
+
+
+### Chores
+
+* **website:** add flip animation ([e01120d](https://github.com/textlint/textlint/commit/e01120d))
+* **website:** change color ([d84e5da](https://github.com/textlint/textlint/commit/d84e5da))
+* **website:** Change color ([022028f](https://github.com/textlint/textlint/commit/022028f))
+* **website:** change secondaryColor ([458eb36](https://github.com/textlint/textlint/commit/458eb36))
+* **website:** make primaryColor's brightness 50 ([7a2a187](https://github.com/textlint/textlint/commit/7a2a187))
+* **website:** tweak text ([d511fcd](https://github.com/textlint/textlint/commit/d511fcd))
+* **website:** tweak text ([13ab6a6](https://github.com/textlint/textlint/commit/13ab6a6))
+* **website:** update Docusaurus ([6e01ded](https://github.com/textlint/textlint/commit/6e01ded))
+* **website:** Update mobile ([e22588a](https://github.com/textlint/textlint/commit/e22588a))
+
+
+### Features
+
+* **website:** add short getting started ([d2c21d5](https://github.com/textlint/textlint/commit/d2c21d5))
+* **website:** apply design ([e49e46c](https://github.com/textlint/textlint/commit/e49e46c))
+
+
+
+
 <a name="10.2.1"></a>
 ## [10.2.1](https://github.com/textlint/textlint/compare/textlint-website@10.2.0...textlint-website@10.2.1) (2018-01-27)
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-website",
-  "version": "10.2.1",
+  "version": "10.3.0",
   "private": true,
   "homepage": "https://github.com/textlint/textlint/",
   "bugs": {
@@ -26,7 +26,7 @@
     "docusaurus": "^1.0.9",
     "eslint": "^4.15.0",
     "npm-run-all": "^4.1.2",
-    "textlint": "^10.1.4",
+    "textlint": "^10.1.5",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-eslint": "^2.0.1",
     "textlint-rule-no-dead-link": "^4.3.0",


### PR DESCRIPTION
## Changelog

## [textlint@10.1.5](https://github.com/textlint/textlint/releases/tag/textlint@10.1.5)

### fixes

- **textlint:** remove utf-8-validate ([7668c1b](https://github.com/textlint/textlint/commit/7668c1b))
- **test:** use `ts-node-test-register` for TypeScript testing ([be746d8](https://github.com/textlint/textlint/commit/be746d8)), closes [#451](https://github.com/textlint/textlint/issues/451)

## version

 - gulp-textlint@5.0.8
 - textlint-tester@4.1.1
 - textlint@10.1.5
 - textlint-example-cli@2.0.8
 - textlint-example-config-file@2.0.8
 - textlint-example-filter@2.0.8
 - textlint-example-fix-dry-run@2.0.8
 - textlint-example-fix@2.0.8
 - textlint-example-html-plugin@2.0.8
 - textlint-perf-test@2.0.8
 - textlint-example-preset@2.0.8
 - textlint-example-rulesdir@2.0.8
 - textlint-example-use-as-module@2.0.8
 - textlint-example-use-as-ts-module@2.1.5
 - textlint-script-release@1.1.1
 - @textlint/ast-node-types@4.0.2
 - @textlint/ast-tester@2.0.5
 - @textlint/ast-traverse@2.0.6
 - @textlint/fixer-formatter@3.0.5
 - @textlint/kernel@2.0.7
 - @textlint/linter-formatter@3.0.5
 - @textlint/markdown-to-ast@6.0.6
 - @textlint/text-to-ast@3.0.6
 - @textlint/textlint-plugin-markdown@4.0.8
 - @textlint/textlint-plugin-text@3.0.8
 - integration-test@2.0.8
 - textlint-website@10.3.0