### PR TITLE
docs(use-as-modules): remove unnecessary char

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -42,7 +42,7 @@ Recommend to use `TextLintEngine`.
 
 ## Architecture
 
-See <https://github.com/textlint/textlint/blob/master/packages/textlint/src/README.md>>
+See <https://github.com/textlint/textlint/blob/master/packages/textlint/src/README.md>
 
 ### CLI(Command Line Interface)
 


### PR DESCRIPTION
## About

I think there is no need for this character

<img width="753" alt="screenshot" src="https://user-images.githubusercontent.com/10488/55118642-57841780-5132-11e9-8c3a-afe40c44cbf9.png">