### PR TITLE
fix(markdown-to-ast):fix tab + CodeBlock AST

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Please install following development prerequisites. You also need a [GitHub](htt
 
 - [Git](https://git-scm.com/)
 - [Node.js](https://nodejs.org/en/) -- we tend to use latest stable Node.js although textlint supports >= 6.0.0
-- [Yarn](https://legacy.yarnpkg.com/en/) -- textlint supports [npm](https://www.npmjs.com/get-npm) >= 2.0.0, but for development purpose, we chose Yarn as package manager
+- [Yarn](https://classic.yarnpkg.com/en/) -- textlint supports [npm](https://www.npmjs.com/get-npm) >= 2.0.0, but for development purpose, we chose Yarn as package manager
 - Text editor
 - Terminal emulator
 

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -25,6 +25,7 @@
     "clean": "rimraf lib/",
     "example:build": "browserify example/js/index.js -o example/app/app.js",
     "prepublish": "npm run --if-present build",
+    "updateSnapshot": "npm run build && node tools/update-fixtures.js",
     "test": "mocha \"test/**/*.{js,ts}\"",
     "watch": "babel src --out-dir lib --watch --source-maps"
   },

--- a/packages/@textlint/markdown-to-ast/src/markdown-parser.js
+++ b/packages/@textlint/markdown-to-ast/src/markdown-parser.js
@@ -34,8 +34,8 @@ function parse(text) {
             if (node.position) {
                 const position = node.position;
                 const positionCompensated = {
-                    start: { line: position.start.line, column: position.start.column - 1 },
-                    end: { line: position.end.line, column: position.end.column - 1 }
+                    start: { line: position.start.line, column: Math.max(position.start.column - 1, 0) },
+                    end: { line: position.end.line, column: Math.max(position.end.column - 1, 0) }
                 };
                 const range = src.locationToRange(positionCompensated);
                 node.loc = positionCompensated;
@@ -53,6 +53,7 @@ function parse(text) {
     });
     return ast;
 }
+
 module.exports = {
     parse,
     Syntax: ASTNodeTypes

--- a/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/input.md
@@ -1,0 +1,4 @@
+* Below are the two types of parameters expected:
+
+	* Type `String` called `code`
+	* Type `boolean` called `accepted`

--- a/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/output.json
@@ -1,0 +1,124 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "loose": true,
+            "children": [
+                {
+                    "type": "ListItem",
+                    "loose": true,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Below are the two types of parameters expected:",
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 49
+                                        }
+                                    },
+                                    "range": [
+                                        2,
+                                        49
+                                    ],
+                                    "raw": "Below are the two types of parameters expected:"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 49
+                                }
+                            },
+                            "range": [
+                                2,
+                                49
+                            ],
+                            "raw": "Below are the two types of parameters expected:"
+                        },
+                        {
+                            "type": "CodeBlock",
+                            "lang": null,
+                            "value": "\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 0
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 35
+                                }
+                            },
+                            "range": [
+                                51,
+                                117
+                            ],
+                            "raw": "\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 35
+                        }
+                    },
+                    "range": [
+                        0,
+                        117
+                    ],
+                    "raw": "* Below are the two types of parameters expected:\n\n\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 35
+                }
+            },
+            "range": [
+                0,
+                117
+            ],
+            "raw": "* Below are the two types of parameters expected:\n\n\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        118
+    ],
+    "raw": "* Below are the two types of parameters expected:\n\n\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`\n"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,11 +1587,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@types/bluebird@^3.5.18":
-  version "3.5.27"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.27.tgz#61eb4d75dc6bfbce51cf49ee9bbebe941b2cb5d0"
-  integrity sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==
-
 "@types/cheerio@^0.22.8":
   version "0.22.11"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.11.tgz#61c0facf9636d14ba5f77fc65ed8913aa845d717"
@@ -3038,11 +3033,6 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
   integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
-
-bluebird@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
-  integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"


### PR DESCRIPTION
- Normalize rrong `column: -1` to `column: 0`

markdown-to-ast create an invalid AST from following text:

```
* Below are the two types of parameters expected:

	* Type `String` called `code`
	* Type `boolean` called `accepted`
```

This commit fix to create valid AST.


fix https://github.com/textlint-rule/textlint-rule-no-dead-link/issues/129
fix https://github.com/textlint/textlint/issues/661
