### PR TITLE
fix(prettier): use escaped double quotes instead of single quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:examples": "lerna run test:ci --scope textlint-example-*",
     "test:integration": "lerna run test --scope integration-test",
     "test:packages": "lerna run test --ignore integration-test --ignore textlint-example-* --ignore textlint-script-* --ignore textlint-website",
-    "prettier": "prettier --write 'packages/**/*.{js,jsx,ts,tsx,css}'",
+    "prettier": "prettier --write \"packages/**/*.{js,jsx,ts,tsx,css}\"",
     "yarn-check": "yarn check --integrity || (echo '=> Please run `$ yarn bootstrap`' && exit 1)"
   },
   "devDependencies": {


### PR DESCRIPTION
Thank you for [your quick response](https://github.com/textlint/textlint/issues/544#issuecomment-410427813).

I changed package.json. Now prettier uses escaped double quotes.