### PR TITLE
fix(@textlint/types): enhance `TextlintRuleReportHandler` typing

### DIFF
--- a/docs/rule-tips-after-all.md
+++ b/docs/rule-tips-after-all.md
@@ -25,9 +25,9 @@ module.exports = context => {
             promiseQueue.push(callAsync(text));
         },
         // call this method at the end
-        // Syntax.Document <-> Syntax.Document:exit
+        // Syntax.Document <-> Syntax.DocumentExit
         // https://github.com/textlint/textlint/blob/master/docs/rule.md
-        [`${Syntax.Document}:exit`]() {
+        [Syntax.DocumentExit]() {
             // Note: textlint wait for `Promise.all` is resolved.
             return Promise.all(promiseQueue)
                 .then((...responses) => {

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -60,19 +60,21 @@ module.exports = function(context) {
 
 By default, the method matching a node name is called during the traversal when the node is first encountered(This is called **Enter**), on the way down the AST.
 
-You can also specify to visit the node on the other side of the traversal, as it comes back up the tree(This is called **Leave**), but adding `:exit` to the end of the node type, such as:
-
+You can also specify to visit the node on the other side of the traversal, as it comes back up the tree(This is called **Leave**), but adding `Exit` to the end of the node type, such as:
 
 ```js
 export default function(context) {
     return {
         // Str:exit
-        [`${context.Syntax.Str}:exit`](node) {
+        [context.Syntax.StrExit](node) {
             // this method is called
         }
     };
 }
 ```
+
+Note: textlint@11.1.1+ support `Exit` constance value like `Syntax.DocumentExit`.
+Previously, you had to write `[Syntax.Document + ":exit"]`.
 
 [visualize-txt-traverse](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse") help you better understand this traversing.
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -74,7 +74,7 @@ export default function(context) {
 ```
 
 Note: textlint@11.1.1+ support `Exit` constance value like `Syntax.DocumentExit`.
-Previously, you had to write `[Syntax.Document + ":exit"]`.
+In textlint@11.1.0<=, you had to write `[Syntax.Document + ":exit"]`.
 
 [visualize-txt-traverse](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse") help you better understand this traversing.
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -73,7 +73,7 @@ export default function(context) {
 }
 ```
 
-Note: textlint@11.1.1+ support `Exit` constance value like `Syntax.DocumentExit`.
+Note: textlint@11.1.1+ support `*Exit` constant value like `Syntax.DocumentExit`.
 In textlint@11.1.0<=, you had to write `[Syntax.Document + ":exit"]`.
 
 [visualize-txt-traverse](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse") help you better understand this traversing.

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -182,8 +182,6 @@ These types are defined in `@textlint/ast-node-types`.
 | ASTNodeTypes.HtmlExit           | TxtTextNode   |                                      |
 
 
-
-
 The type is based on HTML tag and Markdown syntax.
 Other plugin has define other node type that is not defined in `@textlint/ast-node-types`, but you can specify it as just a string.
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -128,37 +128,64 @@ import { ASTNodeTypes } from "@textlint/ast-node-types";
 console.log(ASTNodeTypes.Str); // "Str"
 ```
 
-See [packages/ast-node-types](https://github.com/textlint/textlint/tree/master/packages/@textlint/ast-node-types) for more details.
+You can get Node type for Type name by `TypeofTxtNode` in TypeScript.
 
-These types are be available at all times:
-
-```json5
-{
-    // TxtParentNode
-    "Document": "Document",
-    "Paragraph": "Paragraph",
-    "BlockQuote": "BlockQuote",
-    "ListItem": "ListItem",
-    "List": "List",
-    "Header": "Header",
-    "CodeBlock": "CodeBlock",
-    "HtmlBlock": "HtmlBlock",
-    "ReferenceDef": "ReferenceDef",
-    "HorizontalRule": "HorizontalRule",
-    "Comment": "Comment",
-    // TxtTextNode
-    "Str": "Str",
-    "Break": "Break",
-    "Emphasis": "Emphasis",
-    "Strong": "Strong",
-    "Html": "Html",
-    "Link": "Link",
-    "Image": "Image",
-    "Code": "Code"
-}
+```ts
+// In TypeScript
+import { ASTNodeTypes } from "@textlint/ast-node-types";
+const nodeType = TypeofTxtNode<ASTNodeTypes.Str>; // TxtTextNode
 ```
 
-The type is based on HTML tag.
+These types are be defined in `@textlint/ast-node-types`.
+
+| Type name                       | Node type     | Description                          |
+| ------------------------------- | ------------- | ------------------------------------ |
+| ASTNodeTypes.Document           | TxtParentNode | Root Node                            |
+| ASTNodeTypes.DocumentExit       | TxtParentNode |                                      |
+| ASTNodeTypes.Paragraph          | TxtParentNode | Paragraph Node                       |
+| ASTNodeTypes.ParagraphExit      | TxtParentNode |                                      |
+| ASTNodeTypes.BlockQuote         | TxtParentNode | > Str                                |
+| ASTNodeTypes.BlockQuoteExit     | TxtParentNode |                                      |
+| ASTNodeTypes.List               | TxtParentNode | List Node                            |
+| ASTNodeTypes.ListExit           | TxtParentNode |                                      |
+| ASTNodeTypes.ListItem           | TxtParentNode | List (each) item Node                |
+| ASTNodeTypes.ListItemExit       | TxtParentNode |                                      |
+| ASTNodeTypes.Header             | TxtParentNode | # Header Node                        |
+| ASTNodeTypes.HeaderExit         | TxtParentNode |                                      |
+| ASTNodeTypes.CodeBlock          | TxtParentNode | Code Block Node                      |
+| ASTNodeTypes.CodeBlockExit      | TxtParentNode |                                      |
+| ASTNodeTypes.HtmlBlock          | TxtParentNode | HTML Block Node                      |
+| ASTNodeTypes.HtmlBlockExit      | TxtParentNode |                                      |
+| ASTNodeTypes.Link               | TxtParentNode | Link Node                            |
+| ASTNodeTypes.LinkExit           | TxtParentNode |                                      |
+| ASTNodeTypes.ReferenceDef       | TxtParentNode | Link Reference Node(`[link][]`)      |
+| ASTNodeTypes.ReferenceDefExit   | TxtParentNode |                                      |
+| ASTNodeTypes.Delete             | TxtParentNode | Delete Node(`~Str~`)                 |
+| ASTNodeTypes.DeleteExit         | TxtParentNode |                                      |
+| ASTNodeTypes.Emphasis           | TxtParentNode | Emphasis(`*Str*`)                    |
+| ASTNodeTypes.EmphasisExit       | TxtParentNode |                                      |
+| ASTNodeTypes.Strong             | TxtParentNode | Strong Node(`**Str**`)               |
+| ASTNodeTypes.StrongExit         | TxtParentNode |                                      |
+| ASTNodeTypes.Break              | TxtNode       | Hard Break Node(`Str<space><space>`) |
+| ASTNodeTypes.BreakExit          | TxtNode       |                                      |
+| ASTNodeTypes.Image              | TxtNode       | Image Node                           |
+| ASTNodeTypes.ImageExit          | TxtNode       |                                      |
+| ASTNodeTypes.HorizontalRule     | TxtNode       | Horizontal Node(`---`)               |
+| ASTNodeTypes.HorizontalRuleExit | TxtNode       |                                      |
+| ASTNodeTypes.Comment            | TxtTextNode   | Comment Node                         |
+| ASTNodeTypes.CommentExit        | TxtTextNode   |                                      |
+| ASTNodeTypes.Str                | TxtTextNode   | Str Node                             |
+| ASTNodeTypes.StrExit            | TxtTextNode   |                                      |
+| ASTNodeTypes.Code               | TxtTextNode   | Inline Code Node                     |
+| ASTNodeTypes.CodeExit           | TxtTextNode   |                                      |
+| ASTNodeTypes.Html               | TxtTextNode   | Inline HTML Node                     |
+| ASTNodeTypes.HtmlExit           | TxtTextNode   |                                      |
+
+
+
+
+The type is based on HTML tag and Markdown syntax.
+Other plugin has define other node type that is not defined in `@textlint/ast-node-types`, but you can specify it as just a string.
 
 ### Minimal node property
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -136,7 +136,7 @@ import { ASTNodeTypes } from "@textlint/ast-node-types";
 const nodeType = TypeofTxtNode<ASTNodeTypes.Str>; // TxtTextNode
 ```
 
-These types are be defined in `@textlint/ast-node-types`.
+These types are defined in `@textlint/ast-node-types`.
 
 | Type name                       | Node type     | Description                          |
 | ------------------------------- | ------------- | ------------------------------------ |
@@ -144,7 +144,7 @@ These types are be defined in `@textlint/ast-node-types`.
 | ASTNodeTypes.DocumentExit       | TxtParentNode |                                      |
 | ASTNodeTypes.Paragraph          | TxtParentNode | Paragraph Node                       |
 | ASTNodeTypes.ParagraphExit      | TxtParentNode |                                      |
-| ASTNodeTypes.BlockQuote         | TxtParentNode | > Str                                |
+| ASTNodeTypes.BlockQuote         | TxtParentNode | > Block Quote Node                   |
 | ASTNodeTypes.BlockQuoteExit     | TxtParentNode |                                      |
 | ASTNodeTypes.List               | TxtParentNode | List Node                            |
 | ASTNodeTypes.ListExit           | TxtParentNode |                                      |

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -32,11 +32,11 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         ? TxtParentNode
         : T extends ASTNodeTypes.HeaderExit
         ? TxtParentNode
-          /* ```
-           * code
-           * ```
-           */
-        : T extends ASTNodeTypes.CodeBlock
+        : /* ```
+         * code
+         * ```
+         */
+        T extends ASTNodeTypes.CodeBlock
         ? TxtParentNode
         : T extends ASTNodeTypes.CodeBlockExit
         ? TxtParentNode // <div>\n</div>
@@ -71,8 +71,14 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         : T extends ASTNodeTypes.Image
         ? TxtNode
         : T extends ASTNodeTypes.ImageExit
-        ? TxtNode // <!-- Str -->
-        : T extends ASTNodeTypes.Comment
+        ? TxtNode
+        : // ----
+        T extends ASTNodeTypes.HorizontalRule
+        ? TxtNode
+        : T extends ASTNodeTypes.HorizontalRuleExit
+        ? TxtNode
+        : // <!-- Str -->
+        T extends ASTNodeTypes.Comment
         ? TxtTextNode
         : T extends ASTNodeTypes.CommentExit
         ? TxtTextNode // Str
@@ -87,9 +93,5 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         : T extends ASTNodeTypes.Html
         ? TxtTextNode
         : T extends ASTNodeTypes.HtmlExit
-        ? TxtTextNode // ----
-        : T extends ASTNodeTypes.HorizontalRule
-        ? TxtTextNode
-        : T extends ASTNodeTypes.HorizontalRuleExit
         ? TxtTextNode
         : any;

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -1,0 +1,73 @@
+import { ASTNodeTypes, TxtNode, TxtParentNode, TxtTextNode } from "@textlint/ast-node-types";
+/**
+ * Return TxtNode type of ASTNodeTypes | string
+ *
+ * @example
+ * ```
+ * type NodeType = TxtNodeTypeOfNode<ASTNodeTypes.Document>;
+ */
+export type TypeofTxtNode<T extends ASTNodeTypes | string> =
+    // Root
+    T extends ASTNodeTypes.Document
+        ? TxtParentNode
+        : // Paragraph Str.
+        T extends ASTNodeTypes.Paragraph
+        ? TxtParentNode
+        : // > Str
+        T extends ASTNodeTypes.BlockQuote
+        ? TxtParentNode
+        : // - item
+        T extends ASTNodeTypes.List
+        ? TxtParentNode
+        : // - item
+        T extends ASTNodeTypes.ListItem
+        ? TxtParentNode
+        : // # Str
+        T extends ASTNodeTypes.Header
+        ? TxtParentNode
+        : /* ```
+         * code
+         * ```
+         */
+        T extends ASTNodeTypes.CodeBlock
+        ? TxtParentNode
+        : // <div>\n</div>
+        T extends ASTNodeTypes.HtmlBlock
+        ? TxtParentNode
+        : // [link](https://example.com)
+        T extends ASTNodeTypes.Link
+        ? TxtParentNode
+        : // [link][]
+        T extends ASTNodeTypes.ReferenceDef
+        ? TxtParentNode
+        : // ~~Str~~
+        T extends ASTNodeTypes.Delete
+        ? TxtParentNode
+        : // *Str*
+        T extends ASTNodeTypes.Emphasis
+        ? TxtParentNode
+        : // __Str__
+        T extends ASTNodeTypes.Strong
+        ? TxtParentNode
+        : // Str<space><space>
+        T extends ASTNodeTypes.Break
+        ? TxtNode
+        : // ![alt](https://example.com/img)
+        T extends ASTNodeTypes.Image
+        ? TxtNode
+        : // <!-- Str -->
+        T extends ASTNodeTypes.Comment
+        ? TxtTextNode
+        : // Str
+        T extends ASTNodeTypes.Str
+        ? TxtTextNode
+        : // `code`
+        T extends ASTNodeTypes.Code
+        ? TxtTextNode
+        : // <span>Str</span>
+        T extends ASTNodeTypes.Html
+        ? TxtTextNode
+        : // ----
+        T extends ASTNodeTypes.HorizontalRule
+        ? TxtTextNode
+        : any;

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -10,64 +10,86 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
     // Root
     T extends ASTNodeTypes.Document
         ? TxtParentNode
-        : // Paragraph Str.
-        T extends ASTNodeTypes.Paragraph
+        : T extends ASTNodeTypes.DocumentExit
+        ? TxtParentNode // Paragraph Str.
+        : T extends ASTNodeTypes.Paragraph
         ? TxtParentNode
-        : // > Str
-        T extends ASTNodeTypes.BlockQuote
+        : T extends ASTNodeTypes.ParagraphExit
+        ? TxtParentNode // > Str
+        : T extends ASTNodeTypes.BlockQuote
         ? TxtParentNode
-        : // - item
-        T extends ASTNodeTypes.List
+        : T extends ASTNodeTypes.BlockQuoteExit
+        ? TxtParentNode // - item
+        : T extends ASTNodeTypes.List
         ? TxtParentNode
-        : // - item
-        T extends ASTNodeTypes.ListItem
+        : T extends ASTNodeTypes.ListExit
+        ? TxtParentNode // - item
+        : T extends ASTNodeTypes.ListItem
         ? TxtParentNode
-        : // # Str
-        T extends ASTNodeTypes.Header
+        : T extends ASTNodeTypes.ListItemExit
+        ? TxtParentNode // # Str
+        : T extends ASTNodeTypes.Header
         ? TxtParentNode
-        : /* ```
-         * code
-         * ```
-         */
-        T extends ASTNodeTypes.CodeBlock
+        : T extends ASTNodeTypes.HeaderExit
         ? TxtParentNode
-        : // <div>\n</div>
-        T extends ASTNodeTypes.HtmlBlock
+          /* ```
+           * code
+           * ```
+           */
+        : T extends ASTNodeTypes.CodeBlock
         ? TxtParentNode
-        : // [link](https://example.com)
-        T extends ASTNodeTypes.Link
+        : T extends ASTNodeTypes.CodeBlockExit
+        ? TxtParentNode // <div>\n</div>
+        : T extends ASTNodeTypes.HtmlBlock
         ? TxtParentNode
-        : // [link][]
-        T extends ASTNodeTypes.ReferenceDef
+        : T extends ASTNodeTypes.HtmlBlockExit
+        ? TxtParentNode // [link](https://example.com)
+        : T extends ASTNodeTypes.Link
         ? TxtParentNode
-        : // ~~Str~~
-        T extends ASTNodeTypes.Delete
+        : T extends ASTNodeTypes.LinkExit
+        ? TxtParentNode // [link][]
+        : T extends ASTNodeTypes.ReferenceDef
         ? TxtParentNode
-        : // *Str*
-        T extends ASTNodeTypes.Emphasis
+        : T extends ASTNodeTypes.ReferenceDefExit
+        ? TxtParentNode // ~~Str~~
+        : T extends ASTNodeTypes.Delete
         ? TxtParentNode
-        : // __Str__
-        T extends ASTNodeTypes.Strong
+        : T extends ASTNodeTypes.DeleteExit
+        ? TxtParentNode // *Str*
+        : T extends ASTNodeTypes.Emphasis
         ? TxtParentNode
-        : // Str<space><space>
-        T extends ASTNodeTypes.Break
+        : T extends ASTNodeTypes.EmphasisExit
+        ? TxtParentNode // __Str__
+        : T extends ASTNodeTypes.Strong
+        ? TxtParentNode
+        : T extends ASTNodeTypes.StrongExit
+        ? TxtParentNode // Str<space><space>
+        : T extends ASTNodeTypes.Break
         ? TxtNode
-        : // ![alt](https://example.com/img)
-        T extends ASTNodeTypes.Image
+        : T extends ASTNodeTypes.BreakExit
+        ? TxtNode // ![alt](https://example.com/img)
+        : T extends ASTNodeTypes.Image
         ? TxtNode
-        : // <!-- Str -->
-        T extends ASTNodeTypes.Comment
+        : T extends ASTNodeTypes.ImageExit
+        ? TxtNode // <!-- Str -->
+        : T extends ASTNodeTypes.Comment
         ? TxtTextNode
-        : // Str
-        T extends ASTNodeTypes.Str
+        : T extends ASTNodeTypes.CommentExit
+        ? TxtTextNode // Str
+        : T extends ASTNodeTypes.Str
         ? TxtTextNode
-        : // `code`
-        T extends ASTNodeTypes.Code
+        : T extends ASTNodeTypes.StrExit
+        ? TxtTextNode // `code`
+        : T extends ASTNodeTypes.Code
         ? TxtTextNode
-        : // <span>Str</span>
-        T extends ASTNodeTypes.Html
+        : T extends ASTNodeTypes.CodeExit
+        ? TxtTextNode // <span>Str</span>
+        : T extends ASTNodeTypes.Html
         ? TxtTextNode
-        : // ----
-        T extends ASTNodeTypes.HorizontalRule
+        : T extends ASTNodeTypes.HtmlExit
+        ? TxtTextNode // ----
+        : T extends ASTNodeTypes.HorizontalRule
+        ? TxtTextNode
+        : T extends ASTNodeTypes.HorizontalRuleExit
         ? TxtTextNode
         : any;

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -10,26 +10,46 @@ import { TypeofTxtNode } from "./TypeofTxtNode";
 
 export enum ASTNodeTypes {
     Document = "Document",
+    DocumentExit = "Document:exit",
     Paragraph = "Paragraph",
+    ParagraphExit = "Paragraph:exit",
     BlockQuote = "BlockQuote",
+    BlockQuoteExit = "BlockQuote:exit",
     ListItem = "ListItem",
+    ListItemExit = "ListItem:exit",
     List = "List",
+    ListExit = "List:exit",
     Header = "Header",
+    HeaderExit = "Header:exit",
     CodeBlock = "CodeBlock",
+    CodeBlockExit = "CodeBlock:exit",
     HtmlBlock = "HtmlBlock",
+    HtmlBlockExit = "HtmlBlock:exit",
     ReferenceDef = "ReferenceDef",
+    ReferenceDefExit = "ReferenceDef:exit",
     HorizontalRule = "HorizontalRule",
+    HorizontalRuleExit = "HorizontalRule:exit",
     Comment = "Comment",
+    CommentExit = "Comment:exit",
     // inline
     Str = "Str",
+    StrExit = "Str:exit",
     Break = "Break", // well-known Hard Break
+    BreakExit = "Break:exit", // well-known Hard Break
     Emphasis = "Emphasis",
+    EmphasisExit = "Emphasis:exit",
     Strong = "Strong",
+    StrongExit = "Strong:exit",
     Html = "Html",
+    HtmlExit = "Html:exit",
     Link = "Link",
+    LinkExit = "Link:exit",
     Image = "Image",
+    ImageExit = "Image:exit",
     Code = "Code",
-    Delete = "Delete"
+    CodeExit = "Code:exit",
+    Delete = "Delete",
+    DeleteExit = "Delete:exit"
 }
 
 /**

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -6,6 +6,8 @@
  * Constant value of types
  * @see https://github.com/textlint/textlint/blob/master/docs/txtnode.md
  */
+import { TypeofTxtNode } from "./TypeofTxtNode";
+
 export enum ASTNodeTypes {
     Document = "Document",
     Paragraph = "Paragraph",
@@ -35,6 +37,12 @@ export enum ASTNodeTypes {
  * For example, TxtNodeType is "Document".
  */
 export type TxtNodeType = keyof typeof ASTNodeTypes | string;
+
+/**
+ * Type utility for TxtNodeType
+ * Return TxtNode interface for the TxtNodeTYpe
+ */
+export { TypeofTxtNode };
 
 /**
  * Any TxtNode types

--- a/packages/@textlint/ast-node-types/test/TextLintASTNodeTypes-test.ts
+++ b/packages/@textlint/ast-node-types/test/TextLintASTNodeTypes-test.ts
@@ -11,4 +11,12 @@ describe("TextLintASTNodeTypes", () => {
             assert.strictEqual(key, value);
         }
     });
+    it("Exit type should have :exit value ", () => {
+        for (let key in ASTNodeTypes) {
+            if (key.includes("Exit")) {
+                const value = ASTNodeTypes[key];
+                assert.ok(value.includes(":exit"), "should includes :exit");
+            }
+        }
+    });
 });

--- a/packages/@textlint/ast-node-types/test/TextLintASTNodeTypes-test.ts
+++ b/packages/@textlint/ast-node-types/test/TextLintASTNodeTypes-test.ts
@@ -7,7 +7,10 @@ import { ASTNodeTypes } from "../src";
 describe("TextLintASTNodeTypes", () => {
     it("should have same value with key", () => {
         for (let key in ASTNodeTypes) {
-            let value = ASTNodeTypes[key];
+            if (key.includes("Exit")) {
+                return;
+            }
+            const value = ASTNodeTypes[key];
             assert.strictEqual(key, value);
         }
     });

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
@@ -1,8 +1,8 @@
 /**
  * Filter rule reporter function
  */
-import { AnyTxtNode, TxtNodeType } from "@textlint/ast-node-types";
 import { TextlintFilterRuleContext } from "./TextlintFilterRuleContext";
+import { TxtNodeType, TypeofTxtNode } from "@textlint/ast-node-types";
 /**
  * textlint filter rule option values is object or boolean.
  * if this option value is false, disable the filter rule.
@@ -14,7 +14,7 @@ export type TextlintFilterRuleOptions = {
 /**
  * Rule Reporter Handler object define handler for each TxtNode type.
  */
-export type TextlintFilterRuleReportHandler = { [P in TxtNodeType]?: (node: AnyTxtNode) => void | Promise<any> };
+export type TextlintFilterRuleReportHandler = { [P in TxtNodeType]?: (node: TypeofTxtNode<P>) => void | Promise<any> };
 
 /**
  * textlint filter rule report function

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -1,17 +1,19 @@
 /**
  * Rule reporter function
  */
-import { AnyTxtNode, TxtNodeType } from "@textlint/ast-node-types";
+import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
 import { TextlintRuleOptions } from "./TextlintRuleOptions";
 import { TextlintRuleContext } from "./TextlintRuleContext";
-
 /**
  * Rule Reporter Handler object define handler for each TxtNode type.
  *
  * Note: *Handler* naming is come from ES Proxy.
  * `new Proxy(target, handler)`
+ *
+ * Each comment is example value of Markdown
  */
-export type TextlintRuleReportHandler = { [P in TxtNodeType]?: (node: AnyTxtNode) => void | Promise<any> };
+export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> };
+
 /**
  * Textlint rule reporter function
  */

--- a/packages/textlint-tester/test/async-test.ts
+++ b/packages/textlint-tester/test/async-test.ts
@@ -1,13 +1,14 @@
 // LICENSE : MIT
 "use strict";
 import TextLintTester = require("../src/index");
+import { TextlintRuleReporter } from "@textlint/types";
 
 const tester = new TextLintTester();
 
-function rule(context: any) {
+const report: TextlintRuleReporter = context => {
     const { Syntax, RuleError, report } = context;
     return {
-        [Syntax.Document](node: any) {
+        [Syntax.Document](node) {
             return new Promise(resolve => {
                 setTimeout(() => {
                     report(node, new RuleError("error"));
@@ -16,9 +17,9 @@ function rule(context: any) {
             });
         }
     };
-}
+};
 
-tester.run("async-rule", rule, {
+tester.run("async-rule", report, {
     invalid: [
         {
             text: "test",

--- a/packages/textlint/test/textlint-core/async-rule-test.ts
+++ b/packages/textlint/test/textlint-core/async-rule-test.ts
@@ -32,7 +32,7 @@ describe("Async", function() {
                             }, 100);
                         });
                     },
-                    [Syntax.Str + ":exit"](node) {
+                    [Syntax.StrExit](node) {
                         report(node, new RuleError("after"));
                     }
                 };


### PR DESCRIPTION
Add `TypeofTxtNode` type function to `"@textlint/ast-node-types"`.
You can get Node type for Type name by `TypeofTxtNode` in TypeScript.

```ts
// In TypeScript
import { ASTNodeTypes } from "@textlint/ast-node-types";
const nodeType = TypeofTxtNode<ASTNodeTypes.Str>; // TxtTextNode
```

These types are defined in `@textlint/ast-node-types`.

| Type name                       | Node type     | Description                          |
| ------------------------------- | ------------- | ------------------------------------ |
| ASTNodeTypes.Document           | TxtParentNode | Root Node                            |
| ASTNodeTypes.DocumentExit       | TxtParentNode |                                      |
| ASTNodeTypes.Paragraph          | TxtParentNode | Paragraph Node                       |
| ASTNodeTypes.ParagraphExit      | TxtParentNode |                                      |
| ASTNodeTypes.BlockQuote         | TxtParentNode | > Block Quote Node                   |
| ASTNodeTypes.BlockQuoteExit     | TxtParentNode |                                      |
| ASTNodeTypes.List               | TxtParentNode | List Node                            |
| ASTNodeTypes.ListExit           | TxtParentNode |                                      |
| ASTNodeTypes.ListItem           | TxtParentNode | List (each) item Node                |
| ASTNodeTypes.ListItemExit       | TxtParentNode |                                      |
| ASTNodeTypes.Header             | TxtParentNode | # Header Node                        |
| ASTNodeTypes.HeaderExit         | TxtParentNode |                                      |
| ASTNodeTypes.CodeBlock          | TxtParentNode | Code Block Node                      |
| ASTNodeTypes.CodeBlockExit      | TxtParentNode |                                      |
| ASTNodeTypes.HtmlBlock          | TxtParentNode | HTML Block Node                      |
| ASTNodeTypes.HtmlBlockExit      | TxtParentNode |                                      |
| ASTNodeTypes.Link               | TxtParentNode | Link Node                            |
| ASTNodeTypes.LinkExit           | TxtParentNode |                                      |
| ASTNodeTypes.ReferenceDef       | TxtParentNode | Link Reference Node(`[link][]`)      |
| ASTNodeTypes.ReferenceDefExit   | TxtParentNode |                                      |
| ASTNodeTypes.Delete             | TxtParentNode | Delete Node(`~Str~`)                 |
| ASTNodeTypes.DeleteExit         | TxtParentNode |                                      |
| ASTNodeTypes.Emphasis           | TxtParentNode | Emphasis(`*Str*`)                    |
| ASTNodeTypes.EmphasisExit       | TxtParentNode |                                      |
| ASTNodeTypes.Strong             | TxtParentNode | Strong Node(`**Str**`)               |
| ASTNodeTypes.StrongExit         | TxtParentNode |                                      |
| ASTNodeTypes.Break              | TxtNode       | Hard Break Node(`Str<space><space>`) |
| ASTNodeTypes.BreakExit          | TxtNode       |                                      |
| ASTNodeTypes.Image              | TxtNode       | Image Node                           |
| ASTNodeTypes.ImageExit          | TxtNode       |                                      |
| ASTNodeTypes.HorizontalRule     | TxtNode       | Horizontal Node(`---`)               |
| ASTNodeTypes.HorizontalRuleExit | TxtNode       |                                      |
| ASTNodeTypes.Comment            | TxtTextNode   | Comment Node                         |
| ASTNodeTypes.CommentExit        | TxtTextNode   |                                      |
| ASTNodeTypes.Str                | TxtTextNode   | Str Node                             |
| ASTNodeTypes.StrExit            | TxtTextNode   |                                      |
| ASTNodeTypes.Code               | TxtTextNode   | Inline Code Node                     |
| ASTNodeTypes.CodeExit           | TxtTextNode   |                                      |
| ASTNodeTypes.Html               | TxtTextNode   | Inline HTML Node                     |
| ASTNodeTypes.HtmlExit           | TxtTextNode   |                                      |


As a result, This PR enhance `TextlintRuleReportHandler` typing.

```ts
const report: TextlintRuleReporter = context => {
    const { Syntax, RuleError, report } = context;
    return {
        [Syntax.Document](node) { // node is TxtParentNode
            return new Promise(resolve => {
                setTimeout(() => {
                    report(node, new RuleError("error"));
                    resolve();
                }, 100);
            });
        }
    };
};
```

Also Add `Exit` typing for `TypeOfTxtNode` type function

fix #267 