### PR TITLE
Release textlint@10.2.1

### DIFF
--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.9...textlint-example-cli@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-cli
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.8...textlint-example-cli@2.0.9) (2018-04-02)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-cli",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint --rule no-todo '*.md'"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/config-file/CHANGELOG.md
+++ b/examples/config-file/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.9...textlint-example-config-file@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-config-file
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.8...textlint-example-config-file@2.0.9) (2018-04-02)
 

--- a/examples/config-file/package.json
+++ b/examples/config-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-file",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/filter/CHANGELOG.md
+++ b/examples/filter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.9...textlint-example-filter@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-filter
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.8...textlint-example-filter@2.0.9) (2018-04-02)
 

--- a/examples/filter/package.json
+++ b/examples/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-filter",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "filter rule example",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.0"
   }

--- a/examples/fix-dry-run/CHANGELOG.md
+++ b/examples/fix-dry-run/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.9...textlint-example-fix-dry-run@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-fix-dry-run
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.8...textlint-example-fix-dry-run@2.0.9) (2018-04-02)
 

--- a/examples/fix-dry-run/package.json
+++ b/examples/fix-dry-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix-dry-run",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix --dry-run README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-prh": "^5.0.1"
   }
 }

--- a/examples/fix/CHANGELOG.md
+++ b/examples/fix/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.9...textlint-example-fix@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-fix
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.8...textlint-example-fix@2.0.9) (2018-04-02)
 

--- a/examples/fix/package.json
+++ b/examples/fix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-prh": "^5.0.1"
   }
 }

--- a/examples/html-plugin/CHANGELOG.md
+++ b/examples/html-plugin/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.9...textlint-example-html-plugin@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-html-plugin
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.8...textlint-example-html-plugin@2.0.9) (2018-04-02)
 

--- a/examples/html-plugin/package.json
+++ b/examples/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-html-plugin",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "textlint": "textlint -f pretty-error index.html"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-sentence-length": "^2.0.2"
   }

--- a/examples/perf/CHANGELOG.md
+++ b/examples/perf/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.9...textlint-perf-test@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-perf-test
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.8...textlint-perf-test@2.0.9) (2018-04-02)
 

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-perf-test",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "shelljs": "^0.8.1",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-plugin-jtf-style": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",

--- a/examples/preset/CHANGELOG.md
+++ b/examples/preset/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.9...textlint-example-preset@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-preset
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.8...textlint-example-preset@2.0.9) (2018-04-02)
 

--- a/examples/preset/package.json
+++ b/examples/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-preset",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-preset-jtf-style": "^2.3.1"
   }
 }

--- a/examples/rulesdir/CHANGELOG.md
+++ b/examples/rulesdir/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.9...textlint-example-rulesdir@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-rulesdir
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.8...textlint-example-rulesdir@2.0.9) (2018-04-02)
 

--- a/examples/rulesdir/package.json
+++ b/examples/rulesdir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-rulesdir",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,6 +12,6 @@
     "textlint": "textlint --rulesdir ./rules README.md"
   },
   "devDependencies": {
-    "textlint": "^10.2.0"
+    "textlint": "^10.2.1"
   }
 }

--- a/examples/use-as-module/CHANGELOG.md
+++ b/examples/use-as-module/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.9...textlint-example-use-as-module@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-use-as-module
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.8...textlint-example-use-as-module@2.0.9) (2018-04-02)
 

--- a/examples/use-as-module/package.json
+++ b/examples/use-as-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-module",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-todo": "^2.0.0"
   }
 }

--- a/examples/use-as-ts-module/CHANGELOG.md
+++ b/examples/use-as-ts-module/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.7"></a>
+## [2.1.7](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.6...textlint-example-use-as-ts-module@2.1.7) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-example-use-as-ts-module
+
 <a name="2.1.6"></a>
 ## [2.1.6](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.5...textlint-example-use-as-ts-module@2.1.6) (2018-04-02)
 

--- a/examples/use-as-ts-module/package.json
+++ b/examples/use-as-ts-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-ts-module",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "private": true,
   "license": "MIT",
   "author": "0x6b",
@@ -14,7 +14,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.0"
   },

--- a/packages/@textlint/ast-tester/CHANGELOG.md
+++ b/packages/@textlint/ast-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.7"></a>
+## [2.0.7](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.6...@textlint/ast-tester@2.0.7) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/ast-tester
+
 <a name="2.0.6"></a>
 ## [2.0.6](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.5...@textlint/ast-tester@2.0.6) (2018-04-02)
 

--- a/packages/@textlint/ast-tester/package.json
+++ b/packages/@textlint/ast-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-tester",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Compliance tests for textlint's AST(Abstract Syntax Tree).",
   "keywords": [
     "ast",
@@ -35,8 +35,8 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.7",
-    "@textlint/text-to-ast": "^3.0.7",
+    "@textlint/markdown-to-ast": "^6.0.8",
+    "@textlint/text-to-ast": "^3.0.8",
     "babel-cli": "^6.6.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",

--- a/packages/@textlint/ast-traverse/CHANGELOG.md
+++ b/packages/@textlint/ast-traverse/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.8"></a>
+## [2.0.8](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.0.7...@textlint/ast-traverse@2.0.8) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/ast-traverse
+
 <a name="2.0.7"></a>
 ## [2.0.7](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.0.6...@textlint/ast-traverse@2.0.7) (2018-04-02)
 

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-traverse",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "TxtNode traverse library",
   "keywords": [
     "AST",
@@ -35,7 +35,7 @@
     "@textlint/ast-node-types": "^4.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.7",
+    "@textlint/markdown-to-ast": "^6.0.8",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.5.1",
     "cross-env": "^5.1.1",

--- a/packages/@textlint/fixer-formatter/CHANGELOG.md
+++ b/packages/@textlint/fixer-formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.7"></a>
+## [3.0.7](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.6...@textlint/fixer-formatter@3.0.7) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/fixer-formatter
+
 <a name="3.0.6"></a>
 ## [3.0.6](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.5...@textlint/fixer-formatter@3.0.6) (2018-04-02)
 

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/fixer-formatter",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "textlint output formatter for fixer",
   "keywords": [
     "AST",
@@ -34,7 +34,7 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/kernel": "^2.0.8",
+    "@textlint/kernel": "^2.0.9",
     "chalk": "^1.1.3",
     "debug": "^2.1.0",
     "diff": "^2.2.2",

--- a/packages/@textlint/kernel/CHANGELOG.md
+++ b/packages/@textlint/kernel/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.9"></a>
+## [2.0.9](https://github.com/textlint/textlint/compare/@textlint/kernel@2.0.8...@textlint/kernel@2.0.9) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/kernel
+
 <a name="2.0.8"></a>
 ## [2.0.8](https://github.com/textlint/textlint/compare/@textlint/kernel@2.0.7...@textlint/kernel@2.0.8) (2018-04-02)
 

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/kernel",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "textlint kernel is core logic by pure JavaScript.",
   "keywords": [
     "textlint"
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@textlint/ast-node-types": "^4.0.2",
-    "@textlint/ast-traverse": "^2.0.7",
+    "@textlint/ast-traverse": "^2.0.8",
     "@textlint/feature-flag": "^3.0.4",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.5.1",
@@ -44,8 +44,8 @@
     "structured-source": "^3.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.7",
-    "@textlint/textlint-plugin-markdown": "^4.0.9",
+    "@textlint/markdown-to-ast": "^6.0.8",
+    "@textlint/textlint-plugin-markdown": "^4.0.10",
     "@types/mocha": "^2.2.43",
     "@types/node": "^8.0.28",
     "cpx": "^1.5.0",

--- a/packages/@textlint/linter-formatter/CHANGELOG.md
+++ b/packages/@textlint/linter-formatter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.7"></a>
+## [3.0.7](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.6...@textlint/linter-formatter@3.0.7) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/linter-formatter
+
 <a name="3.0.6"></a>
 ## [3.0.6](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.5...@textlint/linter-formatter@3.0.6) (2018-04-02)
 

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/linter-formatter",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "textlint output formatter",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/linter-formatter",
   "bugs": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azu/format-text": "^1.0.1",
     "@azu/style-format": "^1.0.0",
-    "@textlint/kernel": "^2.0.8",
+    "@textlint/kernel": "^2.0.9",
     "chalk": "^1.0.0",
     "concat-stream": "^1.5.1",
     "js-yaml": "^3.2.4",

--- a/packages/@textlint/markdown-to-ast/CHANGELOG.md
+++ b/packages/@textlint/markdown-to-ast/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="6.0.8"></a>
+## [6.0.8](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.7...@textlint/markdown-to-ast@6.0.8) (2018-04-02)
+
+
+### Bug Fixes
+
+* **markdown-to-ast:** enable yaml frontmatter parse by default ([121c62f](https://github.com/textlint/textlint/commit/121c62f))
+
+
+
+
 <a name="6.0.7"></a>
 ## [6.0.7](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.6...@textlint/markdown-to-ast@6.0.7) (2018-04-02)
 

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/markdown-to-ast",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "description": "Parse Markdown to AST with location info.",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast/",
   "bugs": {
@@ -38,8 +38,8 @@
     "unified": "^6.1.6"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.6",
-    "@textlint/ast-traverse": "^2.0.7",
+    "@textlint/ast-tester": "^2.0.7",
+    "@textlint/ast-traverse": "^2.0.8",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/text-to-ast/CHANGELOG.md
+++ b/packages/@textlint/text-to-ast/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.8"></a>
+## [3.0.8](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.7...@textlint/text-to-ast@3.0.8) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/text-to-ast
+
 <a name="3.0.7"></a>
 ## [3.0.7](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.6...@textlint/text-to-ast@3.0.7) (2018-04-02)
 

--- a/packages/@textlint/text-to-ast/package.json
+++ b/packages/@textlint/text-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/text-to-ast",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "Parse plain text to AST with location info.",
   "keywords": [
     "ast",
@@ -38,7 +38,7 @@
     "@textlint/ast-node-types": "^4.0.2"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.6",
+    "@textlint/ast-tester": "^2.0.7",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.0.10"></a>
+## [4.0.10](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@4.0.9...@textlint/textlint-plugin-markdown@4.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/textlint-plugin-markdown
+
 <a name="4.0.9"></a>
 ## [4.0.9](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@4.0.8...@textlint/textlint-plugin-markdown@4.0.9) (2018-04-02)
 

--- a/packages/@textlint/textlint-plugin-markdown/package.json
+++ b/packages/@textlint/textlint-plugin-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-markdown",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Markdown support for textlint.",
   "keywords": [
     "markdown",
@@ -33,7 +33,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/markdown-to-ast": "^6.0.7"
+    "@textlint/markdown-to-ast": "^6.0.8"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -45,7 +45,7 @@
     "mocha": "^4.0.1",
     "power-assert": "^1.4.1",
     "rimraf": "^2.6.2",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-todo": "^2.0.0"
   },
   "email": "azuciao@gmail.com",

--- a/packages/@textlint/textlint-plugin-text/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-text/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.0.10"></a>
+## [3.0.10](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@3.0.9...@textlint/textlint-plugin-text@3.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package @textlint/textlint-plugin-text
+
 <a name="3.0.9"></a>
 ## [3.0.9](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@3.0.8...@textlint/textlint-plugin-text@3.0.9) (2018-04-02)
 

--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-text",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "plain text plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/textlint-plugin-text/",
   "bugs": {
@@ -29,7 +29,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/text-to-ast": "^3.0.7"
+    "@textlint/text-to-ast": "^3.0.8"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -41,7 +41,7 @@
     "mocha": "^4.0.1",
     "power-assert": "^1.4.2",
     "rimraf": "^2.6.2",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-rule-no-todo": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/gulp-textlint/CHANGELOG.md
+++ b/packages/gulp-textlint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.0.10"></a>
+## [5.0.10](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.9...gulp-textlint@5.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package gulp-textlint
+
 <a name="5.0.9"></a>
 ## [5.0.9](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.8...gulp-textlint@5.0.9) (2018-04-02)
 

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-textlint",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "description": "gulp plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "bugs": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.1",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/textlint-tester/CHANGELOG.md
+++ b/packages/textlint-tester/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.3"></a>
+## [4.1.3](https://github.com/textlint/textlint/compare/textlint-tester@4.1.2...textlint-tester@4.1.3) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-tester
+
 <a name="4.1.2"></a>
 ## [4.1.2](https://github.com/textlint/textlint/compare/textlint-tester@4.1.1...textlint-tester@4.1.2) (2018-04-02)
 

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-tester",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "testing tool for textlint rule.",
   "keywords": [
     "test",
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@textlint/feature-flag": "^3.0.4",
-    "@textlint/kernel": "^2.0.8",
-    "textlint": "^10.2.0"
+    "@textlint/kernel": "^2.0.9",
+    "textlint": "^10.2.1"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.46",
@@ -52,7 +52,7 @@
     "mocha": "^4.1.0",
     "power-assert": "^1.4.1",
     "rimraf": "^2.6.2",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-helper": "^2.0.0",
     "textlint-rule-max-number-of-lines": "^1.0.2",

--- a/packages/textlint/CHANGELOG.md
+++ b/packages/textlint/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.2.1"></a>
+## [10.2.1](https://github.com/textlint/textlint/compare/textlint@10.2.0...textlint@10.2.1) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint
+
 <a name="10.2.0"></a>
 # [10.2.0](https://github.com/textlint/textlint/compare/textlint@10.1.5...textlint@10.2.0) (2018-04-02)
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "The pluggable linting tool for text and markdown.",
   "keywords": [
     "AST",
@@ -45,13 +45,13 @@
   },
   "dependencies": {
     "@textlint/ast-node-types": "^4.0.2",
-    "@textlint/ast-traverse": "^2.0.7",
+    "@textlint/ast-traverse": "^2.0.8",
     "@textlint/feature-flag": "^3.0.4",
-    "@textlint/fixer-formatter": "^3.0.6",
-    "@textlint/kernel": "^2.0.8",
-    "@textlint/linter-formatter": "^3.0.6",
-    "@textlint/textlint-plugin-markdown": "^4.0.9",
-    "@textlint/textlint-plugin-text": "^3.0.9",
+    "@textlint/fixer-formatter": "^3.0.7",
+    "@textlint/kernel": "^2.0.9",
+    "@textlint/linter-formatter": "^3.0.7",
+    "@textlint/textlint-plugin-markdown": "^4.0.10",
+    "@textlint/textlint-plugin-text": "^3.0.10",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.0.5",
     "debug": "^2.1.0",

--- a/test/integration-test/CHANGELOG.md
+++ b/test/integration-test/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.10"></a>
+## [2.0.10](https://github.com/textlint/textlint/compare/integration-test@2.0.9...integration-test@2.0.10) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package integration-test
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/integration-test@2.0.8...integration-test@2.0.9) (2018-04-02)
 

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-test",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "textlint testbot sandbox.",
   "keywords": [
@@ -35,7 +35,7 @@
   "devDependencies": {
     "json5": "^0.5.1",
     "shelljs": "^0.7.7",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlintrc-to-pacakge-list": "^1.2.0"
   },
   "email": "azuciao@gmail.com"

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.3.2"></a>
+## [10.3.2](https://github.com/textlint/textlint/compare/textlint-website@10.3.1...textlint-website@10.3.2) (2018-04-02)
+
+
+
+
+**Note:** Version bump only for package textlint-website
+
 <a name="10.3.1"></a>
 ## [10.3.1](https://github.com/textlint/textlint/compare/textlint-website@10.3.0...textlint-website@10.3.1) (2018-04-02)
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-website",
-  "version": "10.3.1",
+  "version": "10.3.2",
   "private": true,
   "homepage": "https://github.com/textlint/textlint/",
   "bugs": {
@@ -26,7 +26,7 @@
     "docusaurus": "^1.0.9",
     "eslint": "^4.15.0",
     "npm-run-all": "^4.1.2",
-    "textlint": "^10.2.0",
+    "textlint": "^10.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-eslint": "^2.0.1",
     "textlint-rule-no-dead-link": "^4.3.0",


### PR DESCRIPTION
## Changelog

## [@textlint/markdown-to-ast@6.0.8](https://github.com/textlint/textlint/releases/tag/@textlint/markdown-to-ast@6.0.8)

### fixes

- **markdown-to-ast:** enable yaml frontmatter parse by default ([121c62f](https://github.com/textlint/textlint/commit/121c62f)) #518 

This will fix regression of textlint@10.2.0 #517 

## Package Versions

 - gulp-textlint@5.0.10
 - textlint-tester@4.1.3
 - textlint@10.2.1
 - textlint-example-cli@2.0.10
 - textlint-example-config-file@2.0.10
 - textlint-example-filter@2.0.10
 - textlint-example-fix-dry-run@2.0.10
 - textlint-example-fix@2.0.10
 - textlint-example-html-plugin@2.0.10
 - textlint-perf-test@2.0.10
 - textlint-example-preset@2.0.10
 - textlint-example-rulesdir@2.0.10
 - textlint-example-use-as-module@2.0.10
 - textlint-example-use-as-ts-module@2.1.7
 - @textlint/ast-tester@2.0.7
 - @textlint/ast-traverse@2.0.8
 - @textlint/fixer-formatter@3.0.7
 - @textlint/kernel@2.0.9
 - @textlint/linter-formatter@3.0.7
 - @textlint/markdown-to-ast@6.0.8
 - @textlint/text-to-ast@3.0.8
 - @textlint/textlint-plugin-markdown@4.0.10
 - @textlint/textlint-plugin-text@3.0.10
 - integration-test@2.0.10
 - textlint-website@10.3.2