### PR TITLE
Drop Node.js 4.x support from Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install textlint --global
 
 **Requirements**:
 
-- Node.js 4.0.0+
+- Node.js 6.0.0+
 - npm 2.0.0+
 
 If you're not sure what version of Node you're running, you can run `node -v` in your console to find out.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ If you want to contribute to textlint, please check issues labeled [`good first 
 Please install following development prerequisites. You also need a [GitHub](https://github.com/) account for contribution.
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/en/) -- we tend to use latest stable Node.js although textlint supports >= 4.0.0
+- [Node.js](https://nodejs.org/en/) -- we tend to use latest stable Node.js although textlint supports >= 6.0.0
 - [Yarn](https://yarnpkg.com/en/) -- textlint supports [npm](https://www.npmjs.com/get-npm) >= 2.0.0, but for development purpose, we chose Yarn as package manager
 - Text editor
 - Terminal emulator

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -28,6 +28,9 @@
   "bin": {
     "textlint": "./bin/textlint.js"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "directories": {
     "test": "test/"
   },


### PR DESCRIPTION
Fixed: #443 

- [x] Update README and CONTRIBUTING
- [x] We should restrict engines to >=6.x ?
