### PR TITLE
test: migrate mocha.opts to .mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "babel-register"
+  ]
+}

--- a/packages/@textlint/ast-node-types/.mocharc.json
+++ b/packages/@textlint/ast-node-types/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/ast-node-types/test/mocha.opts
+++ b/packages/@textlint/ast-node-types/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/ast-tester/.mocharc.json
+++ b/packages/@textlint/ast-tester/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/ast-tester/test/mocha.opts
+++ b/packages/@textlint/ast-tester/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/ast-traverse/.mocharc.json
+++ b/packages/@textlint/ast-traverse/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/ast-traverse/test/mocha.opts
+++ b/packages/@textlint/ast-traverse/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/feature-flag/.mocharc.json
+++ b/packages/@textlint/feature-flag/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/feature-flag/test/mocha.opts
+++ b/packages/@textlint/feature-flag/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/fixer-formatter/.mocharc.json
+++ b/packages/@textlint/fixer-formatter/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/fixer-formatter/test/mocha.opts
+++ b/packages/@textlint/fixer-formatter/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/kernel/.mocharc.json
+++ b/packages/@textlint/kernel/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/kernel/test/descriptor/mocha.opts
+++ b/packages/@textlint/kernel/test/descriptor/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/kernel/test/mocha.opts
+++ b/packages/@textlint/kernel/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/linter-formatter/.mocharc.json
+++ b/packages/@textlint/linter-formatter/.mocharc.json
@@ -1,0 +1,7 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ],
+  "color": false,
+  "timeout": "10000"
+}

--- a/packages/@textlint/linter-formatter/test/mocha.opts
+++ b/packages/@textlint/linter-formatter/test/mocha.opts
@@ -1,3 +1,0 @@
---require ts-node-test-register
---no-colors
---timeout 10000

--- a/packages/@textlint/markdown-to-ast/.mocharc.json
+++ b/packages/@textlint/markdown-to-ast/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/markdown-to-ast/test/mocha.opts
+++ b/packages/@textlint/markdown-to-ast/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/module-interop/.mocharc.json
+++ b/packages/@textlint/module-interop/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/module-interop/test/mocha.opts
+++ b/packages/@textlint/module-interop/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/text-to-ast/.mocharc.json
+++ b/packages/@textlint/text-to-ast/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/text-to-ast/test/mocha.opts
+++ b/packages/@textlint/text-to-ast/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/textlint-plugin-markdown/.mocharc.json
+++ b/packages/@textlint/textlint-plugin-markdown/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/textlint-plugin-markdown/test/mocha.opts
+++ b/packages/@textlint/textlint-plugin-markdown/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/textlint-plugin-text/.mocharc.json
+++ b/packages/@textlint/textlint-plugin-text/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/textlint-plugin-text/test/mocha.opts
+++ b/packages/@textlint/textlint-plugin-text/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/types/.mocharc.json
+++ b/packages/@textlint/types/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/types/test/mocha.opts
+++ b/packages/@textlint/types/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/@textlint/utils/.mocharc.json
+++ b/packages/@textlint/utils/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/@textlint/utils/test/mocha.opts
+++ b/packages/@textlint/utils/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/gulp-textlint/package.json
+++ b/packages/gulp-textlint/package.json
@@ -29,7 +29,7 @@
     "eslint": "^6.5.1",
     "eslint-plugin-prettier": "^3.1.1",
     "gulp": "^4.0.1",
-    "mocha": "^6.2.1",
+    "mocha": "^7.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.17.0",
     "textlint-rule-prh": "^5.2.0"

--- a/packages/textlint-tester/.mocharc.json
+++ b/packages/textlint-tester/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/textlint-tester/test/mocha.opts
+++ b/packages/textlint-tester/test/mocha.opts
@@ -1,1 +1,0 @@
---require ts-node-test-register

--- a/packages/textlint/.mocharc.json
+++ b/packages/textlint/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "timeout": "5000",
+  "require": [
+    "ts-node-test-register"
+  ]
+}

--- a/packages/textlint/test/mocha.opts
+++ b/packages/textlint/test/mocha.opts
@@ -1,2 +1,0 @@
---timeout 5000
---require ts-node-test-register

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require babel-register

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,7 +3785,7 @@ chai@^4.2.0:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -8859,13 +8859,6 @@ lodash@^4.0.0, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-log-symbols@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
-  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
-  dependencies:
-    chalk "^2.0.1"
-
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
@@ -9376,48 +9369,12 @@ mkdirp@0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.4.tgz#fd01504a6797ec5c9be81ff43d204961ed64a512"
-  integrity sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==
-  dependencies:
-    minimist "^1.2.5"
-
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
-
-mocha@^6.2.1:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-6.2.3.tgz#e648432181d8b99393410212664450a4c1e31912"
-  integrity sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==
-  dependencies:
-    ansi-colors "3.2.3"
-    browser-stdout "1.3.1"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
-    he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "2.2.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.4"
-    ms "2.1.1"
-    node-environment-flags "1.0.5"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
 
 mocha@^7.1.1:
   version "7.1.1"
@@ -9594,14 +9551,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-environment-flags@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.5.tgz#fa930275f5bf5dae188d6192b24b4c8bbac3d76a"
-  integrity sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==
-  dependencies:
-    object.getownpropertydescriptors "^2.0.3"
-    semver "^5.7.0"
 
 node-environment-flags@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
Migrate `mocha.opts` to `.mocharc.json`.

- `gulp-textlint` is used `6.x` mocha, So changed it to the same version as other packages.
- I seem that `packages/@textlint/kernel/test/descriptor/mocha.opts` is an unnecessary file. So removed it.

ref #672 