### PR TITLE
fix(markdown-to-ast): enable yaml frontmatter parse by default

### DIFF
--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -31,9 +31,11 @@
   "dependencies": {
     "@textlint/ast-node-types": "^4.0.2",
     "debug": "^2.1.3",
-    "remark": "^9.0.0",
+    "remark-frontmatter": "^1.2.0",
+    "remark-parse": "^5.0.0",
     "structured-source": "^3.0.2",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "unified": "^6.1.6"
   },
   "devDependencies": {
     "@textlint/ast-tester": "^2.0.6",

--- a/packages/@textlint/markdown-to-ast/src/markdown-parser.js
+++ b/packages/@textlint/markdown-to-ast/src/markdown-parser.js
@@ -5,8 +5,12 @@ const { ASTNodeTypes } = require("@textlint/ast-node-types");
 const StructuredSource = require("structured-source");
 const debug = require("debug")("@textlint/markdown-to-ast");
 const SyntaxMap = require("./mapping/markdown-syntax-map");
-const remarkAbstract = require("remark");
-const remark = remarkAbstract();
+const unified = require("unified");
+const remarkParse = require("remark-parse");
+const frontmatter = require("remark-frontmatter");
+const remark = unified()
+    .use(remarkParse)
+    .use(frontmatter, ["yaml"]);
 /**
  * parse markdown text and return ast mapped location info.
  * @param {string} text

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-empty.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-empty.text/output.json
@@ -2,40 +2,23 @@
     "type": "Document",
     "children": [
         {
-            "type": "HorizontalRule",
+            "type": "Yaml",
+            "value": "",
             "loc": {
                 "start": {
                     "line": 1,
                     "column": 0
                 },
                 "end": {
-                    "line": 1,
+                    "line": 2,
                     "column": 3
                 }
             },
             "range": [
                 0,
-                3
-            ],
-            "raw": "---"
-        },
-        {
-            "type": "HorizontalRule",
-            "loc": {
-                "start": {
-                    "line": 2,
-                    "column": 0
-                },
-                "end": {
-                    "line": 2,
-                    "column": 3
-                }
-            },
-            "range": [
-                4,
                 7
             ],
-            "raw": "---"
+            "raw": "---\n---"
         },
         {
             "type": "Header",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-extra-dashes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-extra-dashes.text/output.json
@@ -2,89 +2,11 @@
     "type": "Document",
     "children": [
         {
-            "type": "HorizontalRule",
+            "type": "Yaml",
+            "value": "title: post\nobject:\n  key: value ---",
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 3
-                }
-            },
-            "range": [
-                0,
-                3
-            ],
-            "raw": "---"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "title: post\nobject:",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        4,
-                        23
-                    ],
-                    "raw": "title: post\nobject:"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 2,
-                    "column": 0
-                },
-                "end": {
-                    "line": 3,
-                    "column": 7
-                }
-            },
-            "range": [
-                4,
-                23
-            ],
-            "raw": "title: post\nobject:"
-        },
-        {
-            "type": "Header",
-            "depth": 2,
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "key: value ---",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        26,
-                        40
-                    ],
-                    "raw": "key: value ---"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 4,
                     "column": 0
                 },
                 "end": {
@@ -93,10 +15,10 @@
                 }
             },
             "range": [
-                24,
+                0,
                 44
             ],
-            "raw": "  key: value ---\n---"
+            "raw": "---\ntitle: post\nobject:\n  key: value ---\n---"
         },
         {
             "type": "Header",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-initial-lines.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-initial-lines.text/output.json
@@ -2,50 +2,11 @@
     "type": "Document",
     "children": [
         {
-            "type": "HorizontalRule",
+            "type": "Yaml",
+            "value": "title: post",
             "loc": {
                 "start": {
                     "line": 3,
-                    "column": 0
-                },
-                "end": {
-                    "line": 3,
-                    "column": 3
-                }
-            },
-            "range": [
-                2,
-                5
-            ],
-            "raw": "---"
-        },
-        {
-            "type": "Header",
-            "depth": 2,
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "title: post",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        6,
-                        17
-                    ],
-                    "raw": "title: post"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 4,
                     "column": 0
                 },
                 "end": {
@@ -54,10 +15,10 @@
                 }
             },
             "range": [
-                6,
+                2,
                 21
             ],
-            "raw": "title: post\n---"
+            "raw": "---\ntitle: post\n---"
         },
         {
             "type": "Header",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-normal.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-normal.text/output.json
@@ -2,50 +2,11 @@
     "type": "Document",
     "children": [
         {
-            "type": "HorizontalRule",
+            "type": "Yaml",
+            "value": "title: post",
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 3
-                }
-            },
-            "range": [
-                0,
-                3
-            ],
-            "raw": "---"
-        },
-        {
-            "type": "Header",
-            "depth": 2,
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "title: post",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        4,
-                        15
-                    ],
-                    "raw": "title: post"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 2,
                     "column": 0
                 },
                 "end": {
@@ -54,10 +15,10 @@
                 }
             },
             "range": [
-                4,
+                0,
                 19
             ],
-            "raw": "title: post\n---"
+            "raw": "---\ntitle: post\n---"
         },
         {
             "type": "Header",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-only.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-only.text/output.json
@@ -2,50 +2,11 @@
     "type": "Document",
     "children": [
         {
-            "type": "HorizontalRule",
+            "type": "Yaml",
+            "value": "title: post",
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 3
-                }
-            },
-            "range": [
-                0,
-                3
-            ],
-            "raw": "---"
-        },
-        {
-            "type": "Header",
-            "depth": 2,
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "title: post",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        4,
-                        15
-                    ],
-                    "raw": "title: post"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 2,
                     "column": 0
                 },
                 "end": {
@@ -54,10 +15,10 @@
                 }
             },
             "range": [
-                4,
+                0,
                 19
             ],
-            "raw": "title: post\n---"
+            "raw": "---\ntitle: post\n---"
         }
     ],
     "loc": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,10 +1532,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-ccount@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
-
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -1568,10 +1564,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
-
-character-entities-html4@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.1.tgz#359a2a4a0f7e29d3dc2ac99bdbe21ee39438ea50"
 
 character-entities-legacy@^1.0.0:
   version "1.1.1"
@@ -3012,7 +3004,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fault@^1.0.0:
+fault@^1.0.0, fault@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.1.tgz#de8d350dfd48be24b5dc1b02867e0871b9135092"
   dependencies:
@@ -4025,10 +4017,6 @@ is-alphabetical@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.1.tgz#c77079cc91d4efac775be1034bf2d243f95e6f08"
 
-is-alphanumeric@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz#4a9cef71daf4c001c1d81d63d140cf53fd6889f4"
-
 is-alphanumerical@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz#dfb4aa4d1085e33bdb61c2dee9c80e9c6c19f53b"
@@ -4901,10 +4889,6 @@ lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
 
-longest-streak@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.2.tgz#2421b6ba939a443bb9ffebf596585a50b4c38e2e"
-
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4987,10 +4971,6 @@ markdown-escapes@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.1.tgz#1994df2d3af4811de59a6714934c2b2292734518"
 
-markdown-table@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
-
 match-index@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/match-index/-/match-index-1.0.1.tgz#b4b673e99ab3ac5a6af303ccf4db709812bc3f58"
@@ -5015,13 +4995,6 @@ md5@^2.2.1:
 mdast-comment-marker@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mdast-comment-marker/-/mdast-comment-marker-1.0.2.tgz#1ddf0ef811fb52439017c8d2c0b922035f2ba74a"
-
-mdast-util-compact@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz#cdb5f84e2b6a2d3114df33bd05d9cb32e3c4083a"
-  dependencies:
-    unist-util-modify-children "^1.0.0"
-    unist-util-visit "^1.1.0"
 
 mdast-util-to-nlcst@^3.2.0:
   version "3.2.0"
@@ -6441,6 +6414,13 @@ regx@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/regx/-/regx-1.0.4.tgz#a0ee32c308910902019ca1117ed41b9ddd041b2f"
 
+remark-frontmatter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.2.0.tgz#67905d178c0fe531ed12c57b98759f101fc2c1b5"
+  dependencies:
+    fault "^1.0.1"
+    xtend "^4.0.1"
+
 remark-message-control@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/remark-message-control/-/remark-message-control-4.0.2.tgz#103d277418ce747fc0143542596c82c853990d51"
@@ -6496,33 +6476,6 @@ remark-retext@^3.0.0:
   resolved "https://registry.yarnpkg.com/remark-retext/-/remark-retext-3.1.0.tgz#1b3df2d49469c0d3596cad86e91503a8b600fdcc"
   dependencies:
     mdast-util-to-nlcst "^3.2.0"
-
-remark-stringify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-5.0.0.tgz#336d3a4d4a6a3390d933eeba62e8de4bd280afba"
-  dependencies:
-    ccount "^1.0.0"
-    is-alphanumeric "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    longest-streak "^2.0.1"
-    markdown-escapes "^1.0.0"
-    markdown-table "^1.1.0"
-    mdast-util-compact "^1.0.0"
-    parse-entities "^1.0.2"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    stringify-entities "^1.0.1"
-    unherit "^1.0.4"
-    xtend "^4.0.1"
-
-remark@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/remark/-/remark-9.0.0.tgz#c5cfa8ec535c73a67c4b0f12bfdbd3a67d8b2f60"
-  dependencies:
-    remark-parse "^5.0.0"
-    remark-stringify "^5.0.0"
-    unified "^6.0.0"
 
 remarkable@^1.7.1:
   version "1.7.1"
@@ -7303,15 +7256,6 @@ stringifier@^1.3.0:
     core-js "^2.0.0"
     traverse "^0.6.6"
     type-name "^2.0.1"
-
-stringify-entities@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-1.3.1.tgz#b150ec2d72ac4c1b5f324b51fb6b28c9cdff058c"
-  dependencies:
-    character-entities-html4 "^1.0.0"
-    character-entities-legacy "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-hexadecimal "^1.0.0"
 
 stringify-object@^3.2.0:
   version "3.2.1"
@@ -8099,7 +8043,7 @@ unified@^2.1.0:
     vfile "^1.0.0"
     ware "^1.3.0"
 
-unified@^6.0.0, unified@^6.1.0:
+unified@^6.1.0, unified@^6.1.6:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
   dependencies:


### PR DESCRIPTION
Fix to parse yaml frontmatter as `YAML` node type.
It is compatibility for textlint@10.1.x <=

Fix #517 #515 
Refs #514 