### PR TITLE
Release @textlint/types@1.1.0

### DIFF
--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.13...textlint-example-cli@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-cli@2.0.11...textlint-example-cli@2.0.13) (2018-12-24)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-cli",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint --rule no-todo '*.md'"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/config-file/CHANGELOG.md
+++ b/examples/config-file/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.13...textlint-example-config-file@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.0.11...textlint-example-config-file@2.0.13) (2018-12-24)
 

--- a/examples/config-file/package.json
+++ b/examples/config-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-file",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/filter/CHANGELOG.md
+++ b/examples/filter/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.13...textlint-example-filter@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-filter@2.0.11...textlint-example-filter@2.0.13) (2018-12-24)
 

--- a/examples/filter/package.json
+++ b/examples/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-filter",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "filter rule example",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.1"
   }

--- a/examples/fix-dry-run/CHANGELOG.md
+++ b/examples/fix-dry-run/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.13...textlint-example-fix-dry-run@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.0.11...textlint-example-fix-dry-run@2.0.13) (2018-12-24)
 

--- a/examples/fix-dry-run/package.json
+++ b/examples/fix-dry-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix-dry-run",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix --dry-run README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/fix/CHANGELOG.md
+++ b/examples/fix/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.13...textlint-example-fix@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-fix@2.0.11...textlint-example-fix@2.0.13) (2018-12-24)
 

--- a/examples/fix/package.json
+++ b/examples/fix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/html-plugin/CHANGELOG.md
+++ b/examples/html-plugin/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.13...textlint-example-html-plugin@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.0.11...textlint-example-html-plugin@2.0.13) (2018-12-24)
 

--- a/examples/html-plugin/package.json
+++ b/examples/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-html-plugin",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "textlint": "textlint -f pretty-error index.html"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-sentence-length": "^2.1.1"
   }

--- a/examples/perf/CHANGELOG.md
+++ b/examples/perf/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.13...textlint-perf-test@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-perf-test@2.0.11...textlint-perf-test@2.0.13) (2018-12-24)
 

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-perf-test",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "shelljs": "^0.8.1",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-plugin-jtf-style": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",

--- a/examples/plugin-extensions-option/CHANGELOG.md
+++ b/examples/plugin-extensions-option/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.0.13...textlint-example-plugin-extensions-option@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.0.11...textlint-example-plugin-extensions-option@2.0.13) (2018-12-24)
 

--- a/examples/plugin-extensions-option/package.json
+++ b/examples/plugin-extensions-option/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-plugin-extensions-option",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "expected-exit-status": "^1.0.2",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/preset/CHANGELOG.md
+++ b/examples/preset/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.13...textlint-example-preset@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-preset@2.0.11...textlint-example-preset@2.0.13) (2018-12-24)
 

--- a/examples/preset/package.json
+++ b/examples/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-preset",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-preset-jtf-style": "^2.3.2"
   }
 }

--- a/examples/rulesdir/CHANGELOG.md
+++ b/examples/rulesdir/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.13...textlint-example-rulesdir@2.1.0) (2019-01-01)
+
+
+
+
+**Note:** Version bump only for package textlint-example-rulesdir
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.0.11...textlint-example-rulesdir@2.0.13) (2018-12-24)
 

--- a/examples/rulesdir/package.json
+++ b/examples/rulesdir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-rulesdir",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,6 +12,6 @@
     "textlint": "textlint --rulesdir ./rules README.md"
   },
   "devDependencies": {
-    "textlint": "^11.0.2"
+    "textlint": "^11.1.0"
   }
 }

--- a/examples/use-as-module/CHANGELOG.md
+++ b/examples/use-as-module/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.13...textlint-example-use-as-module@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.0.11...textlint-example-use-as-module@2.0.13) (2018-12-24)
 

--- a/examples/use-as-module/package.json
+++ b/examples/use-as-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-module",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/use-as-ts-module/CHANGELOG.md
+++ b/examples/use-as-ts-module/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.2.0"></a>
+# [2.2.0](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.10...textlint-example-use-as-ts-module@2.2.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.1.10"></a>
 ## [2.1.10](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.1.8...textlint-example-use-as-ts-module@2.1.10) (2018-12-24)
 

--- a/examples/use-as-ts-module/package.json
+++ b/examples/use-as-ts-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-ts-module",
-  "version": "2.1.10",
+  "version": "2.2.0",
   "private": true,
   "license": "MIT",
   "author": "0x6b",
@@ -14,7 +14,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.1"
   },

--- a/packages/@textlint/ast-node-types/CHANGELOG.md
+++ b/packages/@textlint/ast-node-types/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.0"></a>
+# [4.1.0](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.0.3...@textlint/ast-node-types@4.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Code Refactoring
+
+* **types:** move type definition for rule to [@textlint](https://github.com/textlint)/types ([9be6e16](https://github.com/textlint/textlint/commit/9be6e16))
+
+
+
+
 <a name="4.0.3"></a>
 ## [4.0.3](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.0.2...@textlint/ast-node-types@4.0.3) (2018-07-22)
 

--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-node-types",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "description": "textlint AST node type definition.",
   "keywords": [
     "textlint"

--- a/packages/@textlint/ast-tester/CHANGELOG.md
+++ b/packages/@textlint/ast-tester/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.8...@textlint/ast-tester@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.8"></a>
 ## [2.0.8](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.0.7...@textlint/ast-tester@2.0.8) (2018-07-22)
 

--- a/packages/@textlint/ast-tester/package.json
+++ b/packages/@textlint/ast-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-tester",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "description": "Compliance tests for textlint's AST(Abstract Syntax Tree).",
   "keywords": [
     "ast",
@@ -35,8 +35,8 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.9",
-    "@textlint/text-to-ast": "^3.0.9",
+    "@textlint/markdown-to-ast": "^6.1.0",
+    "@textlint/text-to-ast": "^3.1.0",
     "babel-cli": "^6.6.5",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",

--- a/packages/@textlint/ast-traverse/CHANGELOG.md
+++ b/packages/@textlint/ast-traverse/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.0.9...@textlint/ast-traverse@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="2.0.9"></a>
 ## [2.0.9](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.0.8...@textlint/ast-traverse@2.0.9) (2018-07-22)
 

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-traverse",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "TxtNode traverse library",
   "keywords": [
     "AST",
@@ -32,10 +32,10 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.3"
+    "@textlint/ast-node-types": "^4.1.0"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.9",
+    "@textlint/markdown-to-ast": "^6.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "cross-env": "^5.2.0",

--- a/packages/@textlint/feature-flag/CHANGELOG.md
+++ b/packages/@textlint/feature-flag/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/textlint/textlint/compare/@textlint/feature-flag@3.0.5...@textlint/feature-flag@3.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="3.0.5"></a>
 ## [3.0.5](https://github.com/textlint/textlint/compare/@textlint/feature-flag@3.0.4...@textlint/feature-flag@3.0.5) (2018-07-22)
 

--- a/packages/@textlint/feature-flag/package.json
+++ b/packages/@textlint/feature-flag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/feature-flag",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "textlint internal feature flag manager.",
   "keywords": [
     "textlint"

--- a/packages/@textlint/fixer-formatter/CHANGELOG.md
+++ b/packages/@textlint/fixer-formatter/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.9...@textlint/fixer-formatter@3.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Code Refactoring
+
+* **fixer-formatter:** use [@textlint](https://github.com/textlint)/types instead of [@textlint](https://github.com/textlint)/kernel ([ef96a80](https://github.com/textlint/textlint/commit/ef96a80))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+* **prettier:** format style by prettier ([19a2901](https://github.com/textlint/textlint/commit/19a2901))
+
+
+
+
 <a name="3.0.9"></a>
 ## [3.0.9](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.0.8...@textlint/fixer-formatter@3.0.9) (2018-12-24)
 

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/fixer-formatter",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "textlint output formatter for fixer",
   "keywords": [
     "AST",
@@ -34,7 +34,7 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/types": "^1.0.0",
+    "@textlint/types": "^1.1.0",
     "chalk": "^1.1.3",
     "debug": "^4.1.1",
     "diff": "^2.2.2",

--- a/packages/@textlint/kernel/CHANGELOG.md
+++ b/packages/@textlint/kernel/CHANGELOG.md
@@ -3,6 +3,53 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/textlint/textlint/compare/@textlint/kernel@3.0.1...@textlint/kernel@3.1.0) (2019-01-01)
+
+
+### Bug Fixes
+
+* **kernel:** fix type error ([214c287](https://github.com/textlint/textlint/commit/214c287))
+* **kernel:** refer to TextlintRuleContextReportFunctionArgs ([27e6968](https://github.com/textlint/textlint/commit/27e6968))
+* **types:** fix name of type definition ([67d9c49](https://github.com/textlint/textlint/commit/67d9c49))
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Code Refactoring
+
+* **kernel:** move report()/shouldIgnore() definition to types ([601ce3a](https://github.com/textlint/textlint/commit/601ce3a))
+* **kernel:** remove SeverityLevel.ts from kernel ([88a306c](https://github.com/textlint/textlint/commit/88a306c))
+* **types:** move type definition for rule to [@textlint](https://github.com/textlint)/types ([9be6e16](https://github.com/textlint/textlint/commit/9be6e16))
+
+
+### Documentation
+
+* **types:** Update README ([ab1e2ba](https://github.com/textlint/textlint/commit/ab1e2ba))
+
+
+### Features
+
+* **types:** Move TextlintResult/TextlintMessage type to [@textlint](https://github.com/textlint)/types ([b2a03a1](https://github.com/textlint/textlint/commit/b2a03a1))
+
+
+### Styles
+
+* **prettier:** format style by prettier ([19a2901](https://github.com/textlint/textlint/commit/19a2901))
+
+
+### Tests
+
+* **deps:** update no-todo rule reference ([6cecc88](https://github.com/textlint/textlint/commit/6cecc88))
+* **types:** Move SourceCode test to types ([ec61d65](https://github.com/textlint/textlint/commit/ec61d65))
+
+
+
+
 <a name="3.0.1"></a>
 ## [3.0.1](https://github.com/textlint/textlint/compare/@textlint/kernel@3.0.0...@textlint/kernel@3.0.1) (2018-12-24)
 

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/kernel",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "textlint kernel is core logic by pure JavaScript.",
   "keywords": [
     "textlint"
@@ -32,10 +32,10 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.3",
-    "@textlint/ast-traverse": "^2.0.9",
-    "@textlint/feature-flag": "^3.0.5",
-    "@textlint/types": "^1.0.0",
+    "@textlint/ast-node-types": "^4.1.0",
+    "@textlint/ast-traverse": "^2.1.0",
+    "@textlint/feature-flag": "^3.1.0",
+    "@textlint/types": "^1.1.0",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.5.1",
     "debug": "^4.1.1",
@@ -45,7 +45,7 @@
     "structured-source": "^3.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.0.9",
+    "@textlint/markdown-to-ast": "^6.1.0",
     "@types/deep-equal": "^1.0.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",

--- a/packages/@textlint/linter-formatter/CHANGELOG.md
+++ b/packages/@textlint/linter-formatter/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.9...@textlint/linter-formatter@3.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+* **formatter:** revert unnecessary changes ([70bef1e](https://github.com/textlint/textlint/commit/70bef1e))
+
+
+### Code Refactoring
+
+* **linter-formatter:** use [@textlint](https://github.com/textlint)/types instead of [@textlint](https://github.com/textlint)/kernel ([09cc67f](https://github.com/textlint/textlint/commit/09cc67f))
+* **types:** move type definition for rule to [@textlint](https://github.com/textlint)/types ([9be6e16](https://github.com/textlint/textlint/commit/9be6e16))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+
+
+
+
 <a name="3.0.9"></a>
 ## [3.0.9](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.0.8...@textlint/linter-formatter@3.0.9) (2018-12-24)
 

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/linter-formatter",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "textlint output formatter",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/linter-formatter",
   "bugs": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azu/format-text": "^1.0.1",
     "@azu/style-format": "^1.0.0",
-    "@textlint/types": "^1.0.0",
+    "@textlint/types": "^1.1.0",
     "chalk": "^1.0.0",
     "concat-stream": "^1.5.1",
     "js-yaml": "^3.2.4",

--- a/packages/@textlint/markdown-to-ast/CHANGELOG.md
+++ b/packages/@textlint/markdown-to-ast/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="6.1.0"></a>
+# [6.1.0](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.9...@textlint/markdown-to-ast@6.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+* **prettier:** format style by prettier ([19a2901](https://github.com/textlint/textlint/commit/19a2901))
+
+
+
+
 <a name="6.0.9"></a>
 ## [6.0.9](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.0.8...@textlint/markdown-to-ast@6.0.9) (2018-07-22)
 

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/markdown-to-ast",
-  "version": "6.0.9",
+  "version": "6.1.0",
   "description": "Parse Markdown to AST with location info.",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast/",
   "bugs": {
@@ -29,7 +29,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.3",
+    "@textlint/ast-node-types": "^4.1.0",
     "debug": "^4.1.1",
     "remark-frontmatter": "^1.2.0",
     "remark-parse": "^5.0.0",
@@ -38,8 +38,8 @@
     "unified": "^6.1.6"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.8",
-    "@textlint/ast-traverse": "^2.0.9",
+    "@textlint/ast-tester": "^2.1.0",
+    "@textlint/ast-traverse": "^2.1.0",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/text-to-ast/CHANGELOG.md
+++ b/packages/@textlint/text-to-ast/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.0"></a>
+# [3.1.0](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.9...@textlint/text-to-ast@3.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+
+
+
+
 <a name="3.0.9"></a>
 ## [3.0.9](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.0.8...@textlint/text-to-ast@3.0.9) (2018-07-22)
 

--- a/packages/@textlint/text-to-ast/package.json
+++ b/packages/@textlint/text-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/text-to-ast",
-  "version": "3.0.9",
+  "version": "3.1.0",
   "description": "Parse plain text to AST with location info.",
   "keywords": [
     "ast",
@@ -35,10 +35,10 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.3"
+    "@textlint/ast-node-types": "^4.1.0"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.0.8",
+    "@textlint/ast-tester": "^2.1.0",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.0"></a>
+# [5.1.0](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@5.0.2...@textlint/textlint-plugin-markdown@5.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Tests
+
+* **deps:** update no-todo rule reference ([6cecc88](https://github.com/textlint/textlint/commit/6cecc88))
+
+
+
+
 <a name="5.0.2"></a>
 ## [5.0.2](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@5.0.0...@textlint/textlint-plugin-markdown@5.0.2) (2018-12-24)
 

--- a/packages/@textlint/textlint-plugin-markdown/package.json
+++ b/packages/@textlint/textlint-plugin-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-markdown",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "Markdown support for textlint.",
   "keywords": [
     "markdown",
@@ -33,7 +33,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/markdown-to-ast": "^6.0.9"
+    "@textlint/markdown-to-ast": "^6.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
@@ -45,7 +45,7 @@
     "mocha": "^5.2.0",
     "power-assert": "^1.6.1",
     "rimraf": "^2.6.2",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   },
   "email": "azuciao@gmail.com",

--- a/packages/@textlint/textlint-plugin-text/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-text/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.0"></a>
+# [4.1.0](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@4.0.2...@textlint/textlint-plugin-text@4.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Tests
+
+* **deps:** update no-todo rule reference ([6cecc88](https://github.com/textlint/textlint/commit/6cecc88))
+
+
+
+
 <a name="4.0.2"></a>
 ## [4.0.2](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@4.0.0...@textlint/textlint-plugin-text@4.0.2) (2018-12-24)
 

--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-text",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "plain text plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/textlint-plugin-text/",
   "bugs": {
@@ -29,7 +29,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/text-to-ast": "^3.0.9"
+    "@textlint/text-to-ast": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -41,7 +41,7 @@
     "mocha": "^5.2.0",
     "power-assert": "^1.6.1",
     "rimraf": "^2.6.2",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-rule-no-todo": "^2.0.1"
   },
   "publishConfig": {

--- a/packages/@textlint/types/CHANGELOG.md
+++ b/packages/@textlint/types/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+<a name="1.1.0"></a>
+# 1.1.0 (2019-01-01)
+
+
+### Bug Fixes
+
+* **types:** fix name of type definition ([67d9c49](https://github.com/textlint/textlint/commit/67d9c49))
+
+
+### Chores
+
+* **textlint:** restore get severity() ([6057210](https://github.com/textlint/textlint/commit/6057210))
+
+
+### Code Refactoring
+
+* **kernel:** move report()/shouldIgnore() definition to types ([601ce3a](https://github.com/textlint/textlint/commit/601ce3a))
+* **types:** move type definition for rule to [@textlint](https://github.com/textlint)/types ([9be6e16](https://github.com/textlint/textlint/commit/9be6e16))
+
+
+### Documentation
+
+* **types:** Update README ([ab1e2ba](https://github.com/textlint/textlint/commit/ab1e2ba))
+
+
+### Features
+
+* **types:** add ReportHandler types ([d5ffe55](https://github.com/textlint/textlint/commit/d5ffe55))
+* **types:** Move TextlintResult/TextlintMessage type to [@textlint](https://github.com/textlint)/types ([b2a03a1](https://github.com/textlint/textlint/commit/b2a03a1))
+
+
+### Tests
+
+* **types:** Move SourceCode test to types ([ec61d65](https://github.com/textlint/textlint/commit/ec61d65))

--- a/packages/@textlint/types/package.json
+++ b/packages/@textlint/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/types",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Type definition package for textlint",
   "keywords": [
     "definition",
@@ -42,10 +42,11 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "structured-source": "^3.0.2",
-    "@textlint/ast-node-types": "^4.0.3"
+    "@textlint/ast-node-types": "^4.1.0",
+    "structured-source": "^3.0.2"
   },
   "devDependencies": {
+    "@textlint/markdown-to-ast": "^6.1.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "@types/structured-source": "^3.0.0",
@@ -56,8 +57,7 @@
     "ts-node": "^7.0.1",
     "ts-node-test-register": "^4.0.0",
     "typescript": "^3.2.2",
-    "unist-util-select": "^2.0.0",
-    "@textlint/markdown-to-ast": "^6.0.9"
+    "unist-util-select": "^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/gulp-textlint/CHANGELOG.md
+++ b/packages/gulp-textlint/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.0"></a>
+# [5.1.0](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.13...gulp-textlint@5.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Styles
+
+* **prettier:** format style by prettier ([19a2901](https://github.com/textlint/textlint/commit/19a2901))
+
+
+
+
 <a name="5.0.13"></a>
 ## [5.0.13](https://github.com/textlint/textlint/compare/gulp-textlint@5.0.11...gulp-textlint@5.0.13) (2018-12-24)
 

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-textlint",
-  "version": "5.0.13",
+  "version": "5.1.0",
   "description": "gulp plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "bugs": {
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.0.1",
     "plugin-error": "^1.0.1",
     "prettier": "^1.7.4",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/textlint-tester/CHANGELOG.md
+++ b/packages/textlint-tester/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.0"></a>
+# [5.1.0](https://github.com/textlint/textlint/compare/textlint-tester@5.0.2...textlint-tester@5.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+
+
+### Tests
+
+* **deps:** update no-todo rule reference ([6cecc88](https://github.com/textlint/textlint/commit/6cecc88))
+
+
+
+
 <a name="5.0.2"></a>
 ## [5.0.2](https://github.com/textlint/textlint/compare/textlint-tester@5.0.0...textlint-tester@5.0.2) (2018-12-24)
 

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-tester",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "testing tool for textlint rule.",
   "keywords": [
     "test",
@@ -34,9 +34,9 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/feature-flag": "^3.0.5",
-    "@textlint/kernel": "^3.0.1",
-    "textlint": "^11.0.2"
+    "@textlint/feature-flag": "^3.1.0",
+    "@textlint/kernel": "^3.1.0",
+    "textlint": "^11.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",
@@ -52,7 +52,7 @@
     "mocha": "^5.2.0",
     "power-assert": "^1.6.1",
     "rimraf": "^2.6.2",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-helper": "^2.0.1",
     "textlint-rule-max-number-of-lines": "^1.0.2",

--- a/packages/textlint/CHANGELOG.md
+++ b/packages/textlint/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="11.1.0"></a>
+# [11.1.0](https://github.com/textlint/textlint/compare/textlint@11.0.2...textlint@11.1.0) (2019-01-01)
+
+
+### Bug Fixes
+
+* **kernel:** fix type error ([214c287](https://github.com/textlint/textlint/commit/214c287))
+* **textlint:** fix typing of converting function ([ab3b4ef](https://github.com/textlint/textlint/commit/ab3b4ef))
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+* **textlint:** remove unused types ([5f86a62](https://github.com/textlint/textlint/commit/5f86a62))
+* **textlint:** restore get severity() ([6057210](https://github.com/textlint/textlint/commit/6057210))
+
+
+### Code Refactoring
+
+* **kernel:** simply typing ([f53ed51](https://github.com/textlint/textlint/commit/f53ed51))
+
+
+### Styles
+
+* **eslint:** apply eslint to all files ([6a9573f](https://github.com/textlint/textlint/commit/6a9573f))
+* **prettier:** format style by prettier ([19a2901](https://github.com/textlint/textlint/commit/19a2901))
+
+
+
+
 <a name="11.0.2"></a>
 ## [11.0.2](https://github.com/textlint/textlint/compare/textlint@11.0.0...textlint@11.0.2) (2018-12-24)
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint",
-  "version": "11.0.2",
+  "version": "11.1.0",
   "description": "The pluggable linting tool for text and markdown.",
   "keywords": [
     "AST",
@@ -47,14 +47,14 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.0.3",
-    "@textlint/ast-traverse": "^2.0.9",
-    "@textlint/feature-flag": "^3.0.5",
-    "@textlint/fixer-formatter": "^3.0.9",
-    "@textlint/kernel": "^3.0.1",
-    "@textlint/linter-formatter": "^3.0.9",
-    "@textlint/textlint-plugin-markdown": "^5.0.2",
-    "@textlint/textlint-plugin-text": "^4.0.2",
+    "@textlint/ast-node-types": "^4.1.0",
+    "@textlint/ast-traverse": "^2.1.0",
+    "@textlint/feature-flag": "^3.1.0",
+    "@textlint/fixer-formatter": "^3.1.0",
+    "@textlint/kernel": "^3.1.0",
+    "@textlint/linter-formatter": "^3.1.0",
+    "@textlint/textlint-plugin-markdown": "^5.1.0",
+    "@textlint/textlint-plugin-text": "^4.1.0",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.0.5",
     "debug": "^4.1.1",

--- a/test/integration-test/CHANGELOG.md
+++ b/test/integration-test/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.0"></a>
+# [2.1.0](https://github.com/textlint/textlint/compare/integration-test@2.0.13...integration-test@2.1.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+
+
+
+
 <a name="2.0.13"></a>
 ## [2.0.13](https://github.com/textlint/textlint/compare/integration-test@2.0.11...integration-test@2.0.13) (2018-12-24)
 

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-test",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "private": true,
   "description": "textlint testbot sandbox.",
   "keywords": [
@@ -35,7 +35,7 @@
   "devDependencies": {
     "json5": "^2.1.0",
     "shelljs": "^0.8.3",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlintrc-to-pacakge-list": "^1.2.0"
   },
   "email": "azuciao@gmail.com"

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.7.0"></a>
+# [10.7.0](https://github.com/textlint/textlint/compare/textlint-website@10.6.0...textlint-website@10.7.0) (2019-01-01)
+
+
+### Chores
+
+* **deps:** update eslint deps ([5bf2d38](https://github.com/textlint/textlint/commit/5bf2d38))
+* **deps:** update TypeScript deps ([3ea7fb0](https://github.com/textlint/textlint/commit/3ea7fb0))
+
+
+
+
 <a name="10.6.0"></a>
 # [10.6.0](https://github.com/textlint/textlint/compare/textlint-website@10.4.0...textlint-website@10.6.0) (2018-12-24)
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-website",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "private": true,
   "homepage": "https://github.com/textlint/textlint/",
   "bugs": {
@@ -28,7 +28,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-prettier": "^3.0.1",
     "npm-run-all": "^4.1.5",
-    "textlint": "^11.0.2",
+    "textlint": "^11.1.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-eslint": "^3.1.0",
     "textlint-rule-no-dead-link": "^4.3.0",


### PR DESCRIPTION
This minor release does not includes breaking change.
Almost changes is related with TypeScript definition.

## Summary

- Add [@textlint/types](https://github.com/textlint/textlint/tree/master/packages/%40textlint/types) pacakge
- Upgrade to TypeScript@3

## @textlint/ast-node-types@4.1.0

### Features

- **types**: Add `AnyTxtNode` #562 

## @textlint/types@1.1.0

- Add `@textlint/types` pacakge #561 #562 

This pacakge define types for textlint.

## @textlint/kernel@3.1.0

### fixes

- **types:** use [@textlint/types](https://github.com/textlint) internally 

## textlint@11.1.0

### fixes

- **types:** use [@textlint/types](https://github.com/textlint) internally 


## ♻️ Refactoring

Move following types to `@textlint/types` from `@textlint/kernel`.
Also, `@textlint/kernel` export these types for back-compatible reason.

- TextlintResult
- TextlintFixResult
- TextlintMessageFixCommand
- TextlintMessage
- TextlintRuleReporter,
- TextlintRuleModule
- TextlintRuleOptions
- TextlintRuleSeverityLevel,
- TextlintFilterRuleReporter,
- TextlintFilterRuleOptions,
- TextlintPluginCreator
- TextlintPluginOptions
- TextlintPluginProcessor
- TextlintPluginProcessorConstructor

## Move files

Move following codes to `@textlint/types` from `@textlint/kernel`.
Also, `@textlint/types` export it.

- TextlintSourceCode
- TextlintSourceCodeArgs
- TextlintSourceCodeRange
- TextlintSourceCodeLocation

## Add types

`@textlint/types` and `@textlint/kernel` export these new types.

- TextlintRuleSeverityLevel
- TextlintMessageFixCommand
- AnyTxtNode
  - `@textlint/ast-node-types`

## Realted refactoring

- `@textlint/linter-formatter`: use `@textlint/types` instead of `@textlint/kernel`
- `@textlint/fixer-formatter`: use `@textlint/types` instead of `@textlint/kernel`

For more details, see #561 