### PR TITLE
fix(ast-node-types): deprecated "ReferenceDef" type

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -158,8 +158,6 @@ These types are defined in `@textlint/ast-node-types`.
 | ASTNodeTypes.HtmlBlockExit      | TxtParentNode |                                      |
 | ASTNodeTypes.Link               | TxtParentNode | Link Node                            |
 | ASTNodeTypes.LinkExit           | TxtParentNode |                                      |
-| ASTNodeTypes.ReferenceDef       | TxtParentNode | Link Reference Node(`[link][]`)      |
-| ASTNodeTypes.ReferenceDefExit   | TxtParentNode |                                      |
 | ASTNodeTypes.Delete             | TxtParentNode | Delete Node(`~Str~`)                 |
 | ASTNodeTypes.DeleteExit         | TxtParentNode |                                      |
 | ASTNodeTypes.Emphasis           | TxtParentNode | Emphasis(`*Str*`)                    |

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -32,11 +32,11 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         ? TxtParentNode
         : T extends ASTNodeTypes.HeaderExit
         ? TxtParentNode
-        : /* ```
-         * code
-         * ```
-         */
-        T extends ASTNodeTypes.CodeBlock
+          /* ```
+           * code
+           * ```
+           */
+        : T extends ASTNodeTypes.CodeBlock
         ? TxtParentNode
         : T extends ASTNodeTypes.CodeBlockExit
         ? TxtParentNode // <div>\n</div>
@@ -47,10 +47,6 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         : T extends ASTNodeTypes.Link
         ? TxtParentNode
         : T extends ASTNodeTypes.LinkExit
-        ? TxtParentNode // [link][]
-        : T extends ASTNodeTypes.ReferenceDef
-        ? TxtParentNode
-        : T extends ASTNodeTypes.ReferenceDefExit
         ? TxtParentNode // ~~Str~~
         : T extends ASTNodeTypes.Delete
         ? TxtParentNode

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -25,12 +25,18 @@ export enum ASTNodeTypes {
     CodeBlockExit = "CodeBlock:exit",
     HtmlBlock = "HtmlBlock",
     HtmlBlockExit = "HtmlBlock:exit",
-    ReferenceDef = "ReferenceDef",
-    ReferenceDefExit = "ReferenceDef:exit",
     HorizontalRule = "HorizontalRule",
     HorizontalRuleExit = "HorizontalRule:exit",
     Comment = "Comment",
     CommentExit = "Comment:exit",
+    /**
+     * @deprecated
+     */
+    ReferenceDef = "ReferenceDef",
+    /**
+     * @deprecated
+     */
+    ReferenceDefExit = "ReferenceDef:exit",
     // inline
     Str = "Str",
     StrExit = "Str:exit",

--- a/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
+++ b/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
@@ -12,7 +12,6 @@ export const SyntaxMap = {
     heading: ASTNodeTypes.Header,
     code: ASTNodeTypes.CodeBlock,
     HtmlBlock: ASTNodeTypes.HtmlBlock,
-    ReferenceDef: ASTNodeTypes.ReferenceDef,
     thematicBreak: ASTNodeTypes.HorizontalRule,
     // inline block
     text: ASTNodeTypes.Str,
@@ -31,6 +30,10 @@ export const SyntaxMap = {
     tableRow: "TableRow",
     tableCell: "TableCell",
     linkReference: "LinkReference",
-    imageReference: "imageReference",
-    definition: "Definition"
+    imageReference: "ImageReference",
+    definition: "Definition",
+    /**
+     * @deprecated
+     */
+    ReferenceDef: ASTNodeTypes.ReferenceDef
 };

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities-advanced.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities-advanced.text/output.json
@@ -793,7 +793,7 @@
                             "raw": "Or in "
                         },
                         {
-                            "type": "imageReference",
+                            "type": "ImageReference",
                             "identifier": "12",
                             "referenceType": "full",
                             "alt": "\n  l©nks\n",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities.text/output.json
@@ -1989,7 +1989,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with entity",
@@ -2029,7 +2029,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with numeric entity",
@@ -2069,7 +2069,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T without entity",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=escape.text/output.json
@@ -1951,7 +1951,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with entity",
@@ -1991,7 +1991,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with numeric entity",
@@ -2031,7 +2031,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T without entity",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=numbers.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=numbers.text/output.json
@@ -1989,7 +1989,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with entity",
@@ -2029,7 +2029,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with numeric entity",
@@ -2069,7 +2069,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T without entity",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.noentities.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.noentities.text/output.json
@@ -1723,7 +1723,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with entity",
@@ -1763,7 +1763,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T with numeric entity",
@@ -1803,7 +1803,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "favicon",
                     "referenceType": "full",
                     "alt": "AT&T without entity",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-empty-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-empty-parentheses.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -225,7 +225,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-parentheses.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -225,7 +225,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-unclosed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-unclosed.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -225,7 +225,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -445,7 +445,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -505,7 +505,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -725,7 +725,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -785,7 +785,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-empty-title-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-empty-title-parentheses.text/output.json
@@ -365,7 +365,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "world",
                     "referenceType": "shortcut",
                     "alt": "World",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-mismatched-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-mismatched-parentheses.text/output.json
@@ -325,7 +325,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-new-line.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-new-line.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-unclosed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-unclosed.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -225,7 +225,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "world",
                     "referenceType": "shortcut",
                     "alt": "World",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-white-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-white-space.text/output.json
@@ -165,7 +165,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
@@ -49,7 +49,7 @@
                     "referenceType": "full",
                     "children": [
                         {
-                            "type": "imageReference",
+                            "type": "ImageReference",
                             "identifier": "bar",
                             "referenceType": "full",
                             "alt": "Foo",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-image-empty-alt.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-image-empty-alt.text/output.json
@@ -5,7 +5,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "1",
                     "referenceType": "full",
                     "alt": null,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-escape.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-escape.nooutput.text/output.json
@@ -319,7 +319,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "b\\*r*",
                     "referenceType": "full",
                     "alt": "foo",
@@ -359,7 +359,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "b\\*r*",
                     "referenceType": "collapsed",
                     "alt": "b*r*",
@@ -399,7 +399,7 @@
                     "raw": ", "
                 },
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "b\\*r*",
                     "referenceType": "shortcut",
                     "alt": "b*r*",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/title-attributes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/title-attributes.text/output.json
@@ -5216,7 +5216,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -5276,7 +5276,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -5336,7 +5336,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -5396,7 +5396,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -5532,7 +5532,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",
@@ -5668,7 +5668,7 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "imageReference",
+                    "type": "ImageReference",
                     "identifier": "hello",
                     "referenceType": "shortcut",
                     "alt": "Hello",

--- a/packages/@textlint/markdown-to-ast/tools/create-fixtures.js
+++ b/packages/@textlint/markdown-to-ast/tools/create-fixtures.js
@@ -8,7 +8,7 @@
 const fs = require("fs");
 const path = require("path");
 const mkdirp = require("mkdirp");
-const parse = require("../lib/markdown-parser").parse;
+const parse = require("../lib/index").parse;
 const testDir = path.join(__dirname, "..", "test");
 // remark_fixtures to fixtures
 const remarkFixtures = path.join(testDir, "markdown_fixtures");

--- a/packages/@textlint/markdown-to-ast/tools/update-fixtures.js
+++ b/packages/@textlint/markdown-to-ast/tools/update-fixtures.js
@@ -7,7 +7,7 @@
  */
 const fs = require("fs");
 const path = require("path");
-const parse = require("../lib/markdown-parser").parse;
+const parse = require("../lib/index").parse;
 const testDir = path.join(__dirname, "..", "test");
 // remark_fixtures to fixtures
 const fixtureDir = path.join(testDir, "fixtures");


### PR DESCRIPTION
`ReferenceDef` is the wrong type.
We have deprecated it. It will be removed in the future.

fix https://github.com/textlint/textlint/issues/694