### PR TITLE
docs(textlint): fix broken link

### DIFF
--- a/packages/textlint/src/README.md
+++ b/packages/textlint/src/README.md
@@ -23,9 +23,9 @@ textlint apply [Separation of Concern](http://weblogs.asp.net/arturtrosin/separa
 
 ## CLI
 
-- [options.js](./options.js)
+- [options.ts](./options.ts)
     - Parse cli options
-- [cli.js](./cli.js)
+- [cli.ts](./cli.ts)
     - create config
     - run engine
     - output result


### PR DESCRIPTION
Fixed some broken links, which seem to be introduced during migration to typescript.

I also found some files referred in the `README.md` no longer exist (e.g. `core/` directory and `rule-manager-js`), but left them untouched as I wasn't sure whether they'd been renamed or just removed.