### PR TITLE
fix(kernel): fix `configBaseDir()` return correct base dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   documentation:
     strategy:
       matrix:
-        node: [ 12 ]
+        node: [ 14 ]
 
     name: Documentation(Node ${{ matrix.node }}
     runs-on: ubuntu-latest

--- a/packages/@textlint/kernel/src/task/fixer-task.ts
+++ b/packages/@textlint/kernel/src/task/fixer-task.ts
@@ -72,7 +72,8 @@ export default class TextLintCoreTask extends CoreTask {
                 ruleId: filterRuleDescriptor.id,
                 severityLevel: getSeverity(filterRuleDescriptor.normalizedOptions),
                 sourceCode,
-                ignoreReport
+                ignoreReport,
+                configBaseDir: this.configBaseDir
             });
             this.tryToAddListenRule(filterRuleDescriptor.filter, ruleContext, filterRuleDescriptor.normalizedOptions);
         });


### PR DESCRIPTION
Previously, `getConfigBaseDir()` always return undefined when `textlint --fix`.

fix #741 