### PR TITLE
Drop string.prototype.padstart

### DIFF
--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -43,7 +43,6 @@
     "optionator": "^0.8.1",
     "pluralize": "^2.0.0",
     "string-width": "^1.0.1",
-    "string.prototype.padstart": "^3.0.0",
     "strip-ansi": "^6.0.0",
     "table": "^3.7.8",
     "text-table": "^0.2.0",

--- a/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
@@ -8,7 +8,6 @@ import { FormatterOptions } from "../FormatterOptions";
 
 const format = require("@azu/format-text");
 const chalk = require("chalk");
-const padStart = require("string.prototype.padstart");
 const style = require("@azu/style-format");
 const stripAnsi = require("strip-ansi");
 const pluralize = require("pluralize");
@@ -96,15 +95,15 @@ function prettyError(code: string, filePath: string, message: TextlintMessage): 
         title: message.message,
         filename: filePath + ":" + message.line + ":" + message.column,
         previousLine: parsed[0].code ? parsed[0].code : "",
-        previousLineNo: padStart(previousLineNo, linumlen),
+        previousLineNo: previousLineNo.padStart(linumlen),
         previousColNo: parsed[0].col,
         failingLine: parsed[1].code,
-        failingLineNo: padStart(failingLineNo, linumlen),
+        failingLineNo: failingLineNo.padStart(linumlen),
         failingColNo: parsed[1].col,
         nextLine: parsed[2].code ? parsed[2].code : "",
-        nextLineNo: padStart(nextLineNo, linumlen),
+        nextLineNo: nextLineNo.padStart(linumlen),
         nextColNo: parsed[2].col,
-        paddingForLineNo: padStart("", linumlen),
+        paddingForLineNo: "".padStart(linumlen),
         "^": showColumn(parsed, "^"),
         v: showColumn(parsed, "v")
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12673,14 +12673,6 @@ string.prototype.padend@^3.0.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-string.prototype.padstart@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.padstart/-/string.prototype.padstart-3.1.0.tgz#b47c087540d0710be5a49375751a0a627bd4ff90"
-  integrity sha512-envqZvUp2JItI+OeQ5UAh1ihbAV5G/2bixTojvlIa090GGqF+NQRxbWb2nv9fTGrZABv6+pE6jXoAZhhS2k4Hw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-
 string.prototype.trimend@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"


### PR DESCRIPTION
Node.js 8+ supports padStart so that we don't need the  polyfill.

See https://github.com/textlint/textlint/issues/600