### PR TITLE
Release textlint@11.2.1

### DIFF
--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-cli@2.1.1...textlint-example-cli@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-cli
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-cli@2.1.0...textlint-example-cli@2.1.1) (2019-01-03)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-cli",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint --rule no-todo '*.md'"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/config-file/CHANGELOG.md
+++ b/examples/config-file/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.1.1...textlint-example-config-file@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-config-file
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.1.0...textlint-example-config-file@2.1.1) (2019-01-03)
 

--- a/examples/config-file/package.json
+++ b/examples/config-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-file",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/filter/CHANGELOG.md
+++ b/examples/filter/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-filter@2.1.1...textlint-example-filter@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-filter
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-filter@2.1.0...textlint-example-filter@2.1.1) (2019-01-03)
 

--- a/examples/filter/package.json
+++ b/examples/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-filter",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "filter rule example",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.1"
   }

--- a/examples/fix-dry-run/CHANGELOG.md
+++ b/examples/fix-dry-run/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.1.1...textlint-example-fix-dry-run@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-fix-dry-run
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.1.0...textlint-example-fix-dry-run@2.1.1) (2019-01-03)
 

--- a/examples/fix-dry-run/package.json
+++ b/examples/fix-dry-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix-dry-run",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix --dry-run README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/fix/CHANGELOG.md
+++ b/examples/fix/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-fix@2.1.1...textlint-example-fix@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-fix
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-fix@2.1.0...textlint-example-fix@2.1.1) (2019-01-03)
 

--- a/examples/fix/package.json
+++ b/examples/fix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/html-plugin/CHANGELOG.md
+++ b/examples/html-plugin/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.1.1...textlint-example-html-plugin@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-html-plugin
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.1.0...textlint-example-html-plugin@2.1.1) (2019-01-03)
 

--- a/examples/html-plugin/package.json
+++ b/examples/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-html-plugin",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "textlint": "textlint -f pretty-error index.html"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-plugin-html": "^0.1.7",
     "textlint-rule-sentence-length": "^2.1.1"
   }

--- a/examples/perf/CHANGELOG.md
+++ b/examples/perf/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-perf-test@2.1.1...textlint-perf-test@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-perf-test
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-perf-test@2.1.0...textlint-perf-test@2.1.1) (2019-01-03)
 

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-perf-test",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "shelljs": "^0.8.1",
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-plugin-jtf-style": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",

--- a/examples/plugin-extensions-option/CHANGELOG.md
+++ b/examples/plugin-extensions-option/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.1.1...textlint-example-plugin-extensions-option@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-plugin-extensions-option
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.1.0...textlint-example-plugin-extensions-option@2.1.1) (2019-01-03)
 

--- a/examples/plugin-extensions-option/package.json
+++ b/examples/plugin-extensions-option/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-plugin-extensions-option",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "expected-exit-status": "^1.0.2",
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/preset/CHANGELOG.md
+++ b/examples/preset/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-preset@2.1.1...textlint-example-preset@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-preset
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-preset@2.1.0...textlint-example-preset@2.1.1) (2019-01-03)
 

--- a/examples/preset/package.json
+++ b/examples/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-preset",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-preset-jtf-style": "^2.3.2"
   }
 }

--- a/examples/rulesdir/CHANGELOG.md
+++ b/examples/rulesdir/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.1.1...textlint-example-rulesdir@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-rulesdir
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.1.0...textlint-example-rulesdir@2.1.1) (2019-01-03)
 

--- a/examples/rulesdir/package.json
+++ b/examples/rulesdir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-rulesdir",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,6 +12,6 @@
     "textlint": "textlint --rulesdir ./rules README.md"
   },
   "devDependencies": {
-    "textlint": "^11.2.0"
+    "textlint": "^11.2.1"
   }
 }

--- a/examples/use-as-module/CHANGELOG.md
+++ b/examples/use-as-module/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.1.1...textlint-example-use-as-module@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-use-as-module
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.1.0...textlint-example-use-as-module@2.1.1) (2019-01-03)
 

--- a/examples/use-as-module/package.json
+++ b/examples/use-as-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-module",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/use-as-ts-module/CHANGELOG.md
+++ b/examples/use-as-ts-module/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.2.2"></a>
+## [2.2.2](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.2.1...textlint-example-use-as-ts-module@2.2.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-example-use-as-ts-module
+
+
+
+
+
 <a name="2.2.1"></a>
 ## [2.2.1](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.2.0...textlint-example-use-as-ts-module@2.2.1) (2019-01-03)
 

--- a/examples/use-as-ts-module/package.json
+++ b/examples/use-as-ts-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-ts-module",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "license": "MIT",
   "author": "0x6b",
@@ -14,7 +14,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.1"
   },

--- a/packages/@textlint/ast-node-types/CHANGELOG.md
+++ b/packages/@textlint/ast-node-types/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.2.1"></a>
+## [4.2.1](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.2.0...@textlint/ast-node-types@4.2.1) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/ast-node-types
+
+
+
+
+
 <a name="4.2.0"></a>
 # [4.2.0](https://github.com/textlint/textlint/compare/@textlint/ast-node-types@4.1.0...@textlint/ast-node-types@4.2.0) (2019-01-03)
 

--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-node-types",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "textlint AST node type definition.",
   "keywords": [
     "textlint"

--- a/packages/@textlint/ast-tester/CHANGELOG.md
+++ b/packages/@textlint/ast-tester/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.1.1...@textlint/ast-tester@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/ast-tester
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/@textlint/ast-tester@2.1.0...@textlint/ast-tester@2.1.1) (2019-01-03)
 

--- a/packages/@textlint/ast-tester/package.json
+++ b/packages/@textlint/ast-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-tester",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Compliance tests for textlint's AST(Abstract Syntax Tree).",
   "keywords": [
     "ast",
@@ -36,7 +36,7 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0"
+    "@textlint/ast-node-types": "^4.2.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/packages/@textlint/ast-traverse/CHANGELOG.md
+++ b/packages/@textlint/ast-traverse/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.1.1...@textlint/ast-traverse@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/ast-traverse
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/@textlint/ast-traverse@2.1.0...@textlint/ast-traverse@2.1.1) (2019-01-03)
 

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/ast-traverse",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "TxtNode traverse library",
   "keywords": [
     "AST",
@@ -32,10 +32,10 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0"
+    "@textlint/ast-node-types": "^4.2.1"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.1.1",
+    "@textlint/markdown-to-ast": "^6.1.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "cross-env": "^5.2.0",

--- a/packages/@textlint/feature-flag/CHANGELOG.md
+++ b/packages/@textlint/feature-flag/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/textlint/textlint/compare/@textlint/feature-flag@3.1.1...@textlint/feature-flag@3.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/feature-flag
+
+
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/textlint/textlint/compare/@textlint/feature-flag@3.1.0...@textlint/feature-flag@3.1.1) (2019-01-03)
 

--- a/packages/@textlint/feature-flag/package.json
+++ b/packages/@textlint/feature-flag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/feature-flag",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "textlint internal feature flag manager.",
   "keywords": [
     "textlint"

--- a/packages/@textlint/fixer-formatter/CHANGELOG.md
+++ b/packages/@textlint/fixer-formatter/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.1.1...@textlint/fixer-formatter@3.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/fixer-formatter
+
+
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.1.0...@textlint/fixer-formatter@3.1.1) (2019-01-03)
 

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/fixer-formatter",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "textlint output formatter for fixer",
   "keywords": [
     "AST",
@@ -34,7 +34,7 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/types": "^1.1.1",
+    "@textlint/types": "^1.1.2",
     "chalk": "^1.1.3",
     "debug": "^4.1.1",
     "diff": "^2.2.2",

--- a/packages/@textlint/kernel/CHANGELOG.md
+++ b/packages/@textlint/kernel/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/textlint/textlint/compare/@textlint/kernel@3.1.1...@textlint/kernel@3.1.2) (2019-01-03)
+
+
+### Bug Fixes
+
+* **textlint:** fix internal typing ([e2fde6c](https://github.com/textlint/textlint/commit/e2fde6c))
+
+
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/textlint/textlint/compare/@textlint/kernel@3.1.0...@textlint/kernel@3.1.1) (2019-01-03)
 

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/kernel",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "textlint kernel is core logic by pure JavaScript.",
   "keywords": [
     "textlint"
@@ -32,10 +32,10 @@
     "test": "mocha \"test/**/*.{js,ts}\""
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0",
-    "@textlint/ast-traverse": "^2.1.1",
-    "@textlint/feature-flag": "^3.1.1",
-    "@textlint/types": "^1.1.1",
+    "@textlint/ast-node-types": "^4.2.1",
+    "@textlint/ast-traverse": "^2.1.2",
+    "@textlint/feature-flag": "^3.1.2",
+    "@textlint/types": "^1.1.2",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.5.1",
     "debug": "^4.1.1",
@@ -45,7 +45,7 @@
     "structured-source": "^3.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.1.1",
+    "@textlint/markdown-to-ast": "^6.1.2",
     "@types/deep-equal": "^1.0.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",

--- a/packages/@textlint/linter-formatter/CHANGELOG.md
+++ b/packages/@textlint/linter-formatter/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.1.1...@textlint/linter-formatter@3.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/linter-formatter
+
+
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.1.0...@textlint/linter-formatter@3.1.1) (2019-01-03)
 

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/linter-formatter",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "textlint output formatter",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/linter-formatter",
   "bugs": {
@@ -33,7 +33,7 @@
   "dependencies": {
     "@azu/format-text": "^1.0.1",
     "@azu/style-format": "^1.0.0",
-    "@textlint/types": "^1.1.1",
+    "@textlint/types": "^1.1.2",
     "chalk": "^1.0.0",
     "concat-stream": "^1.5.1",
     "js-yaml": "^3.2.4",

--- a/packages/@textlint/markdown-to-ast/CHANGELOG.md
+++ b/packages/@textlint/markdown-to-ast/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="6.1.2"></a>
+## [6.1.2](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.1.1...@textlint/markdown-to-ast@6.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/markdown-to-ast
+
+
+
+
+
 <a name="6.1.1"></a>
 ## [6.1.1](https://github.com/textlint/textlint/compare/@textlint/markdown-to-ast@6.1.0...@textlint/markdown-to-ast@6.1.1) (2019-01-03)
 

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/markdown-to-ast",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Parse Markdown to AST with location info.",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast/",
   "bugs": {
@@ -29,7 +29,7 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0",
+    "@textlint/ast-node-types": "^4.2.1",
     "debug": "^4.1.1",
     "remark-frontmatter": "^1.2.0",
     "remark-parse": "^5.0.0",
@@ -38,7 +38,7 @@
     "unified": "^6.1.6"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.1.1",
+    "@textlint/ast-tester": "^2.1.2",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/text-to-ast/CHANGELOG.md
+++ b/packages/@textlint/text-to-ast/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.2"></a>
+## [3.1.2](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.1.1...@textlint/text-to-ast@3.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/text-to-ast
+
+
+
+
+
 <a name="3.1.1"></a>
 ## [3.1.1](https://github.com/textlint/textlint/compare/@textlint/text-to-ast@3.1.0...@textlint/text-to-ast@3.1.1) (2019-01-03)
 

--- a/packages/@textlint/text-to-ast/package.json
+++ b/packages/@textlint/text-to-ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/text-to-ast",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Parse plain text to AST with location info.",
   "keywords": [
     "ast",
@@ -35,10 +35,10 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0"
+    "@textlint/ast-node-types": "^4.2.1"
   },
   "devDependencies": {
-    "@textlint/ast-tester": "^2.1.1",
+    "@textlint/ast-tester": "^2.1.2",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-markdown/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.2"></a>
+## [5.1.2](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@5.1.1...@textlint/textlint-plugin-markdown@5.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/textlint-plugin-markdown
+
+
+
+
+
 <a name="5.1.1"></a>
 ## [5.1.1](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-markdown@5.1.0...@textlint/textlint-plugin-markdown@5.1.1) (2019-01-03)
 

--- a/packages/@textlint/textlint-plugin-markdown/package.json
+++ b/packages/@textlint/textlint-plugin-markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-markdown",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Markdown support for textlint.",
   "keywords": [
     "markdown",
@@ -33,10 +33,10 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/markdown-to-ast": "^6.1.1"
+    "@textlint/markdown-to-ast": "^6.1.2"
   },
   "devDependencies": {
-    "@textlint/kernel": "^3.1.1",
+    "@textlint/kernel": "^3.1.2",
     "babel-cli": "^6.5.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/textlint-plugin-text/CHANGELOG.md
+++ b/packages/@textlint/textlint-plugin-text/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="4.1.2"></a>
+## [4.1.2](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@4.1.1...@textlint/textlint-plugin-text@4.1.2) (2019-01-03)
+
+**Note:** Version bump only for package @textlint/textlint-plugin-text
+
+
+
+
+
 <a name="4.1.1"></a>
 ## [4.1.1](https://github.com/textlint/textlint/compare/@textlint/textlint-plugin-text@4.1.0...@textlint/textlint-plugin-text@4.1.1) (2019-01-03)
 

--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/textlint-plugin-text",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "plain text plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/textlint-plugin-text/",
   "bugs": {
@@ -29,10 +29,10 @@
     "watch": "babel src --out-dir lib --watch --source-maps"
   },
   "dependencies": {
-    "@textlint/text-to-ast": "^3.1.1"
+    "@textlint/text-to-ast": "^3.1.2"
   },
   "devDependencies": {
-    "@textlint/kernel": "^3.1.1",
+    "@textlint/kernel": "^3.1.2",
     "babel-cli": "^6.24.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-jsdoc-to-assert": "^4.0.0",

--- a/packages/@textlint/types/CHANGELOG.md
+++ b/packages/@textlint/types/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="1.1.2"></a>
+## [1.1.2](https://github.com/textlint/textlint/compare/@textlint/types@1.1.1...@textlint/types@1.1.2) (2019-01-03)
+
+
+### Bug Fixes
+
+* **types:** allow other node type for RuleReportHandler ([fbc73e7](https://github.com/textlint/textlint/commit/fbc73e7))
+
+
+
+
+
 <a name="1.1.1"></a>
 ## [1.1.1](https://github.com/textlint/textlint/compare/@textlint/types@1.1.0...@textlint/types@1.1.1) (2019-01-03)
 

--- a/packages/@textlint/types/package.json
+++ b/packages/@textlint/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/types",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Type definition package for textlint",
   "keywords": [
     "definition",
@@ -42,11 +42,11 @@
     "tabWidth": 4
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0",
+    "@textlint/ast-node-types": "^4.2.1",
     "structured-source": "^3.0.2"
   },
   "devDependencies": {
-    "@textlint/markdown-to-ast": "^6.1.1",
+    "@textlint/markdown-to-ast": "^6.1.2",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.18",
     "@types/structured-source": "^3.0.0",

--- a/packages/gulp-textlint/CHANGELOG.md
+++ b/packages/gulp-textlint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.2"></a>
+## [5.1.2](https://github.com/textlint/textlint/compare/gulp-textlint@5.1.1...gulp-textlint@5.1.2) (2019-01-03)
+
+**Note:** Version bump only for package gulp-textlint
+
+
+
+
+
 <a name="5.1.1"></a>
 ## [5.1.1](https://github.com/textlint/textlint/compare/gulp-textlint@5.1.0...gulp-textlint@5.1.1) (2019-01-03)
 

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-textlint",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "gulp plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "bugs": {
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.0.1",
     "plugin-error": "^1.0.1",
     "prettier": "^1.7.4",
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/textlint-tester/CHANGELOG.md
+++ b/packages/textlint-tester/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.2"></a>
+## [5.1.2](https://github.com/textlint/textlint/compare/textlint-tester@5.1.1...textlint-tester@5.1.2) (2019-01-03)
+
+
+### Tests
+
+* **tester:** add other type test ([2a3b55f](https://github.com/textlint/textlint/commit/2a3b55f))
+
+
+
+
+
 <a name="5.1.1"></a>
 ## [5.1.1](https://github.com/textlint/textlint/compare/textlint-tester@5.1.0...textlint-tester@5.1.1) (2019-01-03)
 

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-tester",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "testing tool for textlint rule.",
   "keywords": [
     "test",
@@ -34,9 +34,9 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/feature-flag": "^3.1.1",
-    "@textlint/kernel": "^3.1.1",
-    "textlint": "^11.2.0"
+    "@textlint/feature-flag": "^3.1.2",
+    "@textlint/kernel": "^3.1.2",
+    "textlint": "^11.2.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",

--- a/packages/textlint/CHANGELOG.md
+++ b/packages/textlint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="11.2.1"></a>
+## [11.2.1](https://github.com/textlint/textlint/compare/textlint@11.2.0...textlint@11.2.1) (2019-01-03)
+
+**Note:** Version bump only for package textlint
+
+
+
+
+
 <a name="11.2.0"></a>
 # [11.2.0](https://github.com/textlint/textlint/compare/textlint@11.1.0...textlint@11.2.0) (2019-01-03)
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "description": "The pluggable linting tool for text and markdown.",
   "keywords": [
     "AST",
@@ -48,14 +48,14 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@textlint/ast-node-types": "^4.2.0",
-    "@textlint/ast-traverse": "^2.1.1",
-    "@textlint/feature-flag": "^3.1.1",
-    "@textlint/fixer-formatter": "^3.1.1",
-    "@textlint/kernel": "^3.1.1",
-    "@textlint/linter-formatter": "^3.1.1",
-    "@textlint/textlint-plugin-markdown": "^5.1.1",
-    "@textlint/textlint-plugin-text": "^4.1.1",
+    "@textlint/ast-node-types": "^4.2.1",
+    "@textlint/ast-traverse": "^2.1.2",
+    "@textlint/feature-flag": "^3.1.2",
+    "@textlint/fixer-formatter": "^3.1.2",
+    "@textlint/kernel": "^3.1.2",
+    "@textlint/linter-formatter": "^3.1.2",
+    "@textlint/textlint-plugin-markdown": "^5.1.2",
+    "@textlint/textlint-plugin-text": "^4.1.2",
     "@types/bluebird": "^3.5.18",
     "bluebird": "^3.0.5",
     "debug": "^4.1.1",

--- a/test/integration-test/CHANGELOG.md
+++ b/test/integration-test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.2"></a>
+## [2.1.2](https://github.com/textlint/textlint/compare/integration-test@2.1.1...integration-test@2.1.2) (2019-01-03)
+
+**Note:** Version bump only for package integration-test
+
+
+
+
+
 <a name="2.1.1"></a>
 ## [2.1.1](https://github.com/textlint/textlint/compare/integration-test@2.1.0...integration-test@2.1.1) (2019-01-03)
 

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-test",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "textlint testbot sandbox.",
   "keywords": [
@@ -35,7 +35,7 @@
   "devDependencies": {
     "json5": "^2.1.0",
     "shelljs": "^0.8.3",
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlintrc-to-pacakge-list": "^1.2.0"
   },
   "email": "azuciao@gmail.com"

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.7.2"></a>
+## [10.7.2](https://github.com/textlint/textlint/compare/textlint-website@10.7.1...textlint-website@10.7.2) (2019-01-03)
+
+**Note:** Version bump only for package textlint-website
+
+
+
+
+
 <a name="10.7.1"></a>
 ## [10.7.1](https://github.com/textlint/textlint/compare/textlint-website@10.7.0...textlint-website@10.7.1) (2019-01-03)
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-website",
-  "version": "10.7.1",
+  "version": "10.7.2",
   "private": true,
   "homepage": "https://github.com/textlint/textlint/",
   "bugs": {
@@ -28,7 +28,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-prettier": "^3.0.1",
     "npm-run-all": "^4.1.5",
-    "textlint": "^11.2.0",
+    "textlint": "^11.2.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-eslint": "^3.1.0",
     "textlint-rule-no-dead-link": "^4.3.0",


### PR DESCRIPTION
This release includes typing fixes only.
No change API from textlint@11.2.0.

## @textlint/types@1.1.2

### fixes

- **types:** allow other node type for RuleReportHandler ([fbc73e7](https://github.com/textlint/textlint/commit/fbc73e7))


---

## All versions

 - textlint-example-cli@2.1.2
 - textlint-example-config-file@2.1.2
 - textlint-example-filter@2.1.2
 - textlint-example-fix-dry-run@2.1.2
 - textlint-example-fix@2.1.2
 - textlint-example-html-plugin@2.1.2
 - textlint-perf-test@2.1.2
 - textlint-example-plugin-extensions-option@2.1.2
 - textlint-example-preset@2.1.2
 - textlint-example-rulesdir@2.1.2
 - textlint-example-use-as-module@2.1.2
 - textlint-example-use-as-ts-module@2.2.2
 - gulp-textlint@5.1.2
 - textlint-tester@5.1.2
 - textlint@11.2.1
 - @textlint/ast-node-types@4.2.1
 - @textlint/ast-tester@2.1.2
 - @textlint/ast-traverse@2.1.2
 - @textlint/feature-flag@3.1.2
 - @textlint/fixer-formatter@3.1.2
 - @textlint/kernel@3.1.2
 - @textlint/linter-formatter@3.1.2
 - @textlint/markdown-to-ast@6.1.2
 - @textlint/text-to-ast@3.1.2
 - @textlint/textlint-plugin-markdown@5.1.2
 - @textlint/textlint-plugin-text@4.1.2
 - @textlint/types@1.1.2
 - integration-test@2.1.2
 - textlint-website@10.7.2