### PR TITLE
fix(kernel): make rule and plugin's option value {} by default

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -125,7 +125,7 @@ export default class YourProcessor {
 }
 ```
 
-:memo: Processor's option value is `{}` (empty obejct) by default.
+:memo: Processor's option value is `{}` (empty object) by default.
 If not set plugin's option in `.textlintrc`, textlint pass `{}` as `options`.
 
 ```js

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -31,7 +31,7 @@ textlint support `.txt` and `.md` by default. These are implemented as `Processo
 // TextProcessor.js
 import { parse } from "txt-to-ast";
 export default class TextProcessor {
-    constructor(options) {
+    constructor(options = {}) {
         this.options = options;
         // support "extension" option
         this.extensions = this.config.extensions ? this.config.extensions : [];
@@ -109,7 +109,7 @@ You can pass a options to your plugin from `.textlintrc`.
 ```
 {
     "plugins": {
-        pluginName: processorOption
+        "pluginName": processorOption
     }
 }
 ```
@@ -120,6 +120,18 @@ You can receive the `processorOption` via constructor arguments.
 export default class YourProcessor {
     constructor(options) {
         this.options = options; // <= processorOption!
+    }
+    // ...
+}
+```
+
+:memo: Processor's option value is `{}` (empty obejct) by default.
+If not set plugin's option in `.textlintrc`, textlint pass `{}` as `options`.
+
+```js
+export default class YourProcessor {
+    constructor(options) {
+        this.options = options; // {}
     }
     // ...
 }

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -518,11 +518,11 @@ Run the tests:
 
 :information_source: Please see [azu/textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "azu/textlint-rule-no-todo") for details.
 
-### Rule Config
+### Rule options
 
 `.textlintrc` is the config file for textlint.
 
-For example, there are a config file:
+For example, `very-nice-rule`'s option is `{ "key": "value" }` in `.textlintrc`
 
 ```json
 {
@@ -546,6 +546,27 @@ export default function(context, options) {
     */
 }
 ```
+
+:memo: The `options` value is `{}` (empty object) by default.
+
+For example, `very-nice-rule`'s option is `true`(enable the rule) in `.textlintrc`
+
+```json
+{
+  "rules": {
+    "very-nice-rule": true
+  }
+}
+```
+
+`very-nice-rule.js` rule get `{}` (emptry object) as `options`.
+
+```js
+export default function(context, options) {
+    console.log(options); // {}
+}
+```
+
 
 ## Advanced example
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -547,7 +547,7 @@ export default function(context, options) {
 }
 ```
 
-:memo: The `options` value is `{}` (empty object) by default.
+The `options` value is `{}` (empty object) by default.
 
 For example, `very-nice-rule`'s option is `true`(enable the rule) in `.textlintrc`
 
@@ -567,6 +567,9 @@ export default function(context, options) {
 }
 ```
 
+**History**: This behavior is changed in textlint@11.
+
+- <https://github.com/textlint/textlint/issues/535>
 
 ## Advanced example
 

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@textlint/markdown-to-ast": "^6.0.8",
-    "@textlint/textlint-plugin-markdown": "^4.0.10",
     "@types/deep-equal": "^1.0.1",
     "@types/mocha": "^5.2.0",
     "@types/node": "^8.0.28",

--- a/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
@@ -28,7 +28,7 @@ export class TextlintFilterRuleDescriptor implements Descriptor<TextlintKernelFi
      * Return true if this rule is enabled.
      */
     get enabled(): boolean {
-        return this.normalizedOptions !== false;
+        return this.rawOptions !== false;
     }
 
     /**
@@ -45,15 +45,15 @@ export class TextlintFilterRuleDescriptor implements Descriptor<TextlintKernelFi
      */
     get normalizedOptions(): TextlintFilterRuleOptions {
         // default: { ruleName: true }
-        const defaultRuleConfigValue = true;
-        if (this.kernelFilterRule.options === undefined) {
-            return defaultRuleConfigValue;
+        const DefaultRuleConfigValue = {};
+        if (typeof this.kernelFilterRule.options === "boolean" || this.kernelFilterRule.options === undefined) {
+            return DefaultRuleConfigValue;
         } else {
             return this.kernelFilterRule.options;
         }
     }
 
-    get rawOptions(): TextlintFilterRuleOptions | undefined {
+    get rawOptions() {
         return this.kernelFilterRule.options;
     }
 

--- a/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
@@ -33,7 +33,7 @@ export class TextlintLintableRuleDescriptor {
      * Return true if this rule is enabled.
      */
     get enabled(): boolean {
-        return this.normalizedOptions !== false;
+        return this.rawOptions !== false;
     }
 
     /**
@@ -50,15 +50,15 @@ export class TextlintLintableRuleDescriptor {
      */
     get normalizedOptions(): TextlintRuleOptions {
         // default: { ruleName: true }
-        const defaultRuleConfigValue = true;
-        if (this.textlintKernelRule.options === undefined) {
-            return defaultRuleConfigValue;
+        const DefaultRuleConfigValue = {};
+        if (typeof this.textlintKernelRule.options === "boolean" || this.textlintKernelRule.options === undefined) {
+            return DefaultRuleConfigValue;
         } else {
             return this.textlintKernelRule.options;
         }
     }
 
-    get rawOptions(): TextlintRuleOptions | undefined {
+    get rawOptions() {
         return this.textlintKernelRule.options;
     }
 

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
@@ -52,7 +52,7 @@ module.exports = {
      * Return true if this rule is enabled.
      */
     get enabled(): boolean {
-        return this.normalizedOptions !== false;
+        return this.rawOptions !== false;
     }
 
     /**
@@ -64,12 +64,16 @@ module.exports = {
 
     get normalizedOptions(): TextlintPluginOptions {
         // default: { ruleName: true }
-        const DEFAULT_PLUGIN_OPTIONS = true;
-        if (this.plugin.options === undefined) {
-            return DEFAULT_PLUGIN_OPTIONS;
+        const DefaultPluginOption = {};
+        if (typeof this.plugin.options === "boolean" || this.plugin.options === undefined) {
+            return DefaultPluginOption;
         } else {
             return this.plugin.options;
         }
+    }
+
+    get rawOptions() {
+        return this.plugin.options;
     }
 
     toKernel() {

--- a/packages/@textlint/kernel/src/textlint-kernel-interface.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel-interface.ts
@@ -27,33 +27,27 @@ export type TextlintFilterRuleReporter = (
  * textlint rule option values is object or boolean.
  * if this option value is false, disable the rule.
  */
-export type TextlintRuleOptions =
-    | {
-          [index: string]: any;
+export type TextlintRuleOptions = {
+    [index: string]: any;
 
-          severity?: SeverityLevelTypes;
-      }
-    | boolean;
+    severity?: SeverityLevelTypes;
+};
 
 /**
  * textlint filter rule option values is object or boolean.
  * if this option value is false, disable the filter rule.
  */
-export type TextlintFilterRuleOptions =
-    | {
-          [index: string]: any;
-      }
-    | boolean;
+export type TextlintFilterRuleOptions = {
+    [index: string]: any;
+};
 
 /**
  * textlint plugin option values is object or boolean.
  * if this option value is false, disable the plugin.
  */
-export type TextlintPluginOptions =
-    | {
-          [index: string]: any;
-      }
-    | boolean;
+export type TextlintPluginOptions = {
+    [index: string]: any;
+};
 
 export interface TextlintKernelConstructorOptions {
     /**
@@ -105,6 +99,7 @@ export interface TextlintPluginProcessorConstructor extends Function {
 
 export declare class TextlintPluginProcessor {
     constructor(options?: TextlintPluginOptions);
+
     /**
      * Return available extensions for this plugin.
      * This extension should start with `.`(dot).
@@ -132,7 +127,7 @@ export interface TextlintKernelPlugin {
     // For example, `plugin: require("@textlint/textlint-plugin-markdown")`
     plugin: TextlintPluginCreator;
     // plugin options
-    options?: TextlintPluginOptions;
+    options?: TextlintPluginOptions | boolean;
 }
 
 export interface TextlintKernelRule {
@@ -143,7 +138,7 @@ export interface TextlintKernelRule {
     rule: TextlintRuleModule;
     // rule options
     // Often rule option is written in .textlintrc
-    options?: TextlintRuleOptions;
+    options?: TextlintRuleOptions | boolean;
 }
 
 export interface TextlintKernelFilterRule {
@@ -153,7 +148,7 @@ export interface TextlintKernelFilterRule {
     rule: TextlintFilterRuleReporter;
     // filter rule options
     // Often rule option is written in .textlintrc
-    options?: TextlintRuleOptions;
+    options?: TextlintFilterRuleOptions | boolean;
 }
 
 export interface TextlintKernelOptions {

--- a/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor-test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor-test.ts
@@ -9,12 +9,11 @@ import {
     TextlintKernelRule,
     TextlintPluginCreator,
     TextlintPluginOptions,
-    TextlintRuleModule,
-    TextlintRuleOptions
+    TextlintRuleModule
 } from "@textlint/kernel";
 import { createTextlintRuleDescriptors } from "../../src/descriptor/DescriptorsFactory";
 import { TextlintLintableRuleDescriptor } from "../../src/descriptor/TextlintLintableRuleDescriptor";
-import { TextlintFilterRuleReporter, TextlintFilterRuleOptions, TextlintKernelFilterRule } from "../../src/index";
+import { TextlintFilterRuleReporter, TextlintKernelFilterRule } from "../../src/index";
 
 /**
  * Convert rulesObject to TextlintKernelRule
@@ -29,7 +28,7 @@ import { TextlintFilterRuleReporter, TextlintFilterRuleOptions, TextlintKernelFi
  */
 export const rulesObjectToKernelRule = (
     rules: { [index: string]: TextlintRuleModule },
-    rulesOption: { [index: string]: TextlintRuleOptions }
+    rulesOption: { [index: string]: TextlintKernelRule["options"] }
 ): TextlintKernelRule[] => {
     return Object.keys(rules).map(ruleId => {
         return {
@@ -42,7 +41,7 @@ export const rulesObjectToKernelRule = (
 
 export const filterRulesObjectToKernelRule = (
     rules: { [index: string]: TextlintFilterRuleReporter },
-    rulesOption: { [index: string]: TextlintFilterRuleOptions }
+    rulesOption: { [index: string]: TextlintKernelFilterRule["options"] }
 ): TextlintKernelFilterRule[] => {
     return Object.keys(rules).map(ruleId => {
         return {

--- a/packages/@textlint/kernel/test/kernel-plugin-test.ts
+++ b/packages/@textlint/kernel/test/kernel-plugin-test.ts
@@ -4,47 +4,92 @@ import { TextlintKernel } from "../src";
 import * as assert from "assert";
 
 describe("kernel-plugin", () => {
-    describe("#processor", () => {
-        it("should receive extension", () => {
+    describe("#constructor", () => {
+        it("should receive {} by default", () => {
             const kernel = new TextlintKernel();
-            const { getPlugin, getProcessorArgs } = createPluginStub();
+            const { plugin, getOptions } = createPluginStub();
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "example", plugin: getPlugin() }],
+                plugins: [{ pluginId: "example", plugin: plugin }],
                 rules: [{ ruleId: "error", rule: errorRule }]
             };
             const text = "text";
             return kernel.lintText(text, options).then(_result => {
-                assert.strictEqual(getProcessorArgs()[0], options.ext);
+                assert.deepStrictEqual(getOptions(), {});
+            });
+        });
+        it("should receive {} when pass `true`", () => {
+            const kernel = new TextlintKernel();
+            const { plugin, getOptions } = createPluginStub();
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [{ pluginId: "example", plugin: plugin, options: true }],
+                rules: [{ ruleId: "error", rule: errorRule }]
+            };
+            const text = "text";
+            return kernel.lintText(text, options).then(_result => {
+                assert.deepStrictEqual(getOptions(), {});
+            });
+        });
+        it("should receive object when pass plugin's option", () => {
+            const kernel = new TextlintKernel();
+            const { plugin, getOptions } = createPluginStub();
+            const PASS_OPTIONS = { key: "value" };
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [{ pluginId: "example", plugin: plugin, options: PASS_OPTIONS }],
+                rules: [{ ruleId: "error", rule: errorRule }]
+            };
+            const text = "text";
+            return kernel.lintText(text, options).then(_result => {
+                assert.deepStrictEqual(getOptions(), PASS_OPTIONS);
+            });
+        });
+    });
+    describe("#processor", () => {
+        it("should receive extension", () => {
+            const kernel = new TextlintKernel();
+            const { plugin, getProcessorArgs } = createPluginStub();
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [{ pluginId: "example", plugin: plugin }],
+                rules: [{ ruleId: "error", rule: errorRule }]
+            };
+            const text = "text";
+            return kernel.lintText(text, options).then(_result => {
+                assert.strictEqual(getProcessorArgs().extension, options.ext);
             });
         });
     });
     describe("#preProcess", () => {
         it("preProcess should be called with text and filePath", () => {
             const kernel = new TextlintKernel();
-            const { getPlugin, getPreProcessArgs } = createPluginStub();
+            const { plugin, getPreProcessArgs } = createPluginStub();
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "example", plugin: getPlugin() }],
+                plugins: [{ pluginId: "example", plugin: plugin }],
                 rules: [{ ruleId: "error", rule: errorRule }]
             };
             const text = "text";
             return kernel.lintText(text, options).then(_result => {
-                assert.strictEqual(getPreProcessArgs()[0], text);
-                assert.strictEqual(getPreProcessArgs()[1], options.filePath);
+                assert.strictEqual(getPreProcessArgs().text, text);
+                assert.strictEqual(getPreProcessArgs().filePath, options.filePath);
             });
         });
     });
     describe("#postProcess", () => {
         it("preProcess should be called with messages and filePath", () => {
             const kernel = new TextlintKernel();
-            const { getPlugin, getPostProcessArgs } = createPluginStub();
+            const { plugin, getPostProcessArgs } = createPluginStub();
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "example", plugin: getPlugin() }],
+                plugins: [{ pluginId: "example", plugin: plugin }],
                 rules: [
                     {
                         ruleId: "error",
@@ -62,8 +107,8 @@ describe("kernel-plugin", () => {
             };
             const text = "text";
             return kernel.lintText(text, options).then(_result => {
-                assert.strictEqual(getPostProcessArgs()[0].length, options.rules[0].options.errors.length);
-                assert.strictEqual(getPostProcessArgs()[1], options.filePath);
+                assert.strictEqual(getPostProcessArgs().messages.length, options.rules[0].options.errors.length);
+                assert.strictEqual(getPostProcessArgs().filePath, options.filePath);
             });
         });
     });

--- a/packages/@textlint/kernel/test/textlint-kernel-test.ts
+++ b/packages/@textlint/kernel/test/textlint-kernel-test.ts
@@ -29,10 +29,13 @@ describe("textlint-kernel", () => {
     describe("#lintText", () => {
         it("should return messages", () => {
             const kernel = new TextlintKernel();
+            const { plugin } = createPluginStub({
+                extensions: [".md"]
+            });
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "markdown", plugin: require("@textlint/textlint-plugin-markdown") }],
+                plugins: [{ pluginId: "markdown", plugin: plugin }],
                 rules: [
                     { ruleId: "error", rule: errorRule, options: { errors: [{ message: "error message", index: 0 }] } }
                 ]
@@ -50,10 +53,11 @@ describe("textlint-kernel", () => {
                     range: [0, 5],
                     text: "fixed"
                 };
+                const { plugin } = createPluginStub();
                 const options = {
                     filePath: "/path/to/file.md",
                     ext: ".md",
-                    plugins: [{ pluginId: "markdown", plugin: require("@textlint/textlint-plugin-markdown") }],
+                    plugins: [{ pluginId: "markdown", plugin: plugin }],
                     rules: [
                         {
                             ruleId: "error",
@@ -85,12 +89,12 @@ describe("textlint-kernel", () => {
         });
         it("should pass pluginOptions to plugin", () => {
             const kernel = new TextlintKernel();
-            const { getOptions, getPlugin } = createPluginStub();
+            const { getOptions, plugin } = createPluginStub();
             const expectedPluginOptions: ExampleProcessorOptions = { testOption: "test" };
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "example", plugin: getPlugin(), options: expectedPluginOptions }],
+                plugins: [{ pluginId: "example", plugin: plugin, options: expectedPluginOptions }],
                 rules: [{ ruleId: "error", rule: errorRule }]
             };
             return kernel.lintText("text", options).then(_result => {
@@ -110,10 +114,11 @@ describe("textlint-kernel", () => {
     describe("#fixText", () => {
         it("should return messages", () => {
             const kernel = new TextlintKernel();
+            const { plugin } = createPluginStub();
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "markdown", plugin: require("@textlint/textlint-plugin-markdown") }],
+                plugins: [{ pluginId: "markdown", plugin: plugin }],
                 rules: [
                     { ruleId: "error", rule: errorRule, options: { errors: [{ message: "error message", index: 0 }] } }
                 ]
@@ -126,12 +131,12 @@ describe("textlint-kernel", () => {
         });
         it("should pass pluginOptions to plugin", () => {
             const kernel = new TextlintKernel();
-            const { getOptions, getPlugin } = createPluginStub();
+            const { getOptions, plugin } = createPluginStub();
             const expectedPluginOptions: ExampleProcessorOptions = { testOption: "test" };
             const options = {
                 filePath: "/path/to/file.md",
                 ext: ".md",
-                plugins: [{ pluginId: "example", plugin: getPlugin(), options: expectedPluginOptions }],
+                plugins: [{ pluginId: "example", plugin: plugin, options: expectedPluginOptions }],
                 rules: [{ ruleId: "error", rule: errorRule }]
             };
             return kernel.lintText("text", options).then(_result => {

--- a/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.js
+++ b/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.js
@@ -4,7 +4,7 @@
 import { parse } from "@textlint/markdown-to-ast";
 
 export class MarkdownProcessor {
-    constructor(config) {
+    constructor(config = {}) {
         this.config = config;
         this.extensions = config.extensions ? config.extensions : [];
     }

--- a/packages/@textlint/textlint-plugin-text/src/TextProcessor.js
+++ b/packages/@textlint/textlint-plugin-text/src/TextProcessor.js
@@ -4,7 +4,7 @@
 import { parse } from "@textlint/text-to-ast";
 
 export class TextProcessor {
-    constructor(config) {
+    constructor(config = {}) {
         this.config = config;
         // support "extension" option
         this.extensions = this.config.extensions ? this.config.extensions : [];

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -129,7 +129,7 @@ function createTestRuleSet(testConfigRules: TestConfigRule[]): TestRuleSet {
     };
     testConfigRules.forEach(rule => {
         const ruleName = rule.ruleId;
-        const ruleOptions = rule.options || {};
+        const ruleOptions = rule.options;
         testRuleSet.rules[ruleName] = rule.rule;
         testRuleSet.rulesOptions[ruleName] = ruleOptions;
     });
@@ -143,7 +143,7 @@ function createTestPluginSet(testConfigPlugins: TestConfigPlugin[]): TestPluginS
     };
     testConfigPlugins.forEach(plugin => {
         const pluginName = plugin.pluginId;
-        const pluginOptions = plugin.options || {};
+        const pluginOptions = plugin.options;
         testPluginSet.plugins[pluginName] = plugin.plugin;
         testPluginSet.pluginOptions[pluginName] = pluginOptions;
     });
@@ -170,7 +170,7 @@ export class TextLintTester {
                 textlint.setupPlugins(testPluginSet.plugins, testPluginSet.pluginOptions);
             }
         } else {
-            const options = (typeof valid === "object" && valid.options) || {};
+            const options = typeof valid === "object" && valid.options;
             textlint.setupRules(
                 {
                     [name]: param
@@ -199,7 +199,7 @@ export class TextLintTester {
                 textlint.setupPlugins(testPluginSet.plugins, testPluginSet.pluginOptions);
             }
         } else {
-            const options = invalid.options || {};
+            const options = invalid.options;
             textlint.setupRules(
                 {
                     [name]: param

--- a/packages/textlint-tester/test/textlint-tester-invalid-testcofig-test.ts
+++ b/packages/textlint-tester/test/textlint-tester-invalid-testcofig-test.ts
@@ -1,13 +1,14 @@
 // LICENSE : MIT
 "use strict";
 
-const TextLintTester = require("../src/index");
+import * as assert from "assert";
+
 const htmlPlugin = require("textlint-plugin-html");
 const noTodoRule = require("textlint-rule-no-todo");
 const maxNumberOfLineRule = require("textlint-rule-max-number-of-lines");
-const tester = new TextLintTester();
-const assert = require("assert");
+import { TextLintTester } from "../src/textlint-tester";
 
+const tester = new TextLintTester();
 const baseCase = {
     valid: [
         {
@@ -244,7 +245,7 @@ describe("new-style-of-test: invalid testConfig", () => {
     testConfigs.forEach(testConfig => {
         it(`Should throw assertion error: ${testConfig.description}`, () => {
             try {
-                tester.run("invalid-testConfig-test", testConfig.config, testConfig.case);
+                tester.run("invalid-testConfig-test", testConfig.config as any, testConfig.case);
             } catch (err) {
                 assert(err instanceof assert.AssertionError);
                 assert.equal(err.message, testConfig.expectedErrorMessage);

--- a/packages/textlint/src/engine/textlint-engine-core.ts
+++ b/packages/textlint/src/engine/textlint-engine-core.ts
@@ -29,14 +29,13 @@ const debug = require("debug")("textlint:engine-core");
  * There are hackable by `executor` option.
  */
 export abstract class AbstractTextLintEngine<LintResult extends TextlintResult> {
-    filerRuleMap: any;
-    moduleLoader: TextLintModuleLoader;
-    pluginMap: PluginMap;
-    filterRuleMap: RuleMap;
-    ruleMap: RuleMap;
-    executeFileBackerManger: ExecuteFileBackerManager;
-    textlint: TextLintCore;
-    config: Config;
+    private moduleLoader: TextLintModuleLoader;
+    private pluginMap: PluginMap;
+    private ruleMap: RuleMap;
+    private filterRuleMap: RuleMap;
+    private executeFileBackerManger: ExecuteFileBackerManager;
+    private textlint: TextLintCore;
+    private config: Config;
     // abstract interface
     // Each engines should be implemented these
     /**
@@ -197,13 +196,24 @@ new TextLintEngine({
     resetRules() {
         this.textlint.resetRules();
         this.ruleMap.resetRules();
-        this.filerRuleMap.resetRules();
+        this.filterRuleMap.resetRules();
+    }
+
+    /**
+     * Return available extensions of plugins that include built-in plugins
+     * @example
+     * ```
+     * engine.availableExtensions; // => [".txt", ".md"]
+     * ```
+     */
+    get availableExtensions(): string[] {
+        return this.textlint.textlintKernelDescriptor.availableExtensions;
     }
 
     /**
      * Return meta descriptor object for this engine
      *
-     * WARNING: This is experimental method.
+     * WARNING: This is experimental getter method.
      * It will be renamed.
      */
     get textlintrcDescriptor(): TextlintKernelDescriptor {

--- a/packages/textlint/src/textlint-core.ts
+++ b/packages/textlint/src/textlint-core.ts
@@ -34,9 +34,9 @@ const textPlugin = require("@textlint/textlint-plugin-text");
  * @class {TextLintCore}
  */
 export class TextLintCore {
-    kernel: TextlintKernel;
-    config: Partial<Config>;
-    defaultPlugins: TextlintKernelPlugin[];
+    private kernel: TextlintKernel;
+    private config: Partial<Config>;
+    private defaultPlugins: TextlintKernelPlugin[];
     public textlintKernelDescriptor: TextlintKernelDescriptor;
 
     constructor(config: Partial<Config> = {}) {
@@ -222,7 +222,7 @@ export class TextLintCore {
     /**
      * @private
      */
-    _mergeSetupOptions(options: { ext: string } | { ext: any; filePath: any }) {
+    private _mergeSetupOptions(options: { ext: string } | { ext: any; filePath: any }) {
         const configFileBaseDir =
             typeof this.config.configFile === "string" ? path.dirname(this.config.configFile) : undefined;
         return ObjectAssign({}, options, {

--- a/packages/textlint/src/util/object-to-kernel-format.ts
+++ b/packages/textlint/src/util/object-to-kernel-format.ts
@@ -1,13 +1,10 @@
 import {
     TextlintFilterRuleReporter,
-    TextlintFilterRuleOptions,
     TextlintKernelFilterRule,
     TextlintKernelPlugin,
     TextlintKernelRule,
     TextlintPluginCreator,
-    TextlintPluginOptions,
-    TextlintRuleModule,
-    TextlintRuleOptions
+    TextlintRuleModule
 } from "@textlint/kernel";
 
 /**
@@ -23,7 +20,7 @@ import {
  */
 export const rulesObjectToKernelRule = (
     rules: { [index: string]: TextlintRuleModule },
-    rulesOption: { [index: string]: TextlintRuleOptions }
+    rulesOption: { [index: string]: TextlintKernelRule["options"] }
 ): TextlintKernelRule[] => {
     return Object.keys(rules).map(ruleId => {
         return {
@@ -33,9 +30,10 @@ export const rulesObjectToKernelRule = (
         };
     });
 };
+
 export const filterRulesObjectToKernelRule = (
     rules: { [index: string]: TextlintFilterRuleReporter },
-    rulesOption: { [index: string]: TextlintFilterRuleOptions }
+    rulesOption: { [index: string]: TextlintKernelFilterRule["options"] }
 ): TextlintKernelFilterRule[] => {
     return Object.keys(rules).map(ruleId => {
         return {
@@ -59,7 +57,7 @@ export const filterRulesObjectToKernelRule = (
  */
 export const pluginsObjectToKernelRule = (
     plugins: { [index: string]: TextlintPluginCreator },
-    pluginsOption: { [index: string]: TextlintPluginOptions }
+    pluginsOption: { [index: string]: TextlintKernelPlugin["options"] }
 ): TextlintKernelPlugin[] => {
     return Object.keys(plugins).map(pluginId => {
         return {

--- a/packages/textlint/test/engine/textfix-engine-test.ts
+++ b/packages/textlint/test/engine/textfix-engine-test.ts
@@ -14,13 +14,13 @@ describe("textfix-engine", function() {
         context("when no-args", function() {
             it("config should be empty", function() {
                 const engine = new TextFixEngine();
-                assert.deepEqual(engine.config.rulePaths, []);
+                assert.deepEqual((engine as any).config.rulePaths, []);
             });
         });
         context("when args is object", function() {
             it("should convert the object and set config", function() {
                 const engine = new TextFixEngine({ rulePaths: [rulesDir] });
-                assert.deepEqual(engine.config.rulePaths, [rulesDir]);
+                assert.deepEqual((engine as any).config.rulePaths, [rulesDir]);
             });
         });
         context("when args is Config object", function() {
@@ -28,7 +28,7 @@ describe("textfix-engine", function() {
                 // Issue : when use Config as argus, have to export `../src/config/config`
                 var config = new Config({ rulePaths: [rulesDir] });
                 const engine = new TextFixEngine(config);
-                assert.deepEqual(engine.config.rulePaths, [rulesDir]);
+                assert.deepEqual((engine as any).config.rulePaths, [rulesDir]);
             });
         });
     });

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.js
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.js
@@ -1,0 +1,11 @@
+// LICENSE : MIT
+"use strict";
+
+const linter = function(context) {
+    return {
+        [context.Syntax.Str](_node) {
+            return;
+        }
+    };
+};
+module.exports = linter;

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.js
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.js
@@ -1,0 +1,41 @@
+class ExampleProcessor {
+    static availableExtensions() {
+        return [".example"];
+    }
+
+    constructor(options) {
+        this.options = options;
+    }
+
+    processor(_extension) {
+        return {
+            preProcess(text, _filePath) {
+                return {
+                    type: "Document",
+                    children: [],
+                    range: [0, 0],
+                    loc: {
+                        start: {
+                            line: 0,
+                            column: 0
+                        },
+                        end: {
+                            line: 0,
+                            column: 0
+                        }
+                    }
+                };
+            },
+            postProcess(messages, filePath) {
+                return {
+                    messages,
+                    filePath: filePath || "unknown"
+                };
+            }
+        };
+    }
+}
+
+module.exports = {
+    Processor: ExampleProcessor
+};

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.js
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.js
@@ -1,0 +1,11 @@
+// LICENSE : MIT
+"use strict";
+
+const linter = function(context) {
+    return {
+        [context.Syntax.Str](node) {
+            context.report(node, new context.RuleError("found error message"));
+        }
+    };
+};
+module.exports = linter;

--- a/packages/textlint/test/object-to-kernel-format/object-to-kernel-format-test.ts
+++ b/packages/textlint/test/object-to-kernel-format/object-to-kernel-format-test.ts
@@ -1,0 +1,163 @@
+import {
+    filterRulesObjectToKernelRule,
+    pluginsObjectToKernelRule,
+    rulesObjectToKernelRule
+} from "../../src/util/object-to-kernel-format";
+import * as assert from "assert";
+
+const exampleRule = require("./fixtures/example-rule.js");
+const exampleFilterRule = require("./fixtures/example-filter-rule.js");
+const examplePlugin = require("./fixtures/example-plugin.js");
+describe("object-to-kernel-format", () => {
+    describe("rulesObjectToKernelRule", () => {
+        it("should return kernel format with true", () => {
+            const rules = {
+                example: exampleRule
+            };
+            const rulesOption = {
+                example: true
+            };
+            const result = rulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleRule,
+                    options: true
+                }
+            ]);
+        });
+        it("should return kernel format with false", () => {
+            const rules = {
+                example: exampleRule
+            };
+            const rulesOption = {
+                example: false
+            };
+            const result = rulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleRule,
+                    options: false
+                }
+            ]);
+        });
+        it("should return kernel format with option object", () => {
+            const rules = {
+                example: exampleRule
+            };
+            const rulesOption = {
+                example: {}
+            };
+            const result = rulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleRule,
+                    options: rulesOption.example
+                }
+            ]);
+        });
+    });
+    describe("filterRulesObjectToKernelRule", () => {
+        it("should return kernel format with true", () => {
+            const rules = {
+                example: exampleFilterRule
+            };
+            const rulesOption = {
+                example: true
+            };
+            const result = filterRulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleFilterRule,
+                    options: true
+                }
+            ]);
+        });
+        it("should return kernel format with false", () => {
+            const rules = {
+                example: exampleFilterRule
+            };
+            const rulesOption = {
+                example: false
+            };
+            const result = filterRulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleFilterRule,
+                    options: false
+                }
+            ]);
+        });
+        it("should return kernel format with option object", () => {
+            const rules = {
+                example: exampleFilterRule
+            };
+            const rulesOption = {
+                example: {}
+            };
+            const result = filterRulesObjectToKernelRule(rules, rulesOption);
+            assert.deepStrictEqual(result, [
+                {
+                    ruleId: "example",
+                    rule: exampleFilterRule,
+                    options: rulesOption.example
+                }
+            ]);
+        });
+    });
+
+    describe("pluginsObjectToKernelRule", () => {
+        it("should return kernel format with true", () => {
+            const plugins = {
+                example: examplePlugin
+            };
+            const pluginsOption = {
+                example: true
+            };
+            const result = pluginsObjectToKernelRule(plugins, pluginsOption);
+            assert.deepStrictEqual(result, [
+                {
+                    pluginId: "example",
+                    plugin: examplePlugin,
+                    options: true
+                }
+            ]);
+        });
+        it("should return kernel format with false", () => {
+            const plugins = {
+                example: examplePlugin
+            };
+            const pluginsOption = {
+                example: false
+            };
+            const result = pluginsObjectToKernelRule(plugins, pluginsOption);
+            assert.deepStrictEqual(result, [
+                {
+                    pluginId: "example",
+                    plugin: examplePlugin,
+                    options: false
+                }
+            ]);
+        });
+        it("should return kernel format with option object", () => {
+            const plugins = {
+                example: examplePlugin
+            };
+            const pluginsOption = {
+                example: {}
+            };
+            const result = pluginsObjectToKernelRule(plugins, pluginsOption);
+            assert.deepStrictEqual(result, [
+                {
+                    pluginId: "example",
+                    plugin: examplePlugin,
+                    options: pluginsOption.example
+                }
+            ]);
+        });
+    });
+});

--- a/packages/textlint/test/pluguins/PluginOption-test.js
+++ b/packages/textlint/test/pluguins/PluginOption-test.js
@@ -7,9 +7,9 @@ import { createPluginStub } from "./fixtures/example-plugin";
 describe("plugin-option", () => {
     it("should load plugin options if match ext", () => {
         const textlintCore = new TextLintCore();
-        const { getPlugin, getOptions } = createPluginStub();
+        const { plugin, getOptions } = createPluginStub();
         const expectedOptions = { test: "expected" };
-        textlintCore.setupPlugins({ example: getPlugin() }, { example: expectedOptions });
+        textlintCore.setupPlugins({ example: plugin }, { example: expectedOptions });
         textlintCore.setupRules({ "example-rule": require("./fixtures/example-rule") });
         return textlintCore.lintText("test", ".example").then(results => {
             const actualOptions = getOptions();
@@ -18,9 +18,9 @@ describe("plugin-option", () => {
     });
     it("should load plugin options when does't match any ext for instance availableExtensions()", () => {
         const textlintCore = new TextLintCore();
-        const { getPlugin, getOptions } = createPluginStub();
+        const { plugin, getOptions } = createPluginStub();
         const expectedOptions = { test: "expected" };
-        textlintCore.setupPlugins({ example: getPlugin() }, { example: expectedOptions });
+        textlintCore.setupPlugins({ example: plugin }, { example: expectedOptions });
         textlintCore.setupRules({ "example-rule": require("./fixtures/example-rule") });
         // .md is built-in
         return textlintCore.lintText("test", ".md").then(results => {

--- a/packages/textlint/test/pluguins/fixtures/example-plugin.js
+++ b/packages/textlint/test/pluguins/fixtures/example-plugin.js
@@ -43,7 +43,7 @@ export const createPluginStub = () => {
         getOptions() {
             return assignedOptions;
         },
-        getPlugin() {
+        createPlugin() {
             return {
                 Processor: class MockProcessor extends ExampleProcessor {
                     constructor(options) {

--- a/packages/textlint/test/pluguins/fixtures/example-plugin.js
+++ b/packages/textlint/test/pluguins/fixtures/example-plugin.js
@@ -43,7 +43,7 @@ export const createPluginStub = () => {
         getOptions() {
             return assignedOptions;
         },
-        createPlugin() {
+        get plugin() {
             return {
                 Processor: class MockProcessor extends ExampleProcessor {
                     constructor(options) {


### PR DESCRIPTION
BREAKING CHANGE: Previously, textlint pass `true` to rule and plugin as default value of option.
This commit change the default value to `{}` (empty object).


For example, `very-nice-rule`'s option is `true`(enable the rule) in `.textlintrc`
 
```json
{
  "rules": {
    "very-nice-rule": true
  }
}
```

**Before**

`very-nice-rule.js` rule get `true` as `options`.
 
```js
export default function(context, options) {
    console.log(options); // true
}
```

**After**:
 
`very-nice-rule.js` rule get `{}` (emptry object) as `options`.
 
```js
export default function(context, options) {
    console.log(options); // {}
}
```
 

fix https://github.com/textlint/textlint/issues/535