### PR TITLE
fix(textlint): fix crypto's DeprecationWarning

### DIFF
--- a/packages/textlint/src/config/config.ts
+++ b/packages/textlint/src/config/config.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import * as crypto from "crypto";
+import crypto from "crypto";
 import { loadConfig } from "./config-loader";
 import { createFlatRulesConfigFromRawRulesConfig, loadRulesConfigFromPresets } from "./preset-loader";
 import { getPluginConfig, getPluginNames } from "./plugin-loader";


### PR DESCRIPTION
Supress following waring on running textlint.
```
(node:68450) [DEP0091] DeprecationWarning: crypto.DEFAULT_ENCODING is deprecated.
(node:68450) [DEP0010] DeprecationWarning: crypto.createCredentials is deprecated. Use tls.createSecureContext instead.
(node:68450) [DEP0011] DeprecationWarning: crypto.Credentials is deprecated. Use tls.SecureContext instead.
```
fix #620 