### PR TITLE
chore: enable TypeScript incremental

### DIFF
--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -43,7 +43,7 @@
     "textlint-rule-no-todo": "^2.0.1",
     "ts-node": "9.0.0",
     "ts-node-test-register": "9.0.0",
-    "typescript": "4.0.2"
+    "typescript": "4.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textlint-tester/test/tsconfig.json
+++ b/packages/textlint-tester/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "outDir": "../out",
+        "noEmit": true,
         "allowJs": true,
         "declaration": false
     },

--- a/packages/textlint/test/tsconfig.json
+++ b/packages/textlint/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../out",
+    "noEmit": true,
     "allowJs": true,
     "declaration": false,
     "sourceMap": true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "<**SHOULD_BE_OVERWRITE##!??**>",
     /* Basic Options */
+    "incremental": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13393,12 +13393,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
-
-typescript@^4.0.2, typescript@~4.0.2:
+typescript@4.0.5, typescript@^4.0.2, typescript@~4.0.2:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
   integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==


### PR DESCRIPTION
Enable `--incremental` by default.
Also, TS 4.0 allows `incremental` with `noEmit`.

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#--incremental-with---noemit

It aims to get fast performance.