### PR TITLE
fix(types): allow other node type for RuleReportHandler

### DIFF
--- a/packages/@textlint/kernel/src/task/textlint-core-task.ts
+++ b/packages/@textlint/kernel/src/task/textlint-core-task.ts
@@ -228,8 +228,8 @@ export default abstract class TextLintCoreTask extends EventEmitter {
                       ruleContext as Readonly<TextlintFilterRuleContext>,
                       ruleOptions
                   );
-        const types = Object.keys(ruleObject) as (keyof typeof ruleObject)[];
-        types.forEach((nodeType: keyof typeof ruleObject) => {
+        const types = Object.keys(ruleObject);
+        types.forEach(nodeType => {
             this.ruleTypeEmitter.on(
                 nodeType,
                 timing.enabled ? timing.time(ruleContext.id, ruleObject[nodeType] as Function) : ruleObject[nodeType]!

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
@@ -2,7 +2,7 @@
  * Filter rule reporter function
  */
 import { TextlintFilterRuleContext } from "./TextlintFilterRuleContext";
-import { TxtNodeType, TypeofTxtNode } from "@textlint/ast-node-types";
+import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
 /**
  * textlint filter rule option values is object or boolean.
  * if this option value is false, disable the filter rule.
@@ -14,7 +14,11 @@ export type TextlintFilterRuleOptions = {
 /**
  * Rule Reporter Handler object define handler for each TxtNode type.
  */
-export type TextlintFilterRuleReportHandler = { [P in TxtNodeType]?: (node: TypeofTxtNode<P>) => void | Promise<any> };
+export type TextlintFilterRuleReportHandler = {
+    [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any>
+} & {
+    [index: string]: (node: any) => void | Promise<any>;
+};
 
 /**
  * textlint filter rule report function

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -12,7 +12,9 @@ import { TextlintRuleContext } from "./TextlintRuleContext";
  *
  * Each comment is example value of Markdown
  */
-export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> };
+export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> } & {
+    [index: string]: (node: any) => void | Promise<any>;
+};
 
 /**
  * Textlint rule reporter function

--- a/packages/textlint-tester/test/async-test.ts
+++ b/packages/textlint-tester/test/async-test.ts
@@ -8,6 +8,9 @@ const tester = new TextLintTester();
 const report: TextlintRuleReporter = context => {
     const { Syntax, RuleError, report } = context;
     return {
+        ["my other type"](_node) {
+            throw new Error("DO NOT CALL");
+        },
         [Syntax.Document](node) {
             return new Promise(resolve => {
                 setTimeout(() => {


### PR DESCRIPTION
Follow below case

```js
module.exports = (context) => {
  return {
    "my-type"(node){}
  }
}
```