### PR TITLE
fix(textlint-tester): fix text only valid test is always passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ See [Processor Plugin List](https://github.com/textlint/textlint/wiki/Collection
 
 textlint has not built-in rules, but there are 100+ pluggable rules:
 
-- [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo)
+- [textlint-rule-no-todo](https://github.com/textlint-rule/textlint-rule-no-todo)
 - [textlint-rule-max-number-of-lines](https://github.com/azu/textlint-rule-max-number-of-lines)
 - [textlint-rule-common-misspellings](https://github.com/io-monad/textlint-rule-common-misspellings)
 - [etc...](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ npm install --save-dev textlint
 
 You can find a rule in [A Collection of textlint rule](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule "A Collection of textlint rule").
 
-As an example, let's install [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "textlint-rule-no-todo"). If you have installed `textlint` locally, you must install each rule locally as well.
+As an example, let's install [textlint-rule-no-todo](https://github.com/textlint-rule/textlint-rule-no-todo "textlint-rule-no-todo"). If you have installed `textlint` locally, you must install each rule locally as well.
 
 ```
 npm install --save-dev textlint-rule-no-todo

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -76,7 +76,7 @@ export default function(context) {
 
 [visualize-txt-traverse](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse") help you better understand this traversing.
 
-[![gif visualize-txt-traverse](http://gyazo.com/155c68f0f9ff35e0a549d655a787c01e.gif)](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse")
+[![gif visualize-txt-traverse](https://gyazo.com/155c68f0f9ff35e0a549d655a787c01e.gif)](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse")
 
 [AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") help you better understand [TxtAST](./txtnode.md).
 
@@ -306,7 +306,7 @@ $ npm run build
 $ textlint --rulesdir lib/ README.md -f pretty-error
 ```
 
-![result error](http://monosnap.com/image/9FeIQr95kXjGPWFjZFRq6ZFG16YscF.png)
+![result error](https://monosnap.com/image/9FeIQr95kXjGPWFjZFRq6ZFG16YscF.png)
 
 ### Advanced rules
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -410,7 +410,7 @@ As as result, linting following text with modified rule, a result was no error.
 [todo:image](http://example.com)
 ```
 
-- The created rule is [textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "azu/textlint-rule-no-todo").
+- The created rule is [textlint-rule-no-todo](https://github.com/textlint-rule/textlint-rule-no-todo "azu/textlint-rule-no-todo").
 - These helper functions like `getParents` are implemented in [textlint/textlint-rule-helper](https://github.com/textlint/textlint-rule-helper "textlint/textlint-rule-helper").
 
 ### How to test the rule?
@@ -516,7 +516,7 @@ Run the tests:
     # or
     $(npm bin)/mocha test/
 
-:information_source: Please see [azu/textlint-rule-no-todo](https://github.com/azu/textlint-rule-no-todo "azu/textlint-rule-no-todo") for details.
+:information_source: Please see [azu/textlint-rule-no-todo](https://github.com/textlint-rule/textlint-rule-no-todo "azu/textlint-rule-no-todo") for details.
 
 ### Rule options
 
@@ -656,7 +656,7 @@ You should add `textlintrule` to npm's `keywords`
 A. You should
 
 - Add `textlint >= 5.5` to `peerDependencies`
-    - See example: [textlint-rule-no-todo/package.json](https://github.com/azu/textlint-rule-no-todo/blob/50880b4e1c13782874a43714ee69900fc54a5348/package.json#L47-L49)
+    - See example: [textlint-rule-no-todo/package.json](https://github.com/textlint-rule/textlint-rule-no-todo/blob/50880b4e1c13782874a43714ee69900fc54a5348/package.json)
 - Release the rule package as *major* because it has breaking change.
 
 #### Q. `textlint` does major update. Do my rule package major update?

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -170,7 +170,11 @@ export class TextLintTester {
                 textlint.setupPlugins(testPluginSet.plugins, testPluginSet.pluginOptions);
             }
         } else {
-            const options = typeof valid === "object" && valid.options;
+            const options =
+                typeof valid === "object"
+                    ? valid.options
+                    : // just enable
+                      true;
             textlint.setupRules(
                 {
                     [name]: param


### PR DESCRIPTION
Previously, text only test case on `valid` is always passed

```
tester.run("no-todo", noTodo, {
    valid: [ "text" ]
})
```