### PR TITLE
fix: make textlint apply adjacent fixes

### DIFF
--- a/packages/@textlint/kernel/src/fixer/source-code-fixer.ts
+++ b/packages/@textlint/kernel/src/fixer/source-code-fixer.ts
@@ -52,7 +52,7 @@ export default class SourceCodeFixer {
         const applyingMessages: TextlintMessage[] = [];
         const cloneMessages = messages.slice();
         const fixes: TextLintMessageFixable[] = [];
-        let lastFixPos = text.length + 1;
+        let lastFixPos = text.length;
         let prefix = sourceCode.hasBOM ? BOM : "";
         cloneMessages.forEach((problem) => {
             if (problem && problem.fix !== undefined) {
@@ -81,7 +81,7 @@ export default class SourceCodeFixer {
                 const end = fix.range[1];
                 let insertionText = fix.text;
 
-                if (end < lastFixPos) {
+                if (end <= lastFixPos) {
                     if (start < 0) {
                         // Remove BOM.
                         prefix = "";

--- a/packages/@textlint/kernel/test/source-code-fixer/source-code-fixer-test.js
+++ b/packages/@textlint/kernel/test/source-code-fixer/source-code-fixer-test.js
@@ -232,11 +232,10 @@ describe("SourceCodeFixer", function () {
                 assert.ok(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function () {
+            it("should apply all fixes when the end of one range is the same as the start of a previous range", function () {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_START, REPLACE_ID]);
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
-                assert.equal(result.remainingMessages.length, 1);
-                assert.equal(result.remainingMessages[0].message, "removestart");
+                assert.equal(result.output, TEST_CODE.replace("answer", "foo").replace("var ", ""));
+                assert.equal(result.remainingMessages.length, 0);
                 assert.ok(result.fixed);
             });
 
@@ -431,11 +430,10 @@ describe("SourceCodeFixer", function () {
                 assert.ok(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function () {
+            it("should apply all fixes when the end of one range is the same as the start of a previous range", function () {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_START, REPLACE_ID]);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
-                assert.equal(result.remainingMessages.length, 1);
-                assert.equal(result.remainingMessages[0].message, "removestart");
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo").replace("var ", "")}`);
+                assert.equal(result.remainingMessages.length, 0);
                 assert.ok(result.fixed);
             });
 


### PR DESCRIPTION
Please refer to https://github.com/textlint/textlint/issues/731

The ranges don't overlap when the end of one fix's range is same as start of other fixes' range. 

This PR makes textlint apply all fixes in this condition.