### PR TITLE
Add information about emacs texlint support

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -20,6 +20,8 @@ title: Integrating with Editors, Tools, etc..
   - [hidaruma/micro-textlint-plugin](https://github.com/hidaruma/micro-textlint-plugin "hidaruma/micro-textlint-plugin: textlint plugin for micro-editor")
 - NetBeans
   - [netbeans-textlint-plugin](https://github.com/junichi11/netbeans-textlint-plugin "netbeans-textlint-plugin")
+- Emacs
+  - [flycheck/flycheck](https://www.flycheck.org/en/latest/languages.html#syntax-checker-textlint "emacs-flycheck-package")
 
 ## App
 


### PR DESCRIPTION
Emacs support the syntax check for textlint with the flycheck package
https://www.flycheck.org/en/latest/languages.html#syntax-checker-textlint