### PR TITLE
Publish: @textlint/linter-formatter@3.1.11

### DIFF
--- a/examples/cli/CHANGELOG.md
+++ b/examples/cli/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-cli@2.1.12...textlint-example-cli@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-cli
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-cli@2.1.10...textlint-example-cli@2.1.12) (2020-01-07)
 

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-cli",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint --rule no-todo '*.md'"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/config-file/CHANGELOG.md
+++ b/examples/config-file/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.1.12...textlint-example-config-file@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-config-file
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-config-file@2.1.10...textlint-example-config-file@2.1.12) (2020-01-07)
 

--- a/examples/config-file/package.json
+++ b/examples/config-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-file",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/config-in-package-json/CHANGELOG.md
+++ b/examples/config-in-package-json/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-config-in-package-json@2.1.12...textlint-example-config-in-package-json@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-config-in-package-json
+
+
+
+
+
 <a name="2.1.12"></a>
 ## 2.1.12 (2020-01-07)
 

--- a/examples/config-in-package-json/package.json
+++ b/examples/config-in-package-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-config-in-package-json",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-todo": "^2.0.1"
   },
   "textlint": {

--- a/examples/filter/CHANGELOG.md
+++ b/examples/filter/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-filter@2.1.12...textlint-example-filter@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-filter
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-filter@2.1.10...textlint-example-filter@2.1.12) (2020-01-07)
 

--- a/examples/filter/package.json
+++ b/examples/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-filter",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "filter rule example",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.1"
   }

--- a/examples/fix-dry-run/CHANGELOG.md
+++ b/examples/fix-dry-run/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.1.12...textlint-example-fix-dry-run@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-fix-dry-run
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-fix-dry-run@2.1.10...textlint-example-fix-dry-run@2.1.12) (2020-01-07)
 

--- a/examples/fix-dry-run/package.json
+++ b/examples/fix-dry-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix-dry-run",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix --dry-run README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/fix/CHANGELOG.md
+++ b/examples/fix/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-fix@2.1.12...textlint-example-fix@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-fix
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-fix@2.1.10...textlint-example-fix@2.1.12) (2020-01-07)
 

--- a/examples/fix/package.json
+++ b/examples/fix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-fix",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "textlint-fix": "textlint --fix README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-prh": "^5.2.0"
   }
 }

--- a/examples/html-plugin/CHANGELOG.md
+++ b/examples/html-plugin/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.2.3"></a>
+## [2.2.3](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.2.2...textlint-example-html-plugin@2.2.3) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-html-plugin
+
+
+
+
+
 <a name="2.2.2"></a>
 ## [2.2.2](https://github.com/textlint/textlint/compare/textlint-example-html-plugin@2.2.0...textlint-example-html-plugin@2.2.2) (2020-01-07)
 

--- a/examples/html-plugin/package.json
+++ b/examples/html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-html-plugin",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "textlint": "textlint -f pretty-error index.html"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-plugin-html": "^0.2.0",
     "textlint-rule-sentence-length": "^2.1.2"
   }

--- a/examples/perf/CHANGELOG.md
+++ b/examples/perf/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-perf-test@2.1.12...textlint-perf-test@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-perf-test
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-perf-test@2.1.10...textlint-perf-test@2.1.12) (2020-01-07)
 

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-perf-test",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "shelljs": "^0.8.1",
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-plugin-jtf-style": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.3",
     "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",

--- a/examples/plugin-extensions-option/CHANGELOG.md
+++ b/examples/plugin-extensions-option/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.1.12...textlint-example-plugin-extensions-option@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-plugin-extensions-option
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-plugin-extensions-option@2.1.10...textlint-example-plugin-extensions-option@2.1.12) (2020-01-07)
 

--- a/examples/plugin-extensions-option/package.json
+++ b/examples/plugin-extensions-option/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-plugin-extensions-option",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "expected-exit-status": "^1.0.2",
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/preset/CHANGELOG.md
+++ b/examples/preset/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-preset@2.1.12...textlint-example-preset@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-preset
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-preset@2.1.10...textlint-example-preset@2.1.12) (2020-01-07)
 

--- a/examples/preset/package.json
+++ b/examples/preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-preset",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,7 +12,7 @@
     "textlint": "textlint -f pretty-error README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-preset-jtf-style": "^2.3.2"
   }
 }

--- a/examples/rulesdir/CHANGELOG.md
+++ b/examples/rulesdir/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.1.12...textlint-example-rulesdir@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-rulesdir
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-rulesdir@2.1.10...textlint-example-rulesdir@2.1.12) (2020-01-07)
 

--- a/examples/rulesdir/package.json
+++ b/examples/rulesdir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-rulesdir",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "",
   "license": "MIT",
@@ -12,6 +12,6 @@
     "textlint": "textlint --rulesdir ./rules README.md"
   },
   "devDependencies": {
-    "textlint": "^11.6.0"
+    "textlint": "^11.6.1"
   }
 }

--- a/examples/use-as-module/CHANGELOG.md
+++ b/examples/use-as-module/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.1.12...textlint-example-use-as-module@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-use-as-module
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/textlint-example-use-as-module@2.1.10...textlint-example-use-as-module@2.1.12) (2020-01-07)
 

--- a/examples/use-as-module/package.json
+++ b/examples/use-as-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-module",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "license": "MIT",
   "author": "azu",
@@ -10,7 +10,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-todo": "^2.0.1"
   }
 }

--- a/examples/use-as-ts-module/CHANGELOG.md
+++ b/examples/use-as-ts-module/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.2.13"></a>
+## [2.2.13](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.2.12...textlint-example-use-as-ts-module@2.2.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-example-use-as-ts-module
+
+
+
+
+
 <a name="2.2.12"></a>
 ## [2.2.12](https://github.com/textlint/textlint/compare/textlint-example-use-as-ts-module@2.2.10...textlint-example-use-as-ts-module@2.2.12) (2020-01-07)
 

--- a/examples/use-as-ts-module/package.json
+++ b/examples/use-as-ts-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-example-use-as-ts-module",
-  "version": "2.2.12",
+  "version": "2.2.13",
   "private": true,
   "license": "MIT",
   "author": "0x6b",
@@ -14,7 +14,7 @@
     "test:ci": "npm test"
   },
   "dependencies": {
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-rule-no-exclamation-question-mark": "^1.0.2",
     "textlint-rule-no-todo": "^2.0.1"
   },

--- a/packages/@textlint/fixer-formatter/CHANGELOG.md
+++ b/packages/@textlint/fixer-formatter/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.12"></a>
+## [3.1.12](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.1.11...@textlint/fixer-formatter@3.1.12) (2020-01-08)
+
+
+### Tests
+
+* **fixer-formatter:** use strip-ansi for --no-color ([ddc53b2](https://github.com/textlint/textlint/commit/ddc53b2))
+
+
+
+
+
 <a name="3.1.11"></a>
 ## [3.1.11](https://github.com/textlint/textlint/compare/@textlint/fixer-formatter@3.1.9...@textlint/fixer-formatter@3.1.11) (2020-01-07)
 

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/fixer-formatter",
-  "version": "3.1.11",
+  "version": "3.1.12",
   "description": "textlint output formatter for fixer",
   "keywords": [
     "AST",
@@ -41,9 +41,9 @@
     "diff": "^4.0.1",
     "is-file": "^1.0.0",
     "string-width": "^1.0.1",
+    "strip-ansi": "^6.0.0",
     "text-table": "^0.2.0",
-    "try-resolve": "^1.0.1",
-    "strip-ansi": "^6.0.0"
+    "try-resolve": "^1.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",

--- a/packages/@textlint/linter-formatter/CHANGELOG.md
+++ b/packages/@textlint/linter-formatter/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="3.1.11"></a>
+## [3.1.11](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.1.10...@textlint/linter-formatter@3.1.11) (2020-01-08)
+
+
+### Bug Fixes
+
+* **linter-formatter:** add missing dependencies ([5501a42](https://github.com/textlint/textlint/commit/5501a42))
+* **linter-formatter:** fix --no-color support ([6cbfb1f](https://github.com/textlint/textlint/commit/6cbfb1f))
+
+
+### Chores
+
+* **deps:** update yarn.lock ([2f6fa9e](https://github.com/textlint/textlint/commit/2f6fa9e))
+* **linter-formatter:** move path ([98ff781](https://github.com/textlint/textlint/commit/98ff781))
+
+
+### Tests
+
+* **liner-formatter:** pass { color: false } ([fe3c2df](https://github.com/textlint/textlint/commit/fe3c2df))
+
+
+
+
+
 <a name="3.1.10"></a>
 ## [3.1.10](https://github.com/textlint/textlint/compare/@textlint/linter-formatter@3.1.8...@textlint/linter-formatter@3.1.10) (2020-01-07)
 

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textlint/linter-formatter",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "description": "textlint output formatter",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/linter-formatter",
   "bugs": {

--- a/packages/gulp-textlint/CHANGELOG.md
+++ b/packages/gulp-textlint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.14"></a>
+## [5.1.14](https://github.com/textlint/textlint/compare/gulp-textlint@5.1.13...gulp-textlint@5.1.14) (2020-01-08)
+
+**Note:** Version bump only for package gulp-textlint
+
+
+
+
+
 <a name="5.1.13"></a>
 ## [5.1.13](https://github.com/textlint/textlint/compare/gulp-textlint@5.1.11...gulp-textlint@5.1.13) (2020-01-07)
 

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-textlint",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "description": "gulp plugin for textlint",
   "homepage": "https://github.com/textlint/textlint/tree/master/packages/gulp-textlint",
   "bugs": {
@@ -22,7 +22,7 @@
   "dependencies": {
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.1",
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/textlint-tester/CHANGELOG.md
+++ b/packages/textlint-tester/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="5.1.13"></a>
+## [5.1.13](https://github.com/textlint/textlint/compare/textlint-tester@5.1.12...textlint-tester@5.1.13) (2020-01-08)
+
+**Note:** Version bump only for package textlint-tester
+
+
+
+
+
 <a name="5.1.12"></a>
 ## [5.1.12](https://github.com/textlint/textlint/compare/textlint-tester@5.1.10...textlint-tester@5.1.12) (2020-01-07)
 

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-tester",
-  "version": "5.1.12",
+  "version": "5.1.13",
   "description": "testing tool for textlint rule.",
   "keywords": [
     "test",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@textlint/feature-flag": "^3.1.6",
     "@textlint/kernel": "^3.2.0",
-    "textlint": "^11.6.0"
+    "textlint": "^11.6.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.6",

--- a/packages/textlint/CHANGELOG.md
+++ b/packages/textlint/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="11.6.1"></a>
+## [11.6.1](https://github.com/textlint/textlint/compare/textlint@11.6.0...textlint@11.6.1) (2020-01-08)
+
+**Note:** Version bump only for package textlint
+
+
+
+
+
 <a name="11.6.0"></a>
 # [11.6.0](https://github.com/textlint/textlint/compare/textlint@11.4.0...textlint@11.6.0) (2020-01-07)
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint",
-  "version": "11.6.0",
+  "version": "11.6.1",
   "description": "The pluggable linting tool for text and markdown.",
   "keywords": [
     "AST",
@@ -54,9 +54,9 @@
     "@textlint/ast-node-types": "^4.2.5",
     "@textlint/ast-traverse": "^2.1.6",
     "@textlint/feature-flag": "^3.1.6",
-    "@textlint/fixer-formatter": "^3.1.11",
+    "@textlint/fixer-formatter": "^3.1.12",
     "@textlint/kernel": "^3.2.0",
-    "@textlint/linter-formatter": "^3.1.10",
+    "@textlint/linter-formatter": "^3.1.11",
     "@textlint/module-interop": "^1.0.2",
     "@textlint/textlint-plugin-markdown": "^5.1.11",
     "@textlint/textlint-plugin-text": "^4.1.11",

--- a/test/integration-test/CHANGELOG.md
+++ b/test/integration-test/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.1.13"></a>
+## [2.1.13](https://github.com/textlint/textlint/compare/integration-test@2.1.12...integration-test@2.1.13) (2020-01-08)
+
+**Note:** Version bump only for package integration-test
+
+
+
+
+
 <a name="2.1.12"></a>
 ## [2.1.12](https://github.com/textlint/textlint/compare/integration-test@2.1.10...integration-test@2.1.12) (2020-01-07)
 

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-test",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "private": true,
   "description": "textlint testbot sandbox.",
   "keywords": [
@@ -35,7 +35,7 @@
   "devDependencies": {
     "json5": "^2.1.1",
     "shelljs": "^0.8.3",
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlintrc-to-pacakge-list": "^1.2.0"
   },
   "email": "azuciao@gmail.com"

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="10.8.3"></a>
+## [10.8.3](https://github.com/textlint/textlint/compare/textlint-website@10.8.2...textlint-website@10.8.3) (2020-01-08)
+
+**Note:** Version bump only for package textlint-website
+
+
+
+
+
 <a name="10.8.2"></a>
 ## [10.8.2](https://github.com/textlint/textlint/compare/textlint-website@10.8.0...textlint-website@10.8.2) (2020-01-07)
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-website",
-  "version": "10.8.2",
+  "version": "10.8.3",
   "private": true,
   "homepage": "https://github.com/textlint/textlint/",
   "bugs": {
@@ -29,7 +29,7 @@
     "eslint-config-prettier": "^6.4.0",
     "eslint-plugin-prettier": "^3.1.1",
     "npm-run-all": "^4.1.5",
-    "textlint": "^11.6.0",
+    "textlint": "^11.6.1",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-eslint": "^3.2.1",
     "textlint-rule-no-dead-link": "^4.6.1",


### PR DESCRIPTION
## @textlint/linter-formatter@3.1.11

### fixes

- **linter-formatter:** add missing dependencies ([5501a42](https://github.com/textlint/textlint/commit/5501a42))
- **linter-formatter:** fix --no-color support ([6cbfb1f](https://github.com/textlint/textlint/commit/6cbfb1f))

















