### PR TITLE
feat(markdown-to-ast): update to remark-parse@9

### DIFF
--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -36,11 +36,12 @@
   "dependencies": {
     "@textlint/ast-node-types": "^4.4.3",
     "debug": "^4.3.1",
-    "remark-frontmatter": "^1.3.3",
-    "remark-parse": "^5.0.0",
+    "remark-frontmatter": "^3.0.0",
+    "remark-gfm": "^1.0.0",
+    "remark-parse": "^9.0.0",
     "structured-source": "^3.0.2",
     "traverse": "^0.6.6",
-    "unified": "^6.2.0"
+    "unified": "^9.2.1"
   },
   "devDependencies": {
     "@textlint/ast-tester": "^2.3.5",

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -40,7 +40,6 @@
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",
-    "structured-source": "^3.0.2",
     "traverse": "^0.6.6",
     "unified": "^9.2.1"
   },
@@ -48,7 +47,6 @@
     "@textlint/ast-tester": "^2.3.5",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.17.0",
-    "@types/structured-source": "^3.0.0",
     "@types/traverse": "^0.6.32",
     "browserify": "^16.5.2",
     "cross-env": "^7.0.3",

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@textlint/ast-node-types": "^4.4.3",
     "debug": "^4.3.1",
+    "remark-footnotes": "^3.0.0",
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -1,7 +1,6 @@
 import { SyntaxMap } from "./mapping/markdown-syntax-map";
 import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import traverse from "traverse";
-import StructuredSource from "structured-source";
 import debug0 from "debug";
 import unified from "unified";
 import remarkGfm from "remark-gfm";
@@ -10,7 +9,9 @@ import frontmatter from "remark-frontmatter";
 import footnotes from "remark-footnotes";
 
 const debug = debug0("@textlint/markdown-to-ast");
-const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes);
+const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes, {
+    inlineNotes: true
+});
 
 export { ASTNodeTypes as Syntax };
 
@@ -21,7 +22,6 @@ export { ASTNodeTypes as Syntax };
  */
 export function parse<T extends TxtNode>(text: string): T {
     const ast = remark.parse(text);
-    const src = new StructuredSource(text);
     traverse(ast).forEach(function (node: TxtNode) {
         // eslint-disable-next-line no-invalid-this
         if (this.notLeaf) {
@@ -40,7 +40,7 @@ export function parse<T extends TxtNode>(text: string): T {
                     start: { line: position.start.line, column: Math.max(position.start.column - 1, 0) },
                     end: { line: position.end.line, column: Math.max(position.end.column - 1, 0) }
                 };
-                const range = src.locationToRange(positionCompensated);
+                const range = [position.start.offset, position.end.offset] as [number, number];
                 node.loc = positionCompensated;
                 node.range = range;
                 node.raw = text.slice(range[0], range[1]);

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -7,9 +7,10 @@ import unified from "unified";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import frontmatter from "remark-frontmatter";
+import footnotes from "remark-footnotes";
 
 const debug = debug0("@textlint/markdown-to-ast");
-const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm);
+const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes);
 
 export { ASTNodeTypes as Syntax };
 

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -3,15 +3,13 @@ import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import traverse from "traverse";
 import StructuredSource from "structured-source";
 import debug0 from "debug";
-// @ts-ignore: no types
 import unified from "unified";
-// @ts-ignore: no types
+import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
-// @ts-ignore: no types
 import frontmatter from "remark-frontmatter";
 
 const debug = debug0("@textlint/markdown-to-ast");
-const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]);
+const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm);
 
 export { ASTNodeTypes as Syntax };
 

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -2,16 +2,9 @@ import { SyntaxMap } from "./mapping/markdown-syntax-map";
 import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import traverse from "traverse";
 import debug0 from "debug";
-import unified from "unified";
-import remarkGfm from "remark-gfm";
-import remarkParse from "remark-parse";
-import frontmatter from "remark-frontmatter";
-import footnotes from "remark-footnotes";
+import { parseMarkdown } from "./parse-markdown";
 
 const debug = debug0("@textlint/markdown-to-ast");
-const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes, {
-    inlineNotes: true
-});
 
 export { ASTNodeTypes as Syntax };
 
@@ -29,7 +22,7 @@ export function parse<T extends TxtNode>(text: string): T {
     // https://github.com/micromark/micromark/blob/0f19c1ac25964872a160d8b536878b125ddfe393/lib/preprocess.mjs#L29-L31
     const hasBOM = text.charCodeAt(0) === 0xfeff;
     const textWithoutBOM = hasBOM ? text.slice(1) : text;
-    const ast = remark.parse(textWithoutBOM);
+    const ast = parseMarkdown(textWithoutBOM);
     traverse(ast).forEach(function (node: TxtNode) {
         // eslint-disable-next-line no-invalid-this
         if (this.notLeaf) {
@@ -52,7 +45,7 @@ export function parse<T extends TxtNode>(text: string): T {
                 node.loc = positionCompensated;
                 node.range = range;
                 node.raw = textWithoutBOM.slice(range[0], range[1]);
-                // Compatible for https://github.com/wooorm/unist, but hidden
+                // Compatible for https://github.com/syntax-tree/unist, but it is hidden
                 Object.defineProperty(node, "position", {
                     enumerable: false,
                     configurable: false,

--- a/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
+++ b/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
@@ -31,6 +31,7 @@ export const SyntaxMap = {
     tableCell: "TableCell",
     linkReference: "LinkReference",
     imageReference: "ImageReference",
+    footnoteReference: "FootnoteReference", // textlint@12+
     definition: "Definition",
     /**
      * @deprecated

--- a/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
+++ b/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
@@ -1,0 +1,19 @@
+import unified from "unified";
+// @ts-ignore
+import autolinkLiteral from "mdast-util-gfm-autolink-literal/from-markdown";
+// FIXME: Disable auto link literal transforms that break AST node
+// https://github.com/remarkjs/remark-gfm/issues/16
+// Need to override before import gfm plugin
+autolinkLiteral.transforms = [];
+// Load plugins
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import frontmatter from "remark-frontmatter";
+import footnotes from "remark-footnotes";
+
+const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes, {
+    inlineNotes: true
+});
+export const parseMarkdown = (text: string) => {
+    return remark.parse(text);
+};

--- a/packages/@textlint/markdown-to-ast/test/fixtures/amps-and-angles-encoding.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/amps-and-angles-encoding.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "AT",
+                    "value": "AT&T is another way to write it.",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,52 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        38,
-                        40
-                    ],
-                    "raw": "AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        40,
-                        45
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T is another way to write it.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 36
                         }
                     },
                     "range": [
-                        45,
+                        38,
                         74
                     ],
-                    "raw": "T is another way to write it."
+                    "raw": "AT&amp;T is another way to write it."
                 }
             ],
             "loc": {
@@ -239,7 +201,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here's a ",
+                    "value": "Here's a [link] ",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -247,44 +209,45 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 9
+                            "column": 16
                         }
                     },
                     "range": [
                         106,
-                        115
+                        122
                     ],
-                    "raw": "Here's a "
+                    "raw": "Here's a [link] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "link",
+                            "value": "1",
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 10
+                                    "column": 17
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 14
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                116,
-                                120
+                                123,
+                                124
                             ],
-                            "raw": "link"
+                            "raw": "1"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 11,
-                            "column": 9
+                            "column": 16
                         },
                         "end": {
                             "line": 11,
@@ -292,10 +255,10 @@
                         }
                     },
                     "range": [
-                        115,
+                        122,
                         125
                     ],
-                    "raw": "[link] [1]"
+                    "raw": "[1]"
                 },
                 {
                     "type": "Str",
@@ -338,7 +301,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here's a link with an amersand in the link text: ",
+                    "value": "Here's a link with an amersand in the link text: [AT&T] ",
                     "loc": {
                         "start": {
                             "line": 13,
@@ -346,44 +309,45 @@
                         },
                         "end": {
                             "line": 13,
-                            "column": 49
+                            "column": 56
                         }
                     },
                     "range": [
                         157,
-                        206
+                        213
                     ],
-                    "raw": "Here's a link with an amersand in the link text: "
+                    "raw": "Here's a link with an amersand in the link text: [AT&T] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "2",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "AT&T",
+                            "value": "2",
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 50
+                                    "column": 57
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 54
+                                    "column": 58
                                 }
                             },
                             "range": [
-                                207,
-                                211
+                                214,
+                                215
                             ],
-                            "raw": "AT&T"
+                            "raw": "2"
                         }
                     ],
+                    "identifier": "2",
+                    "label": "2",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 13,
-                            "column": 49
+                            "column": 56
                         },
                         "end": {
                             "line": 13,
@@ -391,10 +355,10 @@
                         }
                     },
                     "range": [
-                        206,
+                        213,
                         216
                     ],
-                    "raw": "[AT&T] [2]"
+                    "raw": "[2]"
                 },
                 {
                     "type": "Str",
@@ -633,6 +597,7 @@
         {
             "type": "Definition",
             "identifier": "1",
+            "label": "1",
             "title": null,
             "url": "http://example.com/?foo=1&bar=2",
             "loc": {
@@ -654,6 +619,7 @@
         {
             "type": "Definition",
             "identifier": "2",
+            "label": "2",
             "title": "AT&T",
             "url": "http://att.com/",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-invalid.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-invalid.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "<https:/ ",
+                    "value": "<https:/",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,14 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 9
+                            "column": 8
                         }
                     },
                     "range": [
                         9,
-                        18
+                        17
                     ],
-                    "raw": "<https:/ "
+                    "raw": "<https:/"
                 }
             ],
             "loc": {
@@ -83,8 +83,30 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "<mailto:foobarbaz>",
+                    "type": "Link",
+                    "title": null,
+                    "url": "mailto:foobarbaz",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "mailto:foobarbaz",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 17
+                                }
+                            },
+                            "range": [
+                                21,
+                                37
+                            ],
+                            "raw": "mailto:foobarbaz"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 5,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-lines.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-lines.text/output.json
@@ -110,11 +110,11 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "somename@example.com",
+                            "value": "mailto:somename@example.com",
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 8
+                                    "column": 1
                                 },
                                 "end": {
                                     "line": 5,
@@ -122,10 +122,10 @@
                                 }
                             },
                             "range": [
-                                54,
+                                47,
                                 74
                             ],
-                            "raw": "somename@example.com"
+                            "raw": "mailto:somename@example.com"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-output.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-output.output.text/output.json
@@ -129,11 +129,11 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "somename@example.com",
+                            "value": "mailto:somename@example.com",
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 26
+                                    "column": 19
                                 },
                                 "end": {
                                     "line": 3,
@@ -141,10 +141,10 @@
                                 }
                             },
                             "range": [
-                                56,
+                                49,
                                 76
                             ],
-                            "raw": "somename@example.com"
+                            "raw": "mailto:somename@example.com"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-url.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link-url.text/output.json
@@ -204,7 +204,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "So should this: ",
+                    "value": "So should this: mailto:",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -212,14 +212,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 16
+                            "column": 23
                         }
                     },
                     "range": [
                         143,
-                        159
+                        166
                     ],
-                    "raw": "So should this: "
+                    "raw": "So should this: mailto:"
                 },
                 {
                     "type": "Link",
@@ -232,24 +232,24 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 16
+                                    "column": 23
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 27
+                                    "column": 34
                                 }
                             },
                             "range": [
-                                159,
-                                170
+                                166,
+                                177
                             ],
-                            "raw": "mailto:foo@"
+                            "raw": "foo@bar.com"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 16
+                            "column": 23
                         },
                         "end": {
                             "line": 5,
@@ -257,10 +257,10 @@
                         }
                     },
                     "range": [
-                        159,
+                        166,
                         177
                     ],
-                    "raw": "mailto:foo@bar.com"
+                    "raw": "foo@bar.com"
                 },
                 {
                     "type": "Str",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link.text/output.json
@@ -228,11 +228,11 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "somename@example.com",
+                            "value": "mailto:somename@example.com",
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 26
+                                    "column": 19
                                 },
                                 "end": {
                                     "line": 5,
@@ -240,10 +240,10 @@
                                 }
                             },
                             "range": [
-                                99,
+                                92,
                                 119
                             ],
-                            "raw": "somename@example.com"
+                            "raw": "mailto:somename@example.com"
                         }
                     ],
                     "loc": {
@@ -382,11 +382,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -447,7 +447,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -530,7 +530,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -767,6 +767,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "or here: <http://example.com/>",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link/input.md
@@ -1,0 +1,9 @@
+Link: http://example.com/
+Link: www.example.com
+* Link: http://example.com/
+
+> Blockquoted: http://example.com/
+
+Auto-links should not occur here: `http://example.com/`
+
+	or here: http://example.com/

--- a/packages/@textlint/markdown-to-ast/test/fixtures/auto-link/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/auto-link/output.json
@@ -1,0 +1,464 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Link: ",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 6
+                        }
+                    },
+                    "range": [
+                        0,
+                        6
+                    ],
+                    "raw": "Link: "
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "http://example.com/",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "http://example.com/",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                6,
+                                25
+                            ],
+                            "raw": "http://example.com/"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 25
+                        }
+                    },
+                    "range": [
+                        6,
+                        25
+                    ],
+                    "raw": "http://example.com/"
+                },
+                {
+                    "type": "Str",
+                    "value": "\nLink: ",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 6
+                        }
+                    },
+                    "range": [
+                        25,
+                        32
+                    ],
+                    "raw": "\nLink: "
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "http://www.example.com",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "www.example.com",
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 21
+                                }
+                            },
+                            "range": [
+                                32,
+                                47
+                            ],
+                            "raw": "www.example.com"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 21
+                        }
+                    },
+                    "range": [
+                        32,
+                        47
+                    ],
+                    "raw": "www.example.com"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 21
+                }
+            },
+            "range": [
+                0,
+                47
+            ],
+            "raw": "Link: http://example.com/\nLink: www.example.com"
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": false,
+            "children": [
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Link: ",
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        50,
+                                        56
+                                    ],
+                                    "raw": "Link: "
+                                },
+                                {
+                                    "type": "Link",
+                                    "title": null,
+                                    "url": "http://example.com/",
+                                    "children": [
+                                        {
+                                            "type": "Str",
+                                            "value": "http://example.com/",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 3,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 27
+                                                }
+                                            },
+                                            "range": [
+                                                56,
+                                                75
+                                            ],
+                                            "raw": "http://example.com/"
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 27
+                                        }
+                                    },
+                                    "range": [
+                                        56,
+                                        75
+                                    ],
+                                    "raw": "http://example.com/"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 27
+                                }
+                            },
+                            "range": [
+                                50,
+                                75
+                            ],
+                            "raw": "Link: http://example.com/"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        48,
+                        75
+                    ],
+                    "raw": "* Link: http://example.com/"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 27
+                }
+            },
+            "range": [
+                48,
+                75
+            ],
+            "raw": "* Link: http://example.com/"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Blockquoted: ",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 15
+                                }
+                            },
+                            "range": [
+                                79,
+                                92
+                            ],
+                            "raw": "Blockquoted: "
+                        },
+                        {
+                            "type": "Link",
+                            "title": null,
+                            "url": "http://example.com/",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "http://example.com/",
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 15
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 34
+                                        }
+                                    },
+                                    "range": [
+                                        92,
+                                        111
+                                    ],
+                                    "raw": "http://example.com/"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 34
+                                }
+                            },
+                            "range": [
+                                92,
+                                111
+                            ],
+                            "raw": "http://example.com/"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 34
+                        }
+                    },
+                    "range": [
+                        79,
+                        111
+                    ],
+                    "raw": "Blockquoted: http://example.com/"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 5,
+                    "column": 34
+                }
+            },
+            "range": [
+                77,
+                111
+            ],
+            "raw": "> Blockquoted: http://example.com/"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Auto-links should not occur here: ",
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 34
+                        }
+                    },
+                    "range": [
+                        113,
+                        147
+                    ],
+                    "raw": "Auto-links should not occur here: "
+                },
+                {
+                    "type": "Code",
+                    "value": "http://example.com/",
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 34
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 55
+                        }
+                    },
+                    "range": [
+                        147,
+                        168
+                    ],
+                    "raw": "`http://example.com/`"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 55
+                }
+            },
+            "range": [
+                113,
+                168
+            ],
+            "raw": "Auto-links should not occur here: `http://example.com/`"
+        },
+        {
+            "type": "CodeBlock",
+            "lang": null,
+            "meta": null,
+            "value": "or here: http://example.com/",
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 29
+                }
+            },
+            "range": [
+                170,
+                199
+            ],
+            "raw": "\tor here: http://example.com/"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 10,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        200
+    ],
+    "raw": "Link: http://example.com/\nLink: www.example.com\n* Link: http://example.com/\n\n> Blockquoted: http://example.com/\n\nAuto-links should not occur here: `http://example.com/`\n\n\tor here: http://example.com/\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/backslash-escapes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/backslash-escapes.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Backslash: ",
+                    "value": "Backslash: \\",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        31,
-                        42
-                    ],
-                    "raw": "Backslash: "
-                },
-                {
-                    "type": "Str",
-                    "value": "\\",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 13
                         }
                     },
                     "range": [
-                        42,
+                        31,
                         44
                     ],
-                    "raw": "\\\\"
+                    "raw": "Backslash: \\\\"
                 }
             ],
             "loc": {
@@ -103,7 +84,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Backtick: ",
+                    "value": "Backtick: `",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -111,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        46,
-                        56
-                    ],
-                    "raw": "Backtick: "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 12
                         }
                     },
                     "range": [
-                        56,
+                        46,
                         58
                     ],
-                    "raw": "\\`"
+                    "raw": "Backtick: \\`"
                 }
             ],
             "loc": {
@@ -161,7 +123,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Asterisk: ",
+                    "value": "Asterisk: *",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -169,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        60,
-                        70
-                    ],
-                    "raw": "Asterisk: "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 12
                         }
                     },
                     "range": [
-                        70,
+                        60,
                         72
                     ],
-                    "raw": "\\*"
+                    "raw": "Asterisk: \\*"
                 }
             ],
             "loc": {
@@ -219,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscore: ",
+                    "value": "Underscore: _",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -227,33 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        74,
-                        86
-                    ],
-                    "raw": "Underscore: "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 14
                         }
                     },
                     "range": [
-                        86,
+                        74,
                         88
                     ],
-                    "raw": "\\_"
+                    "raw": "Underscore: \\_"
                 }
             ],
             "loc": {
@@ -277,7 +201,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Left brace: ",
+                    "value": "Left brace: {",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -285,33 +209,14 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        90,
-                        102
-                    ],
-                    "raw": "Left brace: "
-                },
-                {
-                    "type": "Str",
-                    "value": "{",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 11,
                             "column": 14
                         }
                     },
                     "range": [
-                        102,
+                        90,
                         104
                     ],
-                    "raw": "\\{"
+                    "raw": "Left brace: \\{"
                 }
             ],
             "loc": {
@@ -335,7 +240,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Right brace: ",
+                    "value": "Right brace: }",
                     "loc": {
                         "start": {
                             "line": 13,
@@ -343,33 +248,14 @@
                         },
                         "end": {
                             "line": 13,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        106,
-                        119
-                    ],
-                    "raw": "Right brace: "
-                },
-                {
-                    "type": "Str",
-                    "value": "}",
-                    "loc": {
-                        "start": {
-                            "line": 13,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 13,
                             "column": 15
                         }
                     },
                     "range": [
-                        119,
+                        106,
                         121
                     ],
-                    "raw": "\\}"
+                    "raw": "Right brace: \\}"
                 }
             ],
             "loc": {
@@ -393,7 +279,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Left bracket: ",
+                    "value": "Left bracket: [",
                     "loc": {
                         "start": {
                             "line": 15,
@@ -401,33 +287,14 @@
                         },
                         "end": {
                             "line": 15,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        123,
-                        137
-                    ],
-                    "raw": "Left bracket: "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 15,
-                            "column": 14
-                        },
-                        "end": {
-                            "line": 15,
                             "column": 16
                         }
                     },
                     "range": [
-                        137,
+                        123,
                         139
                     ],
-                    "raw": "\\["
+                    "raw": "Left bracket: \\["
                 }
             ],
             "loc": {
@@ -451,7 +318,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Right bracket: ",
+                    "value": "Right bracket: ]",
                     "loc": {
                         "start": {
                             "line": 17,
@@ -459,33 +326,14 @@
                         },
                         "end": {
                             "line": 17,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        141,
-                        156
-                    ],
-                    "raw": "Right bracket: "
-                },
-                {
-                    "type": "Str",
-                    "value": "]",
-                    "loc": {
-                        "start": {
-                            "line": 17,
-                            "column": 15
-                        },
-                        "end": {
-                            "line": 17,
                             "column": 17
                         }
                     },
                     "range": [
-                        156,
+                        141,
                         158
                     ],
-                    "raw": "\\]"
+                    "raw": "Right bracket: \\]"
                 }
             ],
             "loc": {
@@ -509,7 +357,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Left paren: ",
+                    "value": "Left paren: (",
                     "loc": {
                         "start": {
                             "line": 19,
@@ -517,33 +365,14 @@
                         },
                         "end": {
                             "line": 19,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        160,
-                        172
-                    ],
-                    "raw": "Left paren: "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 19,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 19,
                             "column": 14
                         }
                     },
                     "range": [
-                        172,
+                        160,
                         174
                     ],
-                    "raw": "\\("
+                    "raw": "Left paren: \\("
                 }
             ],
             "loc": {
@@ -567,7 +396,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Right paren: ",
+                    "value": "Right paren: )",
                     "loc": {
                         "start": {
                             "line": 21,
@@ -575,33 +404,14 @@
                         },
                         "end": {
                             "line": 21,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        176,
-                        189
-                    ],
-                    "raw": "Right paren: "
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 21,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 21,
                             "column": 15
                         }
                     },
                     "range": [
-                        189,
+                        176,
                         191
                     ],
-                    "raw": "\\)"
+                    "raw": "Right paren: \\)"
                 }
             ],
             "loc": {
@@ -625,7 +435,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Greater-than: ",
+                    "value": "Greater-than: >",
                     "loc": {
                         "start": {
                             "line": 23,
@@ -633,33 +443,14 @@
                         },
                         "end": {
                             "line": 23,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        193,
-                        207
-                    ],
-                    "raw": "Greater-than: "
-                },
-                {
-                    "type": "Str",
-                    "value": ">",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 14
-                        },
-                        "end": {
-                            "line": 23,
                             "column": 16
                         }
                     },
                     "range": [
-                        207,
+                        193,
                         209
                     ],
-                    "raw": "\\>"
+                    "raw": "Greater-than: \\>"
                 }
             ],
             "loc": {
@@ -683,7 +474,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Hash: ",
+                    "value": "Hash: #",
                     "loc": {
                         "start": {
                             "line": 25,
@@ -691,33 +482,14 @@
                         },
                         "end": {
                             "line": 25,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        211,
-                        217
-                    ],
-                    "raw": "Hash: "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 25,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 25,
                             "column": 8
                         }
                     },
                     "range": [
-                        217,
+                        211,
                         219
                     ],
-                    "raw": "\\#"
+                    "raw": "Hash: \\#"
                 }
             ],
             "loc": {
@@ -741,7 +513,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Period: ",
+                    "value": "Period: .",
                     "loc": {
                         "start": {
                             "line": 27,
@@ -749,33 +521,14 @@
                         },
                         "end": {
                             "line": 27,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        221,
-                        229
-                    ],
-                    "raw": "Period: "
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 27,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 27,
                             "column": 10
                         }
                     },
                     "range": [
-                        229,
+                        221,
                         231
                     ],
-                    "raw": "\\."
+                    "raw": "Period: \\."
                 }
             ],
             "loc": {
@@ -799,7 +552,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Bang: ",
+                    "value": "Bang: !",
                     "loc": {
                         "start": {
                             "line": 29,
@@ -807,33 +560,14 @@
                         },
                         "end": {
                             "line": 29,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        233,
-                        239
-                    ],
-                    "raw": "Bang: "
-                },
-                {
-                    "type": "Str",
-                    "value": "!",
-                    "loc": {
-                        "start": {
-                            "line": 29,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 29,
                             "column": 8
                         }
                     },
                     "range": [
-                        239,
+                        233,
                         241
                     ],
-                    "raw": "\\!"
+                    "raw": "Bang: \\!"
                 }
             ],
             "loc": {
@@ -857,7 +591,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Plus: ",
+                    "value": "Plus: +",
                     "loc": {
                         "start": {
                             "line": 31,
@@ -865,33 +599,14 @@
                         },
                         "end": {
                             "line": 31,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        243,
-                        249
-                    ],
-                    "raw": "Plus: "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 31,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 31,
                             "column": 8
                         }
                     },
                     "range": [
-                        249,
+                        243,
                         251
                     ],
-                    "raw": "\\+"
+                    "raw": "Plus: \\+"
                 }
             ],
             "loc": {
@@ -915,7 +630,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Minus: ",
+                    "value": "Minus: -",
                     "loc": {
                         "start": {
                             "line": 33,
@@ -923,33 +638,14 @@
                         },
                         "end": {
                             "line": 33,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        253,
-                        260
-                    ],
-                    "raw": "Minus: "
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 33,
                             "column": 9
                         }
                     },
                     "range": [
-                        260,
+                        253,
                         262
                     ],
-                    "raw": "\\-"
+                    "raw": "Minus: \\-"
                 }
             ],
             "loc": {
@@ -1032,7 +728,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Pipe: ",
+                    "value": "Pipe: |",
                     "loc": {
                         "start": {
                             "line": 37,
@@ -1040,33 +736,14 @@
                         },
                         "end": {
                             "line": 37,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        274,
-                        280
-                    ],
-                    "raw": "Pipe: "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 37,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 37,
                             "column": 8
                         }
                     },
                     "range": [
-                        280,
+                        274,
                         282
                     ],
-                    "raw": "\\|"
+                    "raw": "Pipe: \\|"
                 }
             ],
             "loc": {
@@ -1090,7 +767,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Tilde: ",
+                    "value": "Tilde: ~",
                     "loc": {
                         "start": {
                             "line": 39,
@@ -1098,33 +775,14 @@
                         },
                         "end": {
                             "line": 39,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        284,
-                        291
-                    ],
-                    "raw": "Tilde: "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 39,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 39,
                             "column": 9
                         }
                     },
                     "range": [
-                        291,
+                        284,
                         293
                     ],
-                    "raw": "\\~"
+                    "raw": "Tilde: \\~"
                 }
             ],
             "loc": {
@@ -1207,7 +865,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Quote: \\\"",
+                    "value": "Quote: \"",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1246,7 +904,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Dollar: \\$",
+                    "value": "Dollar: $",
                     "loc": {
                         "start": {
                             "line": 45,
@@ -1285,7 +943,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Percentage: \\%",
+                    "value": "Percentage: %",
                     "loc": {
                         "start": {
                             "line": 47,
@@ -1324,7 +982,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Ampersand: \\&",
+                    "value": "Ampersand: &",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -1363,7 +1021,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Single quote: \\'",
+                    "value": "Single quote: '",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -1402,7 +1060,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Comma: \\,",
+                    "value": "Comma: ,",
                     "loc": {
                         "start": {
                             "line": 53,
@@ -1441,7 +1099,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Forward slash: \\/",
+                    "value": "Forward slash: /",
                     "loc": {
                         "start": {
                             "line": 55,
@@ -1480,7 +1138,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Colon: \\:",
+                    "value": "Colon: :",
                     "loc": {
                         "start": {
                             "line": 57,
@@ -1519,7 +1177,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Semicolon: \\;",
+                    "value": "Semicolon: ;",
                     "loc": {
                         "start": {
                             "line": 59,
@@ -1558,7 +1216,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Less-than: \\<",
+                    "value": "Less-than: <",
                     "loc": {
                         "start": {
                             "line": 61,
@@ -1597,7 +1255,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Equals: \\=",
+                    "value": "Equals: =",
                     "loc": {
                         "start": {
                             "line": 63,
@@ -1636,7 +1294,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Question mark: \\?",
+                    "value": "Question mark: ?",
                     "loc": {
                         "start": {
                             "line": 65,
@@ -1675,7 +1333,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "At-sign: \\@",
+                    "value": "At-sign: @",
                     "loc": {
                         "start": {
                             "line": 67,
@@ -1714,7 +1372,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Caret: \\^",
+                    "value": "Caret: ^",
                     "loc": {
                         "start": {
                             "line": 69,
@@ -1753,10 +1411,47 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "New line: \\\nonly works in paragraphs.",
+                    "value": "New line: ",
                     "loc": {
                         "start": {
                             "line": 71,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 71,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        510,
+                        520
+                    ],
+                    "raw": "New line: "
+                },
+                {
+                    "type": "Break",
+                    "loc": {
+                        "start": {
+                            "line": 71,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 72,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        520,
+                        522
+                    ],
+                    "raw": "\\\n"
+                },
+                {
+                    "type": "Str",
+                    "value": "only works in paragraphs.",
+                    "loc": {
+                        "start": {
+                            "line": 72,
                             "column": 0
                         },
                         "end": {
@@ -1765,10 +1460,10 @@
                         }
                     },
                     "range": [
-                        510,
+                        522,
                         547
                     ],
-                    "raw": "New line: \\\nonly works in paragraphs."
+                    "raw": "only works in paragraphs."
                 }
             ],
             "loc": {
@@ -1829,6 +1524,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Backslash: \\\\\n\nBacktick: \\`\n\nAsterisk: \\*\n\nUnderscore: \\_\n\nLeft brace: \\{\n\nRight brace: \\}\n\nLeft bracket: \\[\n\nRight bracket: \\]\n\nLeft paren: \\(\n\nRight paren: \\)\n\nGreater-than: \\>\n\nHash: \\#\n\nPeriod: \\.\n\nBang: \\!\n\nPlus: \\+\n\nMinus: \\-",
             "loc": {
                 "start": {
@@ -1908,6 +1604,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Pipe: \\|\n\nTilde: \\~",
             "loc": {
                 "start": {
@@ -1987,6 +1684,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Quote: \\\"\n\nDollar: \\$\n\nPercentage: \\%\n\nAmpersand: \\&\n\nSingle quote: \\'\n\nComma: \\,\n\nForward slash: \\/\n\nColon: \\:\n\nSemicolon: \\;\n\nLess-than: \\<\n\nEquals: \\=\n\nQuestion mark: \\?\n\nAt-sign: \\@\n\nCaret: \\^\n\nNew line: \\\nonly works in paragraphs.",
             "loc": {
                 "start": {
@@ -4041,7 +3739,7 @@
                 },
                 {
                     "type": "Code",
-                    "value": "\\",
+                    "value": "\\\n",
                     "loc": {
                         "start": {
                             "line": 218,
@@ -4138,7 +3836,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "*",
+                    "value": "*asterisks*",
                     "loc": {
                         "start": {
                             "line": 224,
@@ -4146,52 +3844,14 @@
                         },
                         "end": {
                             "line": 224,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1889,
-                        1891
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": "asterisks",
-                    "loc": {
-                        "start": {
-                            "line": 224,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 224,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        1891,
-                        1900
-                    ],
-                    "raw": "asterisks"
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 224,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 224,
                             "column": 13
                         }
                     },
                     "range": [
-                        1900,
+                        1889,
                         1902
                     ],
-                    "raw": "\\*"
+                    "raw": "\\*asterisks\\*"
                 }
             ],
             "loc": {
@@ -4215,7 +3875,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "_",
+                    "value": "_underscores_",
                     "loc": {
                         "start": {
                             "line": 226,
@@ -4223,52 +3883,14 @@
                         },
                         "end": {
                             "line": 226,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1904,
-                        1906
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "underscores",
-                    "loc": {
-                        "start": {
-                            "line": 226,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 226,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        1906,
-                        1917
-                    ],
-                    "raw": "underscores"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 226,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 226,
                             "column": 15
                         }
                     },
                     "range": [
-                        1917,
+                        1904,
                         1919
                     ],
-                    "raw": "\\_"
+                    "raw": "\\_underscores\\_"
                 }
             ],
             "loc": {
@@ -4292,7 +3914,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "`",
+                    "value": "`backticks`",
                     "loc": {
                         "start": {
                             "line": 228,
@@ -4300,52 +3922,14 @@
                         },
                         "end": {
                             "line": 228,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1921,
-                        1923
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": "backticks",
-                    "loc": {
-                        "start": {
-                            "line": 228,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 228,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        1923,
-                        1932
-                    ],
-                    "raw": "backticks"
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 228,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 228,
                             "column": 13
                         }
                     },
                     "range": [
-                        1932,
+                        1921,
                         1934
                     ],
-                    "raw": "\\`"
+                    "raw": "\\`backticks\\`"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/block-elements.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/block-elements.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -67,33 +67,10 @@
                         75
                     ],
                     "raw": "*   Different lists should receive two newline characters\n    between them."
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 0
                 },
-                "end": {
-                    "line": 2,
-                    "column": 17
-                }
-            },
-            "range": [
-                0,
-                75
-            ],
-            "raw": "*   Different lists should receive two newline characters\n    between them."
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": false,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -155,7 +132,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 5,
+                    "line": 1,
                     "column": 0
                 },
                 "end": {
@@ -164,10 +141,10 @@
                 }
             },
             "range": [
-                78,
+                0,
                 103
             ],
-            "raw": "*   This is another list."
+            "raw": "*   Different lists should receive two newline characters\n    between them.\n\n\n*   This is another list."
         },
         {
             "type": "BlockQuote",
@@ -176,11 +153,11 @@
                     "type": "List",
                     "ordered": false,
                     "start": null,
-                    "loose": false,
+                    "spread": true,
                     "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -226,7 +203,7 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 2
+                                    "column": 3
                                 },
                                 "end": {
                                     "line": 7,
@@ -234,37 +211,14 @@
                                 }
                             },
                             "range": [
-                                107,
+                                108,
                                 152
                             ],
-                            "raw": " *   The same goes for lists in block quotes."
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 2
+                            "raw": "*   The same goes for lists in block quotes."
                         },
-                        "end": {
-                            "line": 7,
-                            "column": 47
-                        }
-                    },
-                    "range": [
-                        107,
-                        152
-                    ],
-                    "raw": " *   The same goes for lists in block quotes."
-                },
-                {
-                    "type": "List",
-                    "ordered": false,
-                    "start": null,
-                    "loose": false,
-                    "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -310,7 +264,7 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 2
+                                    "column": 3
                                 },
                                 "end": {
                                     "line": 10,
@@ -318,16 +272,16 @@
                                 }
                             },
                             "range": [
-                                159,
+                                160,
                                 185
                             ],
-                            "raw": " *   This is another list."
+                            "raw": "*   This is another list."
                         }
                     ],
                     "loc": {
                         "start": {
-                            "line": 10,
-                            "column": 2
+                            "line": 7,
+                            "column": 3
                         },
                         "end": {
                             "line": 10,
@@ -335,10 +289,10 @@
                         }
                     },
                     "range": [
-                        159,
+                        108,
                         185
                     ],
-                    "raw": " *   This is another list."
+                    "raw": "*   The same goes for lists in block quotes.\n>\n>\n>  *   This is another list."
                 }
             ],
             "loc": {
@@ -361,11 +315,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -411,11 +365,11 @@
                             "type": "List",
                             "ordered": true,
                             "start": 1,
-                            "loose": false,
+                            "spread": true,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -473,6 +427,67 @@
                                         239
                                     ],
                                     "raw": "1.   First sublist."
+                                },
+                                {
+                                    "type": "ListItem",
+                                    "spread": false,
+                                    "checked": null,
+                                    "children": [
+                                        {
+                                            "type": "Paragraph",
+                                            "children": [
+                                                {
+                                                    "type": "Str",
+                                                    "value": "Second sublist.",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 17,
+                                                            "column": 9
+                                                        },
+                                                        "end": {
+                                                            "line": 17,
+                                                            "column": 24
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        251,
+                                                        266
+                                                    ],
+                                                    "raw": "Second sublist."
+                                                }
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 17,
+                                                    "column": 9
+                                                },
+                                                "end": {
+                                                    "line": 17,
+                                                    "column": 24
+                                                }
+                                            },
+                                            "range": [
+                                                251,
+                                                266
+                                            ],
+                                            "raw": "Second sublist."
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 17,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 17,
+                                            "column": 24
+                                        }
+                                    },
+                                    "range": [
+                                        246,
+                                        266
+                                    ],
+                                    "raw": "1.   Second sublist."
                                 }
                             ],
                             "loc": {
@@ -481,15 +496,15 @@
                                     "column": 4
                                 },
                                 "end": {
-                                    "line": 14,
-                                    "column": 23
+                                    "line": 17,
+                                    "column": 24
                                 }
                             },
                             "range": [
                                 220,
-                                239
+                                266
                             ],
-                            "raw": "1.   First sublist."
+                            "raw": "1.   First sublist.\n\n\n    1.   Second sublist."
                         }
                     ],
                     "loc": {
@@ -498,15 +513,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 14,
-                            "column": 23
+                            "line": 17,
+                            "column": 24
                         }
                     },
                     "range": [
                         187,
-                        239
+                        266
                     ],
-                    "raw": "*   And for lists in lists:\n\n    1.   First sublist."
+                    "raw": "*   And for lists in lists:\n\n    1.   First sublist.\n\n\n    1.   Second sublist."
                 }
             ],
             "loc": {
@@ -515,35 +530,15 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 14,
-                    "column": 23
-                }
-            },
-            "range": [
-                187,
-                239
-            ],
-            "raw": "*   And for lists in lists:\n\n    1.   First sublist."
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "value": "1.   Second sublist.",
-            "loc": {
-                "start": {
-                    "line": 17,
-                    "column": 0
-                },
-                "end": {
                     "line": 17,
                     "column": 24
                 }
             },
             "range": [
-                242,
+                187,
                 266
             ],
-            "raw": "    1.   Second sublist."
+            "raw": "*   And for lists in lists:\n\n    1.   First sublist.\n\n\n    1.   Second sublist."
         },
         {
             "type": "Paragraph",
@@ -588,11 +583,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -633,6 +628,45 @@
                                 350
                             ],
                             "raw": "This is a paragraph in a list"
+                        },
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "And this is code();",
+                                    "loc": {
+                                        "start": {
+                                            "line": 24,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 24,
+                                            "column": 23
+                                        }
+                                    },
+                                    "range": [
+                                        357,
+                                        376
+                                    ],
+                                    "raw": "And this is code();"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 24,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 24,
+                                    "column": 23
+                                }
+                            },
+                            "range": [
+                                357,
+                                376
+                            ],
+                            "raw": "And this is code();"
                         }
                     ],
                     "loc": {
@@ -641,40 +675,20 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 21,
-                            "column": 33
+                            "line": 24,
+                            "column": 23
                         }
                     },
                     "range": [
                         317,
-                        350
+                        376
                     ],
-                    "raw": "*   This is a paragraph in a list"
+                    "raw": "*   This is a paragraph in a list\n\n\n    And this is code();"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 21,
-                    "column": 0
-                },
-                "end": {
-                    "line": 21,
-                    "column": 33
-                }
-            },
-            "range": [
-                317,
-                350
-            ],
-            "raw": "*   This is a paragraph in a list"
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "value": "And this is code();",
-            "loc": {
-                "start": {
-                    "line": 24,
                     "column": 0
                 },
                 "end": {
@@ -683,10 +697,10 @@
                 }
             },
             "range": [
-                353,
+                317,
                 376
             ],
-            "raw": "    And this is code();"
+            "raw": "*   This is a paragraph in a list\n\n\n    And this is code();"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-indented.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-indented.text/output.json
@@ -47,7 +47,7 @@
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 2,
@@ -55,10 +55,10 @@
                 }
             },
             "range": [
-                0,
+                3,
                 15
             ],
-            "raw": "   > bar\n > baz"
+            "raw": "> bar\n > baz"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-code.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-code.text/output.json
@@ -7,22 +7,23 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
-                    "value": "foo\nbar",
+                    "meta": null,
+                    "value": "foo",
                     "loc": {
                         "start": {
                             "line": 1,
                             "column": 2
                         },
                         "end": {
-                            "line": 2,
-                            "column": 7
+                            "line": 1,
+                            "column": 9
                         }
                     },
                     "range": [
                         2,
-                        17
+                        9
                     ],
-                    "raw": "    foo\n    bar"
+                    "raw": "    foo"
                 }
             ],
             "loc": {
@@ -31,15 +32,36 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            },
+            "range": [
+                0,
+                9
+            ],
+            "raw": ">     foo"
+        },
+        {
+            "type": "CodeBlock",
+            "lang": null,
+            "meta": null,
+            "value": "bar",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
                     "line": 2,
                     "column": 7
                 }
             },
             "range": [
-                0,
+                10,
                 17
             ],
-            "raw": ">     foo\n    bar"
+            "raw": "    bar"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-fence.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-fence.text/output.json
@@ -7,6 +7,7 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
+                    "meta": null,
                     "value": "aNormalCodeBlockInABlockqoute();",
                     "loc": {
                         "start": {
@@ -86,22 +87,23 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
-                    "value": "thisIsAlsoSomeCodeInABlockquote();",
+                    "meta": null,
+                    "value": "",
                     "loc": {
                         "start": {
                             "line": 7,
                             "column": 2
                         },
                         "end": {
-                            "line": 9,
-                            "column": 5
+                            "line": 8,
+                            "column": 0
                         }
                     },
                     "range": [
                         64,
-                        108
+                        68
                     ],
-                    "raw": "```\nthisIsAlsoSomeCodeInABlockquote();\n> ```"
+                    "raw": "```\n"
                 }
             ],
             "loc": {
@@ -110,15 +112,95 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 9,
-                    "column": 5
+                    "line": 8,
+                    "column": 0
                 }
             },
             "range": [
                 62,
-                108
+                68
             ],
-            "raw": "> ```\nthisIsAlsoSomeCodeInABlockquote();\n> ```"
+            "raw": "> ```\n"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "thisIsAlsoSomeCodeInABlockquote();",
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 34
+                        }
+                    },
+                    "range": [
+                        68,
+                        102
+                    ],
+                    "raw": "thisIsAlsoSomeCodeInABlockquote();"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 34
+                }
+            },
+            "range": [
+                68,
+                102
+            ],
+            "raw": "thisIsAlsoSomeCodeInABlockquote();"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
+                {
+                    "type": "CodeBlock",
+                    "lang": null,
+                    "meta": null,
+                    "value": "",
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        105,
+                        109
+                    ],
+                    "raw": "```\n"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 0
+                }
+            },
+            "range": [
+                103,
+                109
+            ],
+            "raw": "> ```\n"
         },
         {
             "type": "Paragraph",
@@ -165,81 +247,23 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
-                    "value": "aNonTerminatedCodeBlockInABlockquote();",
+                    "meta": null,
+                    "value": "",
                     "loc": {
                         "start": {
                             "line": 13,
                             "column": 2
                         },
                         "end": {
-                            "line": 15,
-                            "column": 3
+                            "line": 14,
+                            "column": 0
                         }
                     },
                     "range": [
                         126,
-                        173
+                        130
                     ],
-                    "raw": "```\naNonTerminatedCodeBlockInABlockquote();\n```"
-                },
-                {
-                    "type": "Paragraph",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "aNewCodeBlockFollowingTheBlockQuote();",
-                            "loc": {
-                                "start": {
-                                    "line": 16,
-                                    "column": 0
-                                },
-                                "end": {
-                                    "line": 16,
-                                    "column": 38
-                                }
-                            },
-                            "range": [
-                                174,
-                                212
-                            ],
-                            "raw": "aNewCodeBlockFollowingTheBlockQuote();"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 16,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 16,
-                            "column": 38
-                        }
-                    },
-                    "range": [
-                        174,
-                        212
-                    ],
-                    "raw": "aNewCodeBlockFollowingTheBlockQuote();"
-                },
-                {
-                    "type": "CodeBlock",
-                    "lang": null,
-                    "value": "",
-                    "loc": {
-                        "start": {
-                            "line": 17,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 17,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        213,
-                        216
-                    ],
-                    "raw": "```"
+                    "raw": "```\n"
                 }
             ],
             "loc": {
@@ -248,15 +272,75 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 14,
+                    "column": 0
+                }
+            },
+            "range": [
+                124,
+                130
+            ],
+            "raw": "> ```\n"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "aNonTerminatedCodeBlockInABlockquote();",
+                    "loc": {
+                        "start": {
+                            "line": 14,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 14,
+                            "column": 39
+                        }
+                    },
+                    "range": [
+                        130,
+                        169
+                    ],
+                    "raw": "aNonTerminatedCodeBlockInABlockquote();"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 39
+                }
+            },
+            "range": [
+                130,
+                169
+            ],
+            "raw": "aNonTerminatedCodeBlockInABlockquote();"
+        },
+        {
+            "type": "CodeBlock",
+            "lang": null,
+            "meta": null,
+            "value": "aNewCodeBlockFollowingTheBlockQuote();",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
                     "line": 17,
                     "column": 3
                 }
             },
             "range": [
-                124,
+                170,
                 216
             ],
-            "raw": "> ```\naNonTerminatedCodeBlockInABlockquote();\n```\naNewCodeBlockFollowingTheBlockQuote();\n```"
+            "raw": "```\naNewCodeBlockFollowingTheBlockQuote();\n```"
         },
         {
             "type": "Paragraph",
@@ -338,26 +422,6 @@
                         260
                     ],
                     "raw": "Something in a blockquote."
-                },
-                {
-                    "type": "CodeBlock",
-                    "lang": null,
-                    "value": "aNewCodeBlock();",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        261,
-                        285
-                    ],
-                    "raw": "```\naNewCodeBlock();\n```"
                 }
             ],
             "loc": {
@@ -366,15 +430,36 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 21,
+                    "column": 28
+                }
+            },
+            "range": [
+                232,
+                260
+            ],
+            "raw": "> Something in a blockquote."
+        },
+        {
+            "type": "CodeBlock",
+            "lang": null,
+            "meta": null,
+            "value": "aNewCodeBlock();",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 0
+                },
+                "end": {
                     "line": 24,
                     "column": 3
                 }
             },
             "range": [
-                232,
+                261,
                 285
             ],
-            "raw": "> Something in a blockquote.\n```\naNewCodeBlock();\n```"
+            "raw": "```\naNewCodeBlock();\n```"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-list.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-list.text/output.json
@@ -42,41 +42,41 @@
                         23
                     ],
                     "raw": "This is a blockquote."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
                 },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                0,
+                23
+            ],
+            "raw": "> This is a blockquote."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": false,
+            "children": [
                 {
-                    "type": "List",
-                    "ordered": false,
-                    "start": null,
-                    "loose": false,
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
                     "children": [
                         {
-                            "type": "ListItem",
-                            "loose": false,
-                            "checked": null,
+                            "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "Paragraph",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "And in normal mode this is an internal list, but in commonmark this is a top level list.",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 2,
-                                                    "column": 2
-                                                },
-                                                "end": {
-                                                    "line": 2,
-                                                    "column": 90
-                                                }
-                                            },
-                                            "range": [
-                                                26,
-                                                114
-                                            ],
-                                            "raw": "And in normal mode this is an internal list, but in commonmark this is a top level list."
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "And in normal mode this is an internal list, but in commonmark this is a top level list.",
                                     "loc": {
                                         "start": {
                                             "line": 2,
@@ -97,7 +97,7 @@
                             "loc": {
                                 "start": {
                                     "line": 2,
-                                    "column": 0
+                                    "column": 2
                                 },
                                 "end": {
                                     "line": 2,
@@ -105,10 +105,10 @@
                                 }
                             },
                             "range": [
-                                24,
+                                26,
                                 114
                             ],
-                            "raw": "- And in normal mode this is an internal list, but in commonmark this is a top level list."
+                            "raw": "And in normal mode this is an internal list, but in commonmark this is a top level list."
                         }
                     ],
                     "loc": {
@@ -130,7 +130,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 1,
+                    "line": 2,
                     "column": 0
                 },
                 "end": {
@@ -139,10 +139,10 @@
                 }
             },
             "range": [
-                0,
+                24,
                 114
             ],
-            "raw": "> This is a blockquote.\n- And in normal mode this is an internal list, but in commonmark this is a top level list."
+            "raw": "- And in normal mode this is an internal list, but in commonmark this is a top level list."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-rule.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-lazy-rule.text/output.json
@@ -42,24 +42,6 @@
                         43
                     ],
                     "raw": "This is a blockquote. Followed by a rule."
-                },
-                {
-                    "type": "HorizontalRule",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        44,
-                        49
-                    ],
-                    "raw": "* * *"
                 }
             ],
             "loc": {
@@ -68,15 +50,33 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 1,
+                    "column": 43
+                }
+            },
+            "range": [
+                0,
+                43
+            ],
+            "raw": "> This is a blockquote. Followed by a rule."
+        },
+        {
+            "type": "HorizontalRule",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
                     "line": 2,
                     "column": 5
                 }
             },
             "range": [
-                0,
+                44,
                 49
             ],
-            "raw": "> This is a blockquote. Followed by a rule.\n* * *"
+            "raw": "* * *"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-list-item.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquote-list-item.text/output.json
@@ -44,11 +44,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquotes-with-code-blocks.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquotes-with-code-blocks.text/output.json
@@ -46,6 +46,7 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
+                    "meta": null,
                     "value": "sub status {\n    print \"working\";\n}",
                     "loc": {
                         "start": {
@@ -105,6 +106,7 @@
                 {
                     "type": "CodeBlock",
                     "lang": null,
+                    "meta": null,
                     "value": "sub status {\n    return \"working\";\n}",
                     "loc": {
                         "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/blockquotes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/blockquotes.text/output.json
@@ -42,7 +42,27 @@
                         23
                     ],
                     "raw": "This is a blockquote."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
                 },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                0,
+                23
+            ],
+            "raw": "> This is a blockquote."
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -85,7 +105,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 1,
+                    "line": 3,
                     "column": 0
                 },
                 "end": {
@@ -94,10 +114,10 @@
                 }
             },
             "range": [
-                0,
+                25,
                 75
             ],
-            "raw": "> This is a blockquote.\n\n> This is, in commonmark mode, another blockquote."
+            "raw": "> This is, in commonmark mode, another blockquote."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
@@ -11,35 +11,35 @@
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 3
+                            "column": 2
                         },
                         "end": {
                             "line": 1,
-                            "column": 19
+                            "column": 18
                         }
                     },
                     "range": [
-                        3,
-                        19
+                        2,
+                        18
                     ],
-                    "raw": "Hello from a BOM"
+                    "raw": " Hello from a BO"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 1
+                    "column": 0
                 },
                 "end": {
                     "line": 1,
-                    "column": 19
+                    "column": 18
                 }
             },
             "range": [
-                1,
-                19
+                0,
+                18
             ],
-            "raw": "# Hello from a BOM"
+            "raw": "﻿# Hello from a BO"
         },
         {
             "type": "Paragraph",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
@@ -22,7 +22,7 @@
                         2,
                         18
                     ],
-                    "raw": " Hello from a BO"
+                    "raw": "Hello from a BOM"
                 }
             ],
             "loc": {
@@ -39,7 +39,7 @@
                 0,
                 18
             ],
-            "raw": "﻿# Hello from a BO"
+            "raw": "# Hello from a BOM"
         },
         {
             "type": "Paragraph",
@@ -61,7 +61,7 @@
                         20,
                         54
                     ],
-                    "raw": "\nBe careful when editing this file"
+                    "raw": "Be careful when editing this file!"
                 }
             ],
             "loc": {
@@ -78,7 +78,7 @@
                 20,
                 54
             ],
-            "raw": "\nBe careful when editing this file"
+            "raw": "Be careful when editing this file!"
         }
     ],
     "loc": {
@@ -95,5 +95,5 @@
         0,
         55
     ],
-    "raw": "﻿# Hello from a BOM\n\nBe careful when editing this file!"
+    "raw": "# Hello from a BOM\n\nBe careful when editing this file!\n"
 }

--- a/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/bom.text/output.json
@@ -58,10 +58,10 @@
                         }
                     },
                     "range": [
-                        21,
-                        55
+                        20,
+                        54
                     ],
-                    "raw": "Be careful when editing this file!"
+                    "raw": "\nBe careful when editing this file"
                 }
             ],
             "loc": {
@@ -75,10 +75,10 @@
                 }
             },
             "range": [
-                21,
-                55
+                20,
+                54
             ],
-            "raw": "Be careful when editing this file!"
+            "raw": "\nBe careful when editing this file"
         }
     ],
     "loc": {
@@ -93,7 +93,7 @@
     },
     "range": [
         0,
-        56
+        55
     ],
-    "raw": "﻿# Hello from a BOM\n\nBe careful when editing this file!\n"
+    "raw": "﻿# Hello from a BOM\n\nBe careful when editing this file!"
 }

--- a/packages/@textlint/markdown-to-ast/test/fixtures/breaks-hard.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/breaks-hard.text/output.json
@@ -503,10 +503,84 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Look at the\\\npretty line\\\nbreaks.",
+                    "value": "Look at the",
                     "loc": {
                         "start": {
                             "line": 15,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        349,
+                        360
+                    ],
+                    "raw": "Look at the"
+                },
+                {
+                    "type": "Break",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        360,
+                        362
+                    ],
+                    "raw": "\\\n"
+                },
+                {
+                    "type": "Str",
+                    "value": "pretty line",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        362,
+                        373
+                    ],
+                    "raw": "pretty line"
+                },
+                {
+                    "type": "Break",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 17,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        373,
+                        375
+                    ],
+                    "raw": "\\\n"
+                },
+                {
+                    "type": "Str",
+                    "value": "breaks.",
+                    "loc": {
+                        "start": {
+                            "line": 17,
                             "column": 0
                         },
                         "end": {
@@ -515,10 +589,10 @@
                         }
                     },
                     "range": [
-                        349,
+                        375,
                         382
                     ],
-                    "raw": "Look at the\\\npretty line\\\nbreaks."
+                    "raw": "breaks."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/input.md
@@ -1,0 +1,1 @@
+This is broken: http&#x3B;//example.com/path?key=value#fragment

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/input.md
@@ -1,1 +1,1 @@
-This is broken: http&#x3B;//example.com/path?key=value#fragment
+This is broken: http&#x3A;//example.com/path?key=value#fragment

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/output.json
@@ -1,0 +1,59 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "This is broken: http;//example.com/path?key=value#fragment",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 63
+                        }
+                    },
+                    "range": [
+                        0,
+                        63
+                    ],
+                    "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 63
+                }
+            },
+            "range": [
+                0,
+                63
+            ],
+            "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        64
+    ],
+    "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-auto-link/output.json
@@ -6,22 +6,18 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is broken: http;//example.com/path?key=value#fragment",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 63
+                    "value": "This is broken: "
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "http://example.com/path?key=value#fragment",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "http://example.com/path?key=value#fragment"
                         }
-                    },
-                    "range": [
-                        0,
-                        63
-                    ],
-                    "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment"
+                    ]
                 }
             ],
             "loc": {
@@ -38,7 +34,7 @@
                 0,
                 63
             ],
-            "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment"
+            "raw": "This is broken: http&#x3A;//example.com/path?key=value#fragment"
         }
     ],
     "loc": {
@@ -55,5 +51,5 @@
         0,
         64
     ],
-    "raw": "This is broken: http&#x3B;//example.com/path?key=value#fragment\n"
+    "raw": "This is broken: http&#x3A;//example.com/path?key=value#fragment\n"
 }

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-manuall-link/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-manuall-link/input.md
@@ -1,0 +1,1 @@
+This is broken url <http&#x3A;//example.com/path?key=value#fragment> but it is link

--- a/packages/@textlint/markdown-to-ast/test/fixtures/broken-manuall-link/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/broken-manuall-link/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is broken: http://example.com/path?key=value#fragment",
+                    "value": "This is broken url <http://example.com/path?key=value#fragment> but it is link",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 63
+                            "column": 83
                         }
                     },
                     "range": [
                         0,
-                        63
+                        83
                     ],
-                    "raw": "This is broken: http&#x3A;//example.com/path?key=value#fragment"
+                    "raw": "This is broken url <http&#x3A;//example.com/path?key=value#fragment> but it is link"
                 }
             ],
             "loc": {
@@ -31,14 +31,14 @@
                 },
                 "end": {
                     "line": 1,
-                    "column": 63
+                    "column": 83
                 }
             },
             "range": [
                 0,
-                63
+                83
             ],
-            "raw": "This is broken: http&#x3A;//example.com/path?key=value#fragment"
+            "raw": "This is broken url <http&#x3A;//example.com/path?key=value#fragment> but it is link"
         }
     ],
     "loc": {
@@ -53,7 +53,7 @@
     },
     "range": [
         0,
-        64
+        84
     ],
-    "raw": "This is broken: http&#x3A;//example.com/path?key=value#fragment\n"
+    "raw": "This is broken url <http&#x3A;//example.com/path?key=value#fragment> but it is link\n"
 }

--- a/packages/@textlint/markdown-to-ast/test/fixtures/case-insensitive-refs.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/case-insensitive-refs.text/output.json
@@ -6,8 +6,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "hi",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -29,6 +27,9 @@
                             "raw": "hi"
                         }
                     ],
+                    "identifier": "hi",
+                    "label": "hi",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -65,6 +66,7 @@
         {
             "type": "Definition",
             "identifier": "hi",
+            "label": "HI",
             "title": null,
             "url": "/url",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-block-indentation.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-block-indentation.nooutput.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "    This is a code block...\n        \n    ...which is not exdented.",
             "loc": {
                 "start": {
@@ -102,11 +103,12 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "  This one...\n      \n  ...is.",
             "loc": {
                 "start": {
                     "line": 13,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 17,
@@ -114,10 +116,10 @@
                 }
             },
             "range": [
-                252,
+                254,
                 299
             ],
-            "raw": "  ```\n    This one...\n        \n    ...is.\n  ```"
+            "raw": "```\n    This one...\n        \n    ...is.\n  ```"
         },
         {
             "type": "Paragraph",
@@ -161,11 +163,12 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "So is this...\n      \n  ...one.",
             "loc": {
                 "start": {
                     "line": 21,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 25,
@@ -173,10 +176,10 @@
                 }
             },
             "range": [
-                309,
+                310,
                 351
             ],
-            "raw": " ```\nSo is this...\n       \n   ...one.\n ```"
+            "raw": "```\nSo is this...\n       \n   ...one.\n ```"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-block-nesting-bug.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-block-nesting-bug.nooutput.text/output.json
@@ -82,6 +82,7 @@
         {
             "type": "CodeBlock",
             "lang": "foo",
+            "meta": null,
             "value": "```bar\nbaz\n```",
             "loc": {
                 "start": {
@@ -141,6 +142,7 @@
         {
             "type": "CodeBlock",
             "lang": "foo",
+            "meta": null,
             "value": "~~~bar\nbaz\n~~~",
             "loc": {
                 "start": {
@@ -200,6 +202,7 @@
         {
             "type": "CodeBlock",
             "lang": "foo",
+            "meta": null,
             "value": "~~~bar\nbaz\n~~~",
             "loc": {
                 "start": {
@@ -220,6 +223,7 @@
         {
             "type": "CodeBlock",
             "lang": "foo",
+            "meta": null,
             "value": "```bar\nbaz\n```",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-block.output.fence=`.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-block.output.fence=`.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": "javascript",
+            "meta": null,
             "value": "alert('Hello World!');",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-block.output.fence=~.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-block.output.fence=~.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": "javascript",
+            "meta": null,
             "value": "alert('Hello World!');",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.output.fences.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.output.fences.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "alert('Hello World!');",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.output.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "alert('Hello World!');",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-blocks.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "code block on the first line",
             "loc": {
                 "start": {
@@ -11,15 +12,15 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 2,
-                    "column": 1
+                    "line": 1,
+                    "column": 29
                 }
             },
             "range": [
                 0,
-                31
+                29
             ],
-            "raw": "\tcode block on the first line\n\t"
+            "raw": "\tcode block on the first line"
         },
         {
             "type": "Paragraph",
@@ -63,6 +64,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "code block indented by spaces",
             "loc": {
                 "start": {
@@ -122,6 +124,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "the lines in this block  \nall contain trailing spaces  ",
             "loc": {
                 "start": {
@@ -181,6 +184,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "code block on the last line",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/code-spans.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/code-spans.text/output.json
@@ -256,7 +256,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Additionally, empty code spans are also supported: ",
+                    "value": "Additionally, empty code spans are also supported: ``.",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -264,52 +264,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 51
-                        }
-                    },
-                    "range": [
-                        167,
-                        218
-                    ],
-                    "raw": "Additionally, empty code spans are also supported: "
-                },
-                {
-                    "type": "Code",
-                    "value": "",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 51
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 53
-                        }
-                    },
-                    "range": [
-                        218,
-                        220
-                    ],
-                    "raw": "``"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 53
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 54
                         }
                     },
                     "range": [
-                        220,
+                        167,
                         221
                     ],
-                    "raw": "."
+                    "raw": "Additionally, empty code spans are also supported: ``."
                 }
             ],
             "loc": {
@@ -352,7 +314,7 @@
                 },
                 {
                     "type": "Code",
-                    "value": "foo ` bar",
+                    "value": "foo ` bar ",
                     "loc": {
                         "start": {
                             "line": 9,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/def-blocks.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/def-blocks.text/output.json
@@ -9,47 +9,25 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "hello",
+                            "value": "hello\n",
                             "loc": {
                                 "start": {
                                     "line": 1,
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 1,
-                                    "column": 7
+                                    "line": 2,
+                                    "column": 0
                                 }
                             },
                             "range": [
                                 2,
-                                7
+                                8
                             ],
-                            "raw": "hello"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 2
+                            "raw": "hello\n"
                         },
-                        "end": {
-                            "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        2,
-                        7
-                    ],
-                    "raw": "hello"
-                },
-                {
-                    "type": "Paragraph",
-                    "children": [
                         {
                             "type": "LinkReference",
-                            "identifier": "1",
-                            "referenceType": "shortcut",
                             "children": [
                                 {
                                     "type": "Str",
@@ -71,6 +49,9 @@
                                     "raw": "1"
                                 }
                             ],
+                            "identifier": "1",
+                            "label": "1",
+                            "referenceType": "shortcut",
                             "loc": {
                                 "start": {
                                     "line": 2,
@@ -109,7 +90,7 @@
                     ],
                     "loc": {
                         "start": {
-                            "line": 2,
+                            "line": 1,
                             "column": 2
                         },
                         "end": {
@@ -118,10 +99,10 @@
                         }
                     },
                     "range": [
-                        10,
+                        2,
                         20
                     ],
-                    "raw": "[1]: hello"
+                    "raw": "hello\n> [1]: hello"
                 }
             ],
             "loc": {
@@ -220,6 +201,7 @@
         {
             "type": "Definition",
             "identifier": "2",
+            "label": "2",
             "title": null,
             "url": "hello",
             "loc": {
@@ -242,11 +224,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -307,73 +289,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "LinkReference",
-                                    "identifier": "3",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "3",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 11,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 11,
-                                                    "column": 4
-                                                }
-                                            },
-                                            "range": [
-                                                61,
-                                                62
-                                            ],
-                                            "raw": "3"
-                                        }
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 11,
-                                            "column": 2
-                                        },
-                                        "end": {
-                                            "line": 11,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        60,
-                                        63
-                                    ],
-                                    "raw": "[3]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ": hello",
-                                    "loc": {
-                                        "start": {
-                                            "line": 11,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 11,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        63,
-                                        70
-                                    ],
-                                    "raw": ": hello"
-                                }
-                            ],
+                            "type": "Definition",
+                            "identifier": "3",
+                            "label": "3",
+                            "title": null,
+                            "url": "hello",
                             "loc": {
                                 "start": {
                                     "line": 11,
@@ -406,33 +330,10 @@
                         70
                     ],
                     "raw": "* [3]: hello"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 10,
-                    "column": 0
                 },
-                "end": {
-                    "line": 11,
-                    "column": 12
-                }
-            },
-            "range": [
-                50,
-                70
-            ],
-            "raw": "* hello\n* [3]: hello"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": false,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -494,7 +395,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 14,
+                    "line": 10,
                     "column": 0
                 },
                 "end": {
@@ -503,14 +404,15 @@
                 }
             },
             "range": [
-                73,
+                50,
                 80
             ],
-            "raw": "* hello"
+            "raw": "* hello\n* [3]: hello\n\n\n* hello"
         },
         {
             "type": "Definition",
             "identifier": "4",
+            "label": "4",
             "title": null,
             "url": "hello",
             "loc": {
@@ -591,6 +493,7 @@
         {
             "type": "Definition",
             "identifier": "1",
+            "label": "1",
             "title": null,
             "url": "foo",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/definition-newline.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/definition-newline.text/output.json
@@ -2,69 +2,11 @@
     "type": "Document",
     "children": [
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "baz",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                1,
-                                4
-                            ],
-                            "raw": "baz"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        0,
-                        5
-                    ],
-                    "raw": "[baz]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url (\n)",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 1
-                        }
-                    },
-                    "range": [
-                        5,
-                        15
-                    ],
-                    "raw": ": /url (\n)"
-                }
-            ],
+            "type": "Definition",
+            "identifier": "baz",
+            "label": "baz",
+            "title": "\n",
+            "url": "/url",
             "loc": {
                 "start": {
                     "line": 1,
@@ -82,69 +24,11 @@
             "raw": "[baz]: /url (\n)"
         },
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                18,
-                                21
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        17,
-                        22
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url \"\n\"",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 1
-                        }
-                    },
-                    "range": [
-                        22,
-                        32
-                    ],
-                    "raw": ": /url \"\n\""
-                }
-            ],
+            "type": "Definition",
+            "identifier": "foo",
+            "label": "foo",
+            "title": "\n",
+            "url": "/url",
             "loc": {
                 "start": {
                     "line": 4,
@@ -162,69 +46,11 @@
             "raw": "[foo]: /url \"\n\""
         },
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 7,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                35,
-                                38
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        34,
-                        39
-                    ],
-                    "raw": "[bar]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url '\n'",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 8,
-                            "column": 1
-                        }
-                    },
-                    "range": [
-                        39,
-                        49
-                    ],
-                    "raw": ": /url '\n'"
-                }
-            ],
+            "type": "Definition",
+            "identifier": "bar",
+            "label": "bar",
+            "title": "\n",
+            "url": "/url",
             "loc": {
                 "start": {
                     "line": 7,
@@ -244,6 +70,7 @@
         {
             "type": "Definition",
             "identifier": "baz",
+            "label": "baz",
             "title": "foo\nbar",
             "url": "/url",
             "loc": {
@@ -265,6 +92,7 @@
         {
             "type": "Definition",
             "identifier": "baz",
+            "label": "baz",
             "title": "foo\nbar",
             "url": "/url",
             "loc": {
@@ -286,6 +114,7 @@
         {
             "type": "Definition",
             "identifier": "baz",
+            "label": "baz",
             "title": "foo\nbar",
             "url": "/url",
             "loc": {
@@ -309,8 +138,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -332,6 +159,9 @@
                             "raw": "baz"
                         }
                     ],
+                    "identifier": "baz",
+                    "label": "baz",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 18,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/definition-unclosed-attribute.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/definition-unclosed-attribute.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "baz",
-                            "loc": {
-                                "start": {
-                                    "line": 2,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 2,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                2,
-                                5
-                            ],
-                            "raw": "baz"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[baz]: /url (there",
                     "loc": {
                         "start": {
                             "line": 2,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 2,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        1,
-                        6
-                    ],
-                    "raw": "[baz]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url (there",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 2,
                             "column": 18
                         }
                     },
                     "range": [
-                        6,
+                        1,
                         19
                     ],
-                    "raw": ": /url (there"
+                    "raw": "[baz]: /url (there"
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                22,
-                                25
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[foo]: /url \"there",
                     "loc": {
                         "start": {
                             "line": 4,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 4,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        21,
-                        26
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url \"there",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 4,
                             "column": 18
                         }
                     },
                     "range": [
-                        26,
+                        21,
                         39
                     ],
-                    "raw": ": /url \"there"
+                    "raw": "[foo]: /url \"there"
                 }
             ],
             "loc": {
@@ -165,30 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 6,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 6,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                42,
-                                45
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar]: /url 'there",
                     "loc": {
                         "start": {
                             "line": 6,
@@ -196,33 +92,14 @@
                         },
                         "end": {
                             "line": 6,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        41,
-                        46
-                    ],
-                    "raw": "[bar]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url 'there",
-                    "loc": {
-                        "start": {
-                            "line": 6,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 6,
                             "column": 18
                         }
                     },
                     "range": [
-                        46,
+                        41,
                         59
                     ],
-                    "raw": ": /url 'there"
+                    "raw": "[bar]: /url 'there"
                 }
             ],
             "loc": {
@@ -245,30 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "baz",
-                            "loc": {
-                                "start": {
-                                    "line": 8,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 8,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                62,
-                                65
-                            ],
-                            "raw": "baz"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[baz]: url (",
                     "loc": {
                         "start": {
                             "line": 8,
@@ -276,33 +131,14 @@
                         },
                         "end": {
                             "line": 8,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        61,
-                        66
-                    ],
-                    "raw": "[baz]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": url (",
-                    "loc": {
-                        "start": {
-                            "line": 8,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 8,
                             "column": 12
                         }
                     },
                     "range": [
-                        66,
+                        61,
                         73
                     ],
-                    "raw": ": url ("
+                    "raw": "[baz]: url ("
                 }
             ],
             "loc": {
@@ -325,30 +161,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 10,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                76,
-                                79
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[foo]: url \"",
                     "loc": {
                         "start": {
                             "line": 10,
@@ -356,33 +170,14 @@
                         },
                         "end": {
                             "line": 10,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        75,
-                        80
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": url \"",
-                    "loc": {
-                        "start": {
-                            "line": 10,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 10,
                             "column": 12
                         }
                     },
                     "range": [
-                        80,
+                        75,
                         87
                     ],
-                    "raw": ": url \""
+                    "raw": "[foo]: url \""
                 }
             ],
             "loc": {
@@ -405,30 +200,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 12,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 12,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                90,
-                                93
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar]: /url '",
                     "loc": {
                         "start": {
                             "line": 12,
@@ -436,33 +209,14 @@
                         },
                         "end": {
                             "line": 12,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        89,
-                        94
-                    ],
-                    "raw": "[bar]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": /url '",
-                    "loc": {
-                        "start": {
-                            "line": 12,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 12,
                             "column": 13
                         }
                     },
                     "range": [
-                        94,
+                        89,
                         102
                     ],
-                    "raw": ": /url '"
+                    "raw": "[bar]: /url '"
                 }
             ],
             "loc": {
@@ -485,30 +239,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "baz",
-                            "loc": {
-                                "start": {
-                                    "line": 14,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 14,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                105,
-                                108
-                            ],
-                            "raw": "baz"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[baz]: ",
                     "loc": {
                         "start": {
                             "line": 14,
@@ -516,33 +248,14 @@
                         },
                         "end": {
                             "line": 14,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        104,
-                        109
-                    ],
-                    "raw": "[baz]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": ",
-                    "loc": {
-                        "start": {
-                            "line": 14,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 14,
                             "column": 7
                         }
                     },
                     "range": [
-                        109,
+                        104,
                         111
                     ],
-                    "raw": ": "
+                    "raw": "[baz]: "
                 },
                 {
                     "type": "Html",
@@ -603,30 +316,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 16,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 16,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                120,
-                                123
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[foo]: ",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -634,33 +325,14 @@
                         },
                         "end": {
                             "line": 16,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        119,
-                        124
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": ",
-                    "loc": {
-                        "start": {
-                            "line": 16,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 16,
                             "column": 7
                         }
                     },
                     "range": [
-                        124,
+                        119,
                         126
                     ],
-                    "raw": ": "
+                    "raw": "[foo]: "
                 },
                 {
                     "type": "Html",
@@ -721,30 +393,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                135,
-                                138
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar]: ",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -752,33 +402,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        134,
-                        139
-                    ],
-                    "raw": "[bar]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": ",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 7
                         }
                     },
                     "range": [
-                        139,
+                        134,
                         141
                     ],
-                    "raw": ": "
+                    "raw": "[bar]: "
                 },
                 {
                     "type": "Html",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/definition-unclosed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/definition-unclosed.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                1,
-                                4
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[foo]:",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        0,
-                        5
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ":",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 6
                         }
                     },
                     "range": [
-                        5,
+                        0,
                         6
                     ],
-                    "raw": ":"
+                    "raw": "[foo]:"
                 }
             ],
             "loc": {
@@ -82,10 +41,28 @@
             "raw": "[foo]:"
         },
         {
-            "type": "Definition",
-            "identifier": "bar",
-            "title": null,
-            "url": "</url",
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "[bar]: </url",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 12
+                        }
+                    },
+                    "range": [
+                        8,
+                        20
+                    ],
+                    "raw": "[bar]: </url"
+                }
+            ],
             "loc": {
                 "start": {
                     "line": 3,
@@ -106,30 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "foo",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                23,
-                                26
-                            ],
-                            "raw": "foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[foo]:",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -137,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        22,
-                        27
-                    ],
-                    "raw": "[foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ":",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 6
                         }
                     },
                     "range": [
-                        27,
+                        22,
                         28
                     ],
-                    "raw": ":"
+                    "raw": "[foo]:"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/double-link.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/double-link.text/output.json
@@ -161,28 +161,8 @@
                     "raw": "<a href=\"http://example.com/\">"
                 },
                 {
-                    "type": "Strong",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "http://example.com/",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 48
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 67
-                                }
-                            },
-                            "range": [
-                                188,
-                                207
-                            ],
-                            "raw": "http://example.com/"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "**",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -190,14 +170,55 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 69
+                            "column": 48
                         }
                     },
                     "range": [
                         186,
+                        188
+                    ],
+                    "raw": "**"
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "http://example.com/**",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "http://example.com/**",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 48
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 69
+                                }
+                            },
+                            "range": [
+                                188,
+                                209
+                            ],
+                            "raw": "http://example.com/**"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 48
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 69
+                        }
+                    },
+                    "range": [
+                        188,
                         209
                     ],
-                    "raw": "**http://example.com/**"
+                    "raw": "http://example.com/**"
                 },
                 {
                     "type": "Html",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/emphasis-escaped-final-marker.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/emphasis-escaped-final-marker.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "*bar",
+                    "value": "*bar*",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        0,
-                        4
-                    ],
-                    "raw": "*bar"
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 6
                         }
                     },
                     "range": [
-                        4,
+                        0,
                         6
                     ],
-                    "raw": "\\*"
+                    "raw": "*bar\\*"
                 }
             ],
             "loc": {
@@ -64,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "**bar",
+                    "value": "*",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -72,41 +53,42 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 5
+                            "column": 1
                         }
                     },
                     "range": [
                         8,
-                        13
+                        9
                     ],
-                    "raw": "**bar"
+                    "raw": "*"
                 },
                 {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 7
+                    "type": "Emphasis",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "bar*",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                10,
+                                15
+                            ],
+                            "raw": "bar\\*"
                         }
-                    },
-                    "range": [
-                        13,
-                        15
                     ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 7
+                            "column": 1
                         },
                         "end": {
                             "line": 3,
@@ -114,10 +96,10 @@
                         }
                     },
                     "range": [
-                        15,
+                        9,
                         16
                     ],
-                    "raw": "*"
+                    "raw": "*bar\\**"
                 }
             ],
             "loc": {
@@ -141,7 +123,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "_bar",
+                    "value": "_bar_",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -149,33 +131,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        18,
-                        22
-                    ],
-                    "raw": "_bar"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 6
                         }
                     },
                     "range": [
-                        22,
+                        18,
                         24
                     ],
-                    "raw": "\\_"
+                    "raw": "_bar\\_"
                 }
             ],
             "loc": {
@@ -199,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "__bar",
+                    "value": "_",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -207,41 +170,42 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 5
+                            "column": 1
                         }
                     },
                     "range": [
                         26,
-                        31
+                        27
                     ],
-                    "raw": "__bar"
+                    "raw": "_"
                 },
                 {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 7
+                    "type": "Emphasis",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "bar_",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                28,
+                                33
+                            ],
+                            "raw": "bar\\_"
                         }
-                    },
-                    "range": [
-                        31,
-                        33
                     ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 7
+                            "column": 1
                         },
                         "end": {
                             "line": 7,
@@ -249,10 +213,10 @@
                         }
                     },
                     "range": [
-                        33,
+                        27,
                         34
                     ],
-                    "raw": "_"
+                    "raw": "_bar\\__"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities-advanced.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities-advanced.text/output.json
@@ -42,7 +42,27 @@
                         53
                     ],
                     "raw": "However, &MadeUpEntities; are kept in the document."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
                 },
+                "end": {
+                    "line": 1,
+                    "column": 53
+                }
+            },
+            "range": [
+                0,
+                53
+            ],
+            "raw": "> However, &MadeUpEntities; are kept in the document."
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -81,10 +101,31 @@
                         119
                     ],
                     "raw": "Entities even work in the language flag of fenced code blocks:"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
                 },
+                "end": {
+                    "line": 3,
+                    "column": 64
+                }
+            },
+            "range": [
+                55,
+                119
+            ],
+            "raw": "> Entities even work in the language flag of fenced code blocks:"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "CodeBlock",
-                    "lang": "some©language",
+                    "lang": "some&copylanguage",
+                    "meta": null,
                     "value": "alert('Hello');",
                     "loc": {
                         "start": {
@@ -101,7 +142,27 @@
                         167
                     ],
                     "raw": "```some&copylanguage\n> alert('Hello');\n> ```"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
                 },
+                "end": {
+                    "line": 7,
+                    "column": 5
+                }
+            },
+            "range": [
+                121,
+                167
+            ],
+            "raw": "> ```some&copylanguage\n> alert('Hello');\n> ```"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -167,7 +228,7 @@
                         },
                         {
                             "type": "Str",
-                            "value": "\nxample",
+                            "value": "\nxample&copyxample.com>",
                             "loc": {
                                 "start": {
                                     "line": 9,
@@ -175,52 +236,14 @@
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                201,
-                                210
-                            ],
-                            "raw": "\n> xample"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "©",
-                            "loc": {
-                                "start": {
-                                    "line": 10,
-                                    "column": 8
-                                },
-                                "end": {
-                                    "line": 10,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                210,
-                                215
-                            ],
-                            "raw": "&copy"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "xample.com>",
-                            "loc": {
-                                "start": {
-                                    "line": 10,
-                                    "column": 13
-                                },
-                                "end": {
-                                    "line": 10,
                                     "column": 24
                                 }
                             },
                             "range": [
-                                215,
+                                201,
                                 226
                             ],
-                            "raw": "xample.com>"
+                            "raw": "\n> xample&copyxample.com>"
                         }
                     ],
                     "loc": {
@@ -238,7 +261,27 @@
                         226
                     ],
                     "raw": "And in an auto-link: <http://e\n> xample&copyxample.com>"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 0
                 },
+                "end": {
+                    "line": 10,
+                    "column": 24
+                }
+            },
+            "range": [
+                169,
+                226
+            ],
+            "raw": "> And in an auto-link: <http://e\n> xample&copyxample.com>"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -268,7 +311,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://example",
+                                    "value": "http://example&copyxample.com",
                                     "loc": {
                                         "start": {
                                             "line": 12,
@@ -276,52 +319,14 @@
                                         },
                                         "end": {
                                             "line": 12,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        246,
-                                        260
-                                    ],
-                                    "raw": "http://example"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 12,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 12,
-                                            "column": 37
-                                        }
-                                    },
-                                    "range": [
-                                        260,
-                                        265
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "xample.com",
-                                    "loc": {
-                                        "start": {
-                                            "line": 12,
-                                            "column": 37
-                                        },
-                                        "end": {
-                                            "line": 12,
                                             "column": 47
                                         }
                                     },
                                     "range": [
-                                        265,
+                                        246,
                                         275
                                     ],
-                                    "raw": "xample.com"
+                                    "raw": "http://example&copyxample.com"
                                 }
                             ],
                             "loc": {
@@ -375,7 +380,27 @@
                         284
                     ],
                     "raw": "Foo and bar and http://example&copyxample.com and baz."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 0
                 },
+                "end": {
+                    "line": 12,
+                    "column": 56
+                }
+            },
+            "range": [
+                228,
+                284
+            ],
+            "raw": "> Foo and bar and http://example&copyxample.com and baz."
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -400,12 +425,12 @@
                         },
                         {
                             "type": "Link",
-                            "title": "in some pl©ce",
+                            "title": "in some pl&copyce",
                             "url": "~/some&copyfile",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "l",
+                                    "value": "l&copynks",
                                     "loc": {
                                         "start": {
                                             "line": 14,
@@ -413,52 +438,14 @@
                                         },
                                         "end": {
                                             "line": 14,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        295,
-                                        296
-                                    ],
-                                    "raw": "l"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 14,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        296,
-                                        301
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "nks",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 14,
                                             "column": 18
                                         }
                                     },
                                     "range": [
-                                        301,
+                                        295,
                                         304
                                     ],
-                                    "raw": "nks"
+                                    "raw": "l&copynks"
                                 }
                             ],
                             "loc": {
@@ -493,7 +480,27 @@
                         347
                     ],
                     "raw": "Or in [l&copynks](\n>   ~/some&copyfile \"in some pl&copyce\")"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
                 },
+                "end": {
+                    "line": 15,
+                    "column": 40
+                }
+            },
+            "range": [
+                286,
+                347
+            ],
+            "raw": "> Or in [l&copynks](\n>   ~/some&copyfile \"in some pl&copyce\")"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -518,12 +525,12 @@
                         },
                         {
                             "type": "Link",
-                            "title": "in some pl©ce",
+                            "title": "in some pl&copyce",
                             "url": "~/some&copyfile",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "l",
+                                    "value": "l&copylnks",
                                     "loc": {
                                         "start": {
                                             "line": 17,
@@ -531,52 +538,14 @@
                                         },
                                         "end": {
                                             "line": 17,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        358,
-                                        359
-                                    ],
-                                    "raw": "l"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 17,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 17,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        359,
-                                        364
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "lnks",
-                                    "loc": {
-                                        "start": {
-                                            "line": 17,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 17,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        364,
+                                        358,
                                         368
                                     ],
-                                    "raw": "lnks"
+                                    "raw": "l&copylnks"
                                 }
                             ],
                             "loc": {
@@ -611,7 +580,27 @@
                         417
                     ],
                     "raw": "Or in [l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
                 },
+                "end": {
+                    "line": 19,
+                    "column": 24
+                }
+            },
+            "range": [
+                349,
+                417
+            ],
+            "raw": "> Or in [l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
@@ -636,9 +625,9 @@
                         },
                         {
                             "type": "Image",
-                            "title": "in some pl©ce",
+                            "title": "in some pl&copyce",
                             "url": "~/some&copyfile",
-                            "alt": "\n  l©nks\n",
+                            "alt": "\nl&copynks\n",
                             "loc": {
                                 "start": {
                                     "line": 21,
@@ -675,7 +664,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 1,
+                    "line": 21,
                     "column": 0
                 },
                 "end": {
@@ -684,10 +673,10 @@
                 }
             },
             "range": [
-                0,
+                419,
                 489
             ],
-            "raw": "> However, &MadeUpEntities; are kept in the document.\n\n> Entities even work in the language flag of fenced code blocks:\n\n> ```some&copylanguage\n> alert('Hello');\n> ```\n\n> And in an auto-link: <http://e\n> xample&copyxample.com>\n\n> Foo and bar and http://example&copyxample.com and baz.\n\n> Or in [l&copynks](\n>   ~/some&copyfile \"in some pl&copyce\")\n\n> Or in [l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")\n\n> Or in ![\n>   l&copynks\n> ](\n>   ~/some&copyfile \"in some pl&copyce\")"
+            "raw": "> Or in ![\n>   l&copynks\n> ](\n>   ~/some&copyfile \"in some pl&copyce\")"
         },
         {
             "type": "HorizontalRule",
@@ -734,9 +723,9 @@
                         },
                         {
                             "type": "Image",
-                            "title": "in some pl©ce",
+                            "title": "in some pl&copyce",
                             "url": "~/some&copyfile",
-                            "alt": "l©lnks",
+                            "alt": "l&copylnks",
                             "loc": {
                                 "start": {
                                     "line": 28,
@@ -769,38 +758,37 @@
                         565
                     ],
                     "raw": "Or in ![l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 28,
+                    "column": 0
                 },
+                "end": {
+                    "line": 30,
+                    "column": 24
+                }
+            },
+            "range": [
+                496,
+                565
+            ],
+            "raw": "> Or in ![l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Or in ",
+                            "value": "Or in ![\nl&copynks\n][12]",
                             "loc": {
                                 "start": {
                                     "line": 32,
                                     "column": 2
-                                },
-                                "end": {
-                                    "line": 32,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                569,
-                                575
-                            ],
-                            "raw": "Or in "
-                        },
-                        {
-                            "type": "ImageReference",
-                            "identifier": "12",
-                            "referenceType": "full",
-                            "alt": "\n  l©nks\n",
-                            "loc": {
-                                "start": {
-                                    "line": 32,
-                                    "column": 8
                                 },
                                 "end": {
                                     "line": 34,
@@ -808,10 +796,10 @@
                                 }
                             },
                             "range": [
-                                575,
+                                569,
                                 599
                             ],
-                            "raw": "![\n>   l&copynks\n> ][12]"
+                            "raw": "Or in ![\n>   l&copynks\n> ][12]"
                         }
                     ],
                     "loc": {
@@ -829,207 +817,33 @@
                         599
                     ],
                     "raw": "Or in ![\n>   l&copynks\n> ][12]"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 32,
+                    "column": 0
                 },
+                "end": {
+                    "line": 34,
+                    "column": 7
+                }
+            },
+            "range": [
+                567,
+                599
+            ],
+            "raw": "> Or in ![\n>   l&copynks\n> ][12]"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
-                    "type": "Paragraph",
-                    "children": [
-                        {
-                            "type": "LinkReference",
-                            "identifier": "1",
-                            "referenceType": "shortcut",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "1",
-                                    "loc": {
-                                        "start": {
-                                            "line": 36,
-                                            "column": 3
-                                        },
-                                        "end": {
-                                            "line": 36,
-                                            "column": 4
-                                        }
-                                    },
-                                    "range": [
-                                        604,
-                                        605
-                                    ],
-                                    "raw": "1"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 36,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 36,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                603,
-                                606
-                            ],
-                            "raw": "[1]"
-                        },
-                        {
-                            "type": "Str",
-                            "value": ": ",
-                            "loc": {
-                                "start": {
-                                    "line": 36,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 36,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                606,
-                                608
-                            ],
-                            "raw": ": "
-                        },
-                        {
-                            "type": "Link",
-                            "title": null,
-                            "url": "http://example&copyxample.com",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "http://example",
-                                    "loc": {
-                                        "start": {
-                                            "line": 36,
-                                            "column": 7
-                                        },
-                                        "end": {
-                                            "line": 36,
-                                            "column": 21
-                                        }
-                                    },
-                                    "range": [
-                                        608,
-                                        622
-                                    ],
-                                    "raw": "http://example"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 36,
-                                            "column": 21
-                                        },
-                                        "end": {
-                                            "line": 36,
-                                            "column": 26
-                                        }
-                                    },
-                                    "range": [
-                                        622,
-                                        627
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "xample.com",
-                                    "loc": {
-                                        "start": {
-                                            "line": 36,
-                                            "column": 26
-                                        },
-                                        "end": {
-                                            "line": 36,
-                                            "column": 36
-                                        }
-                                    },
-                                    "range": [
-                                        627,
-                                        637
-                                    ],
-                                    "raw": "xample.com"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 36,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 36,
-                                    "column": 36
-                                }
-                            },
-                            "range": [
-                                608,
-                                637
-                            ],
-                            "raw": "http://example&copyxample.com"
-                        },
-                        {
-                            "type": "Str",
-                            "value": " \"in some\npl",
-                            "loc": {
-                                "start": {
-                                    "line": 36,
-                                    "column": 36
-                                },
-                                "end": {
-                                    "line": 37,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                637,
-                                651
-                            ],
-                            "raw": " \"in some\n> pl"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "©",
-                            "loc": {
-                                "start": {
-                                    "line": 37,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 37,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                651,
-                                656
-                            ],
-                            "raw": "&copy"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "ce\"",
-                            "loc": {
-                                "start": {
-                                    "line": 37,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 37,
-                                    "column": 12
-                                }
-                            },
-                            "range": [
-                                656,
-                                659
-                            ],
-                            "raw": "ce\""
-                        }
-                    ],
+                    "type": "Definition",
+                    "identifier": "1",
+                    "label": "1",
+                    "title": "in some\npl&copyce",
+                    "url": "http://example&copyxample.com",
                     "loc": {
                         "start": {
                             "line": 36,
@@ -1045,207 +859,33 @@
                         659
                     ],
                     "raw": "[1]: http://example&copyxample.com \"in some\n> pl&copyce\""
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 0
                 },
+                "end": {
+                    "line": 37,
+                    "column": 12
+                }
+            },
+            "range": [
+                601,
+                659
+            ],
+            "raw": "> [1]: http://example&copyxample.com \"in some\n> pl&copyce\""
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
-                    "type": "Paragraph",
-                    "children": [
-                        {
-                            "type": "LinkReference",
-                            "identifier": " 1 ",
-                            "referenceType": "shortcut",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "\n  1\n",
-                                    "loc": {
-                                        "start": {
-                                            "line": 39,
-                                            "column": 3
-                                        },
-                                        "end": {
-                                            "line": 41,
-                                            "column": 2
-                                        }
-                                    },
-                                    "range": [
-                                        664,
-                                        673
-                                    ],
-                                    "raw": "\n>   1\n> "
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 39,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 41,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                663,
-                                674
-                            ],
-                            "raw": "[\n>   1\n> ]"
-                        },
-                        {
-                            "type": "Str",
-                            "value": ": ",
-                            "loc": {
-                                "start": {
-                                    "line": 41,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 41,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                674,
-                                676
-                            ],
-                            "raw": ": "
-                        },
-                        {
-                            "type": "Link",
-                            "title": null,
-                            "url": "http://example&copyxample.com",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "http://example",
-                                    "loc": {
-                                        "start": {
-                                            "line": 41,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 41,
-                                            "column": 19
-                                        }
-                                    },
-                                    "range": [
-                                        676,
-                                        690
-                                    ],
-                                    "raw": "http://example"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 41,
-                                            "column": 19
-                                        },
-                                        "end": {
-                                            "line": 41,
-                                            "column": 24
-                                        }
-                                    },
-                                    "range": [
-                                        690,
-                                        695
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "xample.com",
-                                    "loc": {
-                                        "start": {
-                                            "line": 41,
-                                            "column": 24
-                                        },
-                                        "end": {
-                                            "line": 41,
-                                            "column": 34
-                                        }
-                                    },
-                                    "range": [
-                                        695,
-                                        705
-                                    ],
-                                    "raw": "xample.com"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 41,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 41,
-                                    "column": 34
-                                }
-                            },
-                            "range": [
-                                676,
-                                705
-                            ],
-                            "raw": "http://example&copyxample.com"
-                        },
-                        {
-                            "type": "Str",
-                            "value": " \"in some\npl",
-                            "loc": {
-                                "start": {
-                                    "line": 41,
-                                    "column": 34
-                                },
-                                "end": {
-                                    "line": 42,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                705,
-                                719
-                            ],
-                            "raw": " \"in some\n> pl"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "©",
-                            "loc": {
-                                "start": {
-                                    "line": 42,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 42,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                719,
-                                724
-                            ],
-                            "raw": "&copy"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "ce\"",
-                            "loc": {
-                                "start": {
-                                    "line": 42,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 42,
-                                    "column": 12
-                                }
-                            },
-                            "range": [
-                                724,
-                                727
-                            ],
-                            "raw": "ce\""
-                        }
-                    ],
+                    "type": "Definition",
+                    "identifier": "1",
+                    "label": "\n  1\n",
+                    "title": "in some\npl&copyce",
+                    "url": "http://example&copyxample.com",
                     "loc": {
                         "start": {
                             "line": 39,
@@ -1265,7 +905,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 28,
+                    "line": 39,
                     "column": 0
                 },
                 "end": {
@@ -1274,10 +914,10 @@
                 }
             },
             "range": [
-                496,
+                661,
                 727
             ],
-            "raw": "> Or in ![l&copylnks](\n>   <~/some&copyfile>\n>   \"in some pl&copyce\")\n\n> Or in ![\n>   l&copynks\n> ][12]\n\n> [1]: http://example&copyxample.com \"in some\n> pl&copyce\"\n\n> [\n>   1\n> ]: http://example&copyxample.com \"in some\n> pl&copyce\""
+            "raw": "> [\n>   1\n> ]: http://example&copyxample.com \"in some\n> pl&copyce\""
         },
         {
             "type": "HorizontalRule",
@@ -1376,10 +1016,31 @@
                         812
                     ],
                     "raw": "But, entities are not interpreted in `inline c&oumlde`, or in\n> code blocks:"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 46,
+                    "column": 0
                 },
+                "end": {
+                    "line": 47,
+                    "column": 14
+                }
+            },
+            "range": [
+                734,
+                812
+            ],
+            "raw": "> But, entities are not interpreted in `inline c&oumlde`, or in\n> code blocks:"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "CodeBlock",
                     "lang": null,
+                    "meta": null,
                     "value": "C&OumlDE block.",
                     "loc": {
                         "start": {
@@ -1400,7 +1061,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 46,
+                    "line": 49,
                     "column": 0
                 },
                 "end": {
@@ -1409,10 +1070,10 @@
                 }
             },
             "range": [
-                734,
+                814,
                 835
             ],
-            "raw": "> But, entities are not interpreted in `inline c&oumlde`, or in\n> code blocks:\n\n>     C&OumlDE block."
+            "raw": ">     C&OumlDE block."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities.text/output.json
@@ -46,7 +46,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Plain",
+                    "value": "Plain text:",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -54,52 +54,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        12,
-                        17
-                    ],
-                    "raw": "Plain"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        17,
-                        23
-                    ],
-                    "raw": "&nbsp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "text:",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 16
                         }
                     },
                     "range": [
-                        23,
+                        12,
                         28
                     ],
-                    "raw": "text:"
+                    "raw": "Plain&nbsp;text:"
                 }
             ],
             "loc": {
@@ -123,7 +85,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "AT",
+                    "value": "AT&T with entity, AT&T with numeric entity, AT&T without entity.",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -131,128 +93,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        30,
-                        32
-                    ],
-                    "raw": "AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        32,
-                        37
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 24
-                        }
-                    },
-                    "range": [
-                        37,
-                        54
-                    ],
-                    "raw": "T with entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 29
-                        }
-                    },
-                    "range": [
-                        54,
-                        59
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with numeric entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 29
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 54
-                        }
-                    },
-                    "range": [
-                        59,
-                        84
-                    ],
-                    "raw": "T with numeric entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 54
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 59
-                        }
-                    },
-                    "range": [
-                        84,
-                        89
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T without entity.",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 59
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 76
                         }
                     },
                     "range": [
-                        89,
+                        30,
                         106
                     ],
-                    "raw": "T without entity."
+                    "raw": "AT&amp;T with entity, AT&amp;T with numeric entity, AT&amp;T without entity."
                 }
             ],
             "loc": {
@@ -313,6 +161,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&amp;T language",
             "loc": {
                 "start": {
@@ -333,6 +182,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&#x26;T language",
             "loc": {
                 "start": {
@@ -395,11 +245,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -407,52 +257,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                261,
-                                270
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 15
-                                }
-                            },
-                            "range": [
-                                270,
-                                275
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 15
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 20
                                 }
                             },
                             "range": [
-                                275,
+                                261,
                                 280
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -493,11 +305,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -505,52 +317,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                284,
-                                293
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 38
-                                }
-                            },
-                            "range": [
-                                293,
-                                298
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 38
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 43
                                 }
                             },
                             "range": [
-                                298,
+                                284,
                                 303
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -591,11 +365,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -603,52 +377,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 60
-                                }
-                            },
-                            "range": [
-                                311,
-                                320
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 60
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 65
-                                }
-                            },
-                            "range": [
-                                320,
-                                325
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 65
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 70
                                 }
                             },
                             "range": [
-                                325,
+                                311,
                                 330
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -1990,9 +1726,10 @@
             "children": [
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2030,9 +1767,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with numeric entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2070,9 +1808,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T without entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2128,6 +1867,7 @@
         {
             "type": "Definition",
             "identifier": "favicon",
+            "label": "favicon",
             "title": "ATT favicon",
             "url": "http://att.com/fav.ico",
             "loc": {
@@ -2190,8 +1930,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -2213,6 +1951,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2250,8 +1991,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -2273,6 +2012,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2310,12 +2052,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2323,54 +2063,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                1368,
-                                1371
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                1371,
-                                1376
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 36
                                 }
                             },
                             "range": [
-                                1376,
+                                1368,
                                 1379
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2408,12 +2113,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2421,54 +2124,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 43
-                                }
-                            },
-                            "range": [
-                                1383,
-                                1386
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 43
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 48
-                                }
-                            },
-                            "range": [
-                                1386,
-                                1391
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 48
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 51
                                 }
                             },
                             "range": [
-                                1391,
+                                1383,
                                 1394
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2524,6 +2192,7 @@
         {
             "type": "Definition",
             "identifier": "foo&bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {
@@ -2545,6 +2214,7 @@
         {
             "type": "Definition",
             "identifier": "foo&amp;bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=escape.text/output.json
@@ -85,7 +85,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "AT",
+                    "value": "AT&T with entity, AT&T with numeric entity, AT&T without entity.",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -93,128 +93,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        25,
-                        27
-                    ],
-                    "raw": "AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        27,
-                        32
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 24
-                        }
-                    },
-                    "range": [
-                        32,
-                        49
-                    ],
-                    "raw": "T with entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 29
-                        }
-                    },
-                    "range": [
-                        49,
-                        54
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with numeric entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 29
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 54
-                        }
-                    },
-                    "range": [
-                        54,
-                        79
-                    ],
-                    "raw": "T with numeric entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 54
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 59
-                        }
-                    },
-                    "range": [
-                        79,
-                        84
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T without entity.",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 59
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 76
                         }
                     },
                     "range": [
-                        84,
+                        25,
                         101
                     ],
-                    "raw": "T without entity."
+                    "raw": "AT&amp;T with entity, AT&amp;T with numeric entity, AT&amp;T without entity."
                 }
             ],
             "loc": {
@@ -275,6 +161,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&amp;T language",
             "loc": {
                 "start": {
@@ -295,6 +182,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&#x26;T language",
             "loc": {
                 "start": {
@@ -357,11 +245,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -369,52 +257,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                256,
-                                265
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 15
-                                }
-                            },
-                            "range": [
-                                265,
-                                270
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 15
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 20
                                 }
                             },
                             "range": [
-                                270,
+                                256,
                                 275
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -455,11 +305,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -467,52 +317,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                279,
-                                288
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 38
-                                }
-                            },
-                            "range": [
-                                288,
-                                293
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 38
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 43
                                 }
                             },
                             "range": [
-                                293,
+                                279,
                                 298
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -553,11 +365,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&amp;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&amp;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -565,52 +377,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 60
-                                }
-                            },
-                            "range": [
-                                306,
-                                315
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 60
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 65
-                                }
-                            },
-                            "range": [
-                                315,
-                                320
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 65
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 70
                                 }
                             },
                             "range": [
-                                320,
+                                306,
                                 325
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&amp;t.com"
                         }
                     ],
                     "loc": {
@@ -1952,9 +1726,10 @@
             "children": [
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1992,9 +1767,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with numeric entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2032,9 +1808,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T without entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2090,6 +1867,7 @@
         {
             "type": "Definition",
             "identifier": "favicon",
+            "label": "favicon",
             "title": "ATT favicon",
             "url": "http://att.com/fav.ico",
             "loc": {
@@ -2152,8 +1930,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -2175,6 +1951,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2212,8 +1991,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -2235,6 +2012,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2272,12 +2052,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2285,54 +2063,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                1363,
-                                1366
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                1366,
-                                1371
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 36
                                 }
                             },
                             "range": [
-                                1371,
+                                1363,
                                 1374
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2370,12 +2113,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2383,54 +2124,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 43
-                                }
-                            },
-                            "range": [
-                                1378,
-                                1381
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 43
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 48
-                                }
-                            },
-                            "range": [
-                                1381,
-                                1386
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 48
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 51
                                 }
                             },
                             "range": [
-                                1386,
+                                1378,
                                 1389
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2486,6 +2192,7 @@
         {
             "type": "Definition",
             "identifier": "foo&bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {
@@ -2507,6 +2214,7 @@
         {
             "type": "Definition",
             "identifier": "foo&amp;bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=numbers.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.entities=numbers.text/output.json
@@ -46,7 +46,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Plain",
+                    "value": "Plain text:",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -54,52 +54,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        12,
-                        17
-                    ],
-                    "raw": "Plain"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        17,
-                        23
-                    ],
-                    "raw": "&#xA0;"
-                },
-                {
-                    "type": "Str",
-                    "value": "text:",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 16
                         }
                     },
                     "range": [
-                        23,
+                        12,
                         28
                     ],
-                    "raw": "text:"
+                    "raw": "Plain&#xA0;text:"
                 }
             ],
             "loc": {
@@ -123,7 +85,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "AT",
+                    "value": "AT&T with entity, AT&T with numeric entity, AT&T without entity.",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -131,128 +93,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        30,
-                        32
-                    ],
-                    "raw": "AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        32,
-                        38
-                    ],
-                    "raw": "&#x26;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        38,
-                        55
-                    ],
-                    "raw": "T with entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 31
-                        }
-                    },
-                    "range": [
-                        55,
-                        61
-                    ],
-                    "raw": "&#x26;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T with numeric entity, AT",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 31
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 56
-                        }
-                    },
-                    "range": [
-                        61,
-                        86
-                    ],
-                    "raw": "T with numeric entity, AT"
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 56
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 62
-                        }
-                    },
-                    "range": [
-                        86,
-                        92
-                    ],
-                    "raw": "&#x26;"
-                },
-                {
-                    "type": "Str",
-                    "value": "T without entity.",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 62
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 79
                         }
                     },
                     "range": [
-                        92,
+                        30,
                         109
                     ],
-                    "raw": "T without entity."
+                    "raw": "AT&#x26;T with entity, AT&#x26;T with numeric entity, AT&#x26;T without entity."
                 }
             ],
             "loc": {
@@ -313,6 +161,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&amp;T language",
             "loc": {
                 "start": {
@@ -333,6 +182,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&#x26;T language",
             "loc": {
                 "start": {
@@ -395,11 +245,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&#x26;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&#x26;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -407,52 +257,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                266,
-                                275
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 16
-                                }
-                            },
-                            "range": [
-                                275,
-                                281
-                            ],
-                            "raw": "&#x26;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 21
                                 }
                             },
                             "range": [
-                                281,
+                                266,
                                 286
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&#x26;t.com"
                         }
                     ],
                     "loc": {
@@ -493,11 +305,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&#x26;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&#x26;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -505,52 +317,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 34
-                                }
-                            },
-                            "range": [
-                                290,
-                                299
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 34
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 40
-                                }
-                            },
-                            "range": [
-                                299,
-                                305
-                            ],
-                            "raw": "&#x26;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 40
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 45
                                 }
                             },
                             "range": [
-                                305,
+                                290,
                                 310
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&#x26;t.com"
                         }
                     ],
                     "loc": {
@@ -591,11 +365,11 @@
                 {
                     "type": "Link",
                     "title": null,
-                    "url": "http://at&t.com",
+                    "url": "http://at&#x26;t.com",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://at",
+                            "value": "http://at&#x26;t.com",
                             "loc": {
                                 "start": {
                                     "line": 19,
@@ -603,52 +377,14 @@
                                 },
                                 "end": {
                                     "line": 19,
-                                    "column": 62
-                                }
-                            },
-                            "range": [
-                                318,
-                                327
-                            ],
-                            "raw": "http://at"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 62
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 68
-                                }
-                            },
-                            "range": [
-                                327,
-                                333
-                            ],
-                            "raw": "&#x26;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "t.com",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 68
-                                },
-                                "end": {
-                                    "line": 19,
                                     "column": 73
                                 }
                             },
                             "range": [
-                                333,
+                                318,
                                 338
                             ],
-                            "raw": "t.com"
+                            "raw": "http://at&#x26;t.com"
                         }
                     ],
                     "loc": {
@@ -1990,9 +1726,10 @@
             "children": [
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2030,9 +1767,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with numeric entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2070,9 +1808,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T without entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -2128,6 +1867,7 @@
         {
             "type": "Definition",
             "identifier": "favicon",
+            "label": "favicon",
             "title": "ATT favicon",
             "url": "http://att.com/fav.ico",
             "loc": {
@@ -2190,8 +1930,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -2213,6 +1951,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2250,8 +1991,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -2273,6 +2012,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2310,12 +2052,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2323,54 +2063,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                1394,
-                                1397
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                1397,
-                                1402
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 36
                                 }
                             },
                             "range": [
-                                1402,
+                                1394,
                                 1405
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2408,12 +2113,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2421,54 +2124,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 43
-                                }
-                            },
-                            "range": [
-                                1409,
-                                1412
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 43
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 48
-                                }
-                            },
-                            "range": [
-                                1412,
-                                1417
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 48
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 51
                                 }
                             },
                             "range": [
-                                1417,
+                                1409,
                                 1420
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2524,6 +2192,7 @@
         {
             "type": "Definition",
             "identifier": "foo&bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {
@@ -2545,6 +2214,7 @@
         {
             "type": "Definition",
             "identifier": "foo&amp;bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.noentities.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.output.noentities.text/output.json
@@ -161,6 +161,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&amp;T language",
             "loc": {
                 "start": {
@@ -181,6 +182,7 @@
         {
             "type": "CodeBlock",
             "lang": "AT&T",
+            "meta": null,
             "value": "Something in the AT&#x26;T language",
             "loc": {
                 "start": {
@@ -1724,9 +1726,10 @@
             "children": [
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1764,9 +1767,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T with numeric entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1804,9 +1808,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "favicon",
-                    "referenceType": "full",
                     "alt": "AT&T without entity",
+                    "identifier": "favicon",
+                    "label": "favicon",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1862,6 +1867,7 @@
         {
             "type": "Definition",
             "identifier": "favicon",
+            "label": "favicon",
             "title": "ATT favicon",
             "url": "http://att.com/fav.ico",
             "loc": {
@@ -1924,8 +1930,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -1947,6 +1951,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -1984,8 +1991,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -2007,6 +2012,9 @@
                             "raw": "foo&bar"
                         }
                     ],
+                    "identifier": "foo&bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2044,12 +2052,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2057,54 +2063,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                1259,
-                                1262
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 33
-                                }
-                            },
-                            "range": [
-                                1262,
-                                1267
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 33
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 36
                                 }
                             },
                             "range": [
-                                1267,
+                                1259,
                                 1270
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2142,12 +2113,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "foo&amp;bar",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "foo",
+                            "value": "foo&bar",
                             "loc": {
                                 "start": {
                                     "line": 49,
@@ -2155,54 +2124,19 @@
                                 },
                                 "end": {
                                     "line": 49,
-                                    "column": 43
-                                }
-                            },
-                            "range": [
-                                1274,
-                                1277
-                            ],
-                            "raw": "foo"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "&",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 43
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 48
-                                }
-                            },
-                            "range": [
-                                1277,
-                                1282
-                            ],
-                            "raw": "&amp;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 48
-                                },
-                                "end": {
-                                    "line": 49,
                                     "column": 51
                                 }
                             },
                             "range": [
-                                1282,
+                                1274,
                                 1285
                             ],
-                            "raw": "bar"
+                            "raw": "foo&amp;bar"
                         }
                     ],
+                    "identifier": "foo&amp;bar",
+                    "label": "foo&bar",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -2258,6 +2192,7 @@
         {
             "type": "Definition",
             "identifier": "foo&bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {
@@ -2279,6 +2214,7 @@
         {
             "type": "Definition",
             "identifier": "foo&amp;bar",
+            "label": "foo&bar",
             "title": null,
             "url": "http://example.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/entities.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/entities.text/output.json
@@ -6,505 +6,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Lots of entities are supported in mdast: ",
+                    "value": "Lots of entities are supported in mdast:  , &, ©, Æ,\nĎ, ¾, ℋ, ⅆ,\n∲, &c.  Even some entities with a missing\nterminal semicolon are parsed correctly (as per the HTML5 spec):\n&yuml, &aacute, &copy, and &amp.",
                     "loc": {
                         "start": {
                             "line": 1,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 41
-                        }
-                    },
-                    "range": [
-                        0,
-                        41
-                    ],
-                    "raw": "Lots of entities are supported in mdast: "
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 41
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 47
-                        }
-                    },
-                    "range": [
-                        41,
-                        47
-                    ],
-                    "raw": "&nbsp;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 47
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 49
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 49
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 54
-                        }
-                    },
-                    "range": [
-                        49,
-                        54
-                    ],
-                    "raw": "&amp;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 54
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 56
-                        }
-                    },
-                    "range": [
-                        54,
-                        56
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "©",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 56
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 62
-                        }
-                    },
-                    "range": [
-                        56,
-                        62
-                    ],
-                    "raw": "&copy;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 62
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 64
-                        }
-                    },
-                    "range": [
-                        62,
-                        64
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "Æ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 64
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 71
-                        }
-                    },
-                    "range": [
-                        64,
-                        71
-                    ],
-                    "raw": "&AElig;"
-                },
-                {
-                    "type": "Str",
-                    "value": ",\n",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 71
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        71,
-                        73
-                    ],
-                    "raw": ",\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "Ď",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        73,
-                        81
-                    ],
-                    "raw": "&Dcaron;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        81,
-                        83
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "¾",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        83,
-                        91
-                    ],
-                    "raw": "&frac34;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 20
-                        }
-                    },
-                    "range": [
-                        91,
-                        93
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "ℋ",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 20
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 34
-                        }
-                    },
-                    "range": [
-                        93,
-                        107
-                    ],
-                    "raw": "&HilbertSpace;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        107,
-                        109
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "ⅆ",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 36
-                        },
-                        "end": {
-                            "line": 2,
-                            "column": 51
-                        }
-                    },
-                    "range": [
-                        109,
-                        124
-                    ],
-                    "raw": "&DifferentialD;"
-                },
-                {
-                    "type": "Str",
-                    "value": ",\n",
-                    "loc": {
-                        "start": {
-                            "line": 2,
-                            "column": 51
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        124,
-                        126
-                    ],
-                    "raw": ",\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "∲",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        126,
-                        152
-                    ],
-                    "raw": "&ClockwiseContourIntegral;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", &c.  Even some entities with a missing\nterminal semicolon are parsed correctly (as per the HTML5 spec):\n",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        152,
-                        258
-                    ],
-                    "raw": ", &c.  Even some entities with a missing\nterminal semicolon are parsed correctly (as per the HTML5 spec):\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "ÿ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        258,
-                        263
-                    ],
-                    "raw": "&yuml"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        263,
-                        265
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "á",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        265,
-                        272
-                    ],
-                    "raw": "&aacute"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 14
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        272,
-                        274
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "Str",
-                    "value": "©",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 21
-                        }
-                    },
-                    "range": [
-                        274,
-                        279
-                    ],
-                    "raw": "&copy"
-                },
-                {
-                    "type": "Str",
-                    "value": ", and ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 21
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        279,
-                        285
-                    ],
-                    "raw": ", and "
-                },
-                {
-                    "type": "Str",
-                    "value": "&",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 27
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 31
-                        }
-                    },
-                    "range": [
-                        285,
-                        289
-                    ],
-                    "raw": "&amp"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 31
                         },
                         "end": {
                             "line": 5,
@@ -512,10 +18,10 @@
                         }
                     },
                     "range": [
-                        289,
+                        0,
                         290
                     ],
-                    "raw": "."
+                    "raw": "Lots of entities are supported in mdast: &nbsp;, &amp;, &copy;, &AElig;,\n&Dcaron;, &frac34;, &HilbertSpace;, &DifferentialD;,\n&ClockwiseContourIntegral;, &c.  Even some entities with a missing\nterminal semicolon are parsed correctly (as per the HTML5 spec):\n&yuml, &aacute, &copy, and &amp."
                 }
             ],
             "loc": {
@@ -615,6 +121,7 @@
         {
             "type": "CodeBlock",
             "lang": "some—language",
+            "meta": null,
             "value": "alert('Hello');",
             "loc": {
                 "start": {
@@ -661,7 +168,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "l",
+                            "value": "línks",
                             "loc": {
                                 "start": {
                                     "line": 15,
@@ -669,52 +176,14 @@
                                 },
                                 "end": {
                                     "line": 15,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                460,
-                                461
-                            ],
-                            "raw": "l"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "í",
-                            "loc": {
-                                "start": {
-                                    "line": 15,
-                                    "column": 8
-                                },
-                                "end": {
-                                    "line": 15,
-                                    "column": 16
-                                }
-                            },
-                            "range": [
-                                461,
-                                469
-                            ],
-                            "raw": "&iacute;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "nks",
-                            "loc": {
-                                "start": {
-                                    "line": 15,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 15,
                                     "column": 19
                                 }
                             },
                             "range": [
-                                469,
+                                460,
                                 472
                             ],
-                            "raw": "nks"
+                            "raw": "l&iacute;nks"
                         }
                     ],
                     "loc": {
@@ -774,7 +243,7 @@
                 },
                 {
                     "type": "Image",
-                    "title": "© Someone",
+                    "title": "&copy Someone",
                     "url": "~/an–image.png",
                     "alt": "ímages",
                     "loc": {
@@ -890,6 +359,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "C&Ouml;DE block.",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-empty.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-empty.text/output.json
@@ -43,6 +43,7 @@
         {
             "type": "CodeBlock",
             "lang": "js",
+            "meta": null,
             "value": "",
             "loc": {
                 "start": {
@@ -102,6 +103,7 @@
         {
             "type": "CodeBlock",
             "lang": "bash",
+            "meta": null,
             "value": "",
             "loc": {
                 "start": {
@@ -161,6 +163,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "",
             "loc": {
                 "start": {
@@ -220,6 +223,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-trailing-characters-2.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-trailing-characters-2.nooutput.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "``` aaa",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-trailing-characters.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-trailing-characters.nooutput.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "CodeBlock",
             "lang": "js",
+            "meta": null,
             "value": "foo();\n```bash",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-white-space-after-flag.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code-white-space-after-flag.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "CodeBlock",
             "lang": "js",
+            "meta": null,
             "value": "foo();",
             "loc": {
                 "start": {
@@ -24,6 +25,7 @@
         {
             "type": "CodeBlock",
             "lang": "bash",
+            "meta": null,
             "value": "echo \"hello, ${WORLD}\"",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/fenced-code.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "CodeBlock",
             "lang": "js",
+            "meta": null,
             "value": "var a = 'hello';\nconsole.log(a + ' world');",
             "loc": {
                 "start": {
@@ -24,6 +25,7 @@
         {
             "type": "CodeBlock",
             "lang": "bash",
+            "meta": null,
             "value": "echo \"hello, ${WORLD}\"",
             "loc": {
                 "start": {
@@ -44,6 +46,7 @@
         {
             "type": "CodeBlock",
             "lang": "longfence",
+            "meta": null,
             "value": "Q: What do you call a tall person who sells stolen goods?",
             "loc": {
                 "start": {
@@ -64,6 +67,7 @@
         {
             "type": "CodeBlock",
             "lang": "ManyTildes",
+            "meta": null,
             "value": "A longfence!",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet",
+                    "value": "The NATO phonetic alphabet[^wiki].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        0,
-                        26
-                    ],
-                    "raw": "The NATO phonetic alphabet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 27
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 32
-                                }
-                            },
-                            "range": [
-                                27,
-                                32
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 33
-                        }
-                    },
-                    "range": [
-                        26,
-                        33
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 33
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 34
                         }
                     },
                     "range": [
-                        33,
+                        0,
                         34
                     ],
-                    "raw": "."
+                    "raw": "The NATO phonetic alphabet[^wiki]."
                 }
             ],
             "loc": {
@@ -104,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                37,
-                                42
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^wiki]: Read more about it on wikipedia: ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -135,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        36,
-                        43
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Read more about it on wikipedia: ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 42
                         }
                     },
                     "range": [
-                        43,
+                        36,
                         78
                     ],
-                    "raw": ": Read more about it on wikipedia: "
+                    "raw": "[^wiki]: Read more about it on wikipedia: "
                 },
                 {
                     "type": "Link",
@@ -206,7 +105,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": ".\n",
+                    "value": ".\n[^wiki]: Not to be confused with: ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -214,74 +113,14 @@
                         },
                         "end": {
                             "line": 4,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        131,
-                        133
-                    ],
-                    "raw": ".\n"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                134,
-                                139
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        133,
-                        140
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Not to be confused with: ",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 4,
                             "column": 34
                         }
                     },
                     "range": [
-                        140,
+                        131,
                         167
                     ],
-                    "raw": ": Not to be confused with: "
+                    "raw": ".\n[^wiki]: Not to be confused with: "
                 },
                 {
                     "type": "Link",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "The NATO phonetic alphabet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "wiki",
                     "label": "wiki",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-duplicate.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet[^wiki].",
+                    "value": "The NATO phonetic alphabet",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 34
+                            "column": 26
                         }
                     },
                     "range": [
                         0,
+                        26
+                    ],
+                    "raw": "The NATO phonetic alphabet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "wiki",
+                    "label": "wiki",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 33
+                        }
+                    },
+                    "range": [
+                        26,
+                        33
+                    ],
+                    "raw": "[^wiki]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 33
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 34
+                        }
+                    },
+                    "range": [
+                        33,
                         34
                     ],
-                    "raw": "The NATO phonetic alphabet[^wiki]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -41,146 +80,108 @@
             "raw": "The NATO phonetic alphabet[^wiki]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "wiki",
+            "label": "wiki",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^wiki]: Read more about it on wikipedia: ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 42
-                        }
-                    },
-                    "range": [
-                        36,
-                        78
-                    ],
-                    "raw": "[^wiki]: Read more about it on wikipedia: "
-                },
-                {
-                    "type": "Link",
-                    "title": null,
-                    "url": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                            "value": "Read more about it on wikipedia: ",
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 43
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 94
+                                    "column": 42
                                 }
                             },
                             "range": [
-                                79,
-                                130
+                                45,
+                                78
                             ],
-                            "raw": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 42
+                            "raw": "Read more about it on wikipedia: "
                         },
-                        "end": {
-                            "line": 3,
-                            "column": 95
-                        }
-                    },
-                    "range": [
-                        78,
-                        131
-                    ],
-                    "raw": "<http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>"
-                },
-                {
-                    "type": "Str",
-                    "value": ".\n[^wiki]: Not to be confused with: ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 95
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 34
-                        }
-                    },
-                    "range": [
-                        131,
-                        167
-                    ],
-                    "raw": ".\n[^wiki]: Not to be confused with: "
-                },
-                {
-                    "type": "Link",
-                    "title": null,
-                    "url": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet",
-                    "children": [
                         {
-                            "type": "Str",
-                            "value": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet",
+                            "type": "Link",
+                            "title": null,
+                            "url": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 43
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 94
+                                        }
+                                    },
+                                    "range": [
+                                        79,
+                                        130
+                                    ],
+                                    "raw": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet"
+                                }
+                            ],
                             "loc": {
                                 "start": {
-                                    "line": 4,
-                                    "column": 35
+                                    "line": 3,
+                                    "column": 42
                                 },
                                 "end": {
-                                    "line": 4,
+                                    "line": 3,
                                     "column": 95
                                 }
                             },
                             "range": [
-                                168,
-                                228
+                                78,
+                                131
                             ],
-                            "raw": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet"
+                            "raw": "<http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 95
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 96
+                                }
+                            },
+                            "range": [
+                                131,
+                                132
+                            ],
+                            "raw": "."
                         }
                     ],
                     "loc": {
                         "start": {
-                            "line": 4,
-                            "column": 34
+                            "line": 3,
+                            "column": 9
                         },
                         "end": {
-                            "line": 4,
+                            "line": 3,
                             "column": 96
                         }
                     },
                     "range": [
-                        167,
-                        229
+                        45,
+                        132
                     ],
-                    "raw": "<http://en.wikipedia.org/wiki/International_Phonetic_Alphabet>"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 96
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 97
-                        }
-                    },
-                    "range": [
-                        229,
-                        230
-                    ],
-                    "raw": "."
+                    "raw": "Read more about it on wikipedia: <http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>."
                 }
             ],
             "loc": {
@@ -189,15 +190,136 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 3,
+                    "column": 96
+                }
+            },
+            "range": [
+                36,
+                132
+            ],
+            "raw": "[^wiki]: Read more about it on wikipedia: <http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>."
+        },
+        {
+            "type": "footnoteDefinition",
+            "identifier": "wiki",
+            "label": "wiki",
+            "children": [
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Not to be confused with: ",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 34
+                                }
+                            },
+                            "range": [
+                                142,
+                                167
+                            ],
+                            "raw": "Not to be confused with: "
+                        },
+                        {
+                            "type": "Link",
+                            "title": null,
+                            "url": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet",
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 35
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 95
+                                        }
+                                    },
+                                    "range": [
+                                        168,
+                                        228
+                                    ],
+                                    "raw": "http://en.wikipedia.org/wiki/International_Phonetic_Alphabet"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 34
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 96
+                                }
+                            },
+                            "range": [
+                                167,
+                                229
+                            ],
+                            "raw": "<http://en.wikipedia.org/wiki/International_Phonetic_Alphabet>"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 96
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 97
+                                }
+                            },
+                            "range": [
+                                229,
+                                230
+                            ],
+                            "raw": "."
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 97
+                        }
+                    },
+                    "range": [
+                        142,
+                        230
+                    ],
+                    "raw": "Not to be confused with: <http://en.wikipedia.org/wiki/International_Phonetic_Alphabet>."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
                     "line": 4,
                     "column": 97
                 }
             },
             "range": [
-                36,
+                133,
                 230
             ],
-            "raw": "[^wiki]: Read more about it on wikipedia: <http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>.\n[^wiki]: Not to be confused with: <http://en.wikipedia.org/wiki/International_Phonetic_Alphabet>."
+            "raw": "[^wiki]: Not to be confused with: <http://en.wikipedia.org/wiki/International_Phonetic_Alphabet>."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet[^wi-ki].",
+                    "value": "The NATO phonetic alphabet",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 36
+                            "column": 26
                         }
                     },
                     "range": [
                         0,
+                        26
+                    ],
+                    "raw": "The NATO phonetic alphabet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "wi\\-ki",
+                    "label": "wi-ki",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 35
+                        }
+                    },
+                    "range": [
+                        26,
+                        35
+                    ],
+                    "raw": "[^wi\\-ki]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 35
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 36
+                        }
+                    },
+                    "range": [
+                        35,
                         36
                     ],
-                    "raw": "The NATO phonetic alphabet[^wi\\-ki]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -41,15 +80,37 @@
             "raw": "The NATO phonetic alphabet[^wi\\-ki]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "wi\\-ki",
+            "label": "wi-ki",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^wi-ki]: Read more about it somewhere else.",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Read more about it somewhere else.",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 45
+                                }
+                            },
+                            "range": [
+                                49,
+                                83
+                            ],
+                            "raw": "Read more about it somewhere else."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 0
+                            "column": 11
                         },
                         "end": {
                             "line": 3,
@@ -57,10 +118,10 @@
                         }
                     },
                     "range": [
-                        38,
+                        49,
                         83
                     ],
-                    "raw": "[^wi\\-ki]: Read more about it somewhere else."
+                    "raw": "Read more about it somewhere else."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "The NATO phonetic alphabet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "wi\\-ki",
                     "label": "wi-ki",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-escape.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet",
+                    "value": "The NATO phonetic alphabet[^wi-ki].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,112 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        0,
-                        26
-                    ],
-                    "raw": "The NATO phonetic alphabet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wi\\-ki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wi",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 27
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 30
-                                }
-                            },
-                            "range": [
-                                27,
-                                30
-                            ],
-                            "raw": "^wi"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "-",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 30
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 32
-                                }
-                            },
-                            "range": [
-                                30,
-                                32
-                            ],
-                            "raw": "\\-"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "ki",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 32
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 34
-                                }
-                            },
-                            "range": [
-                                32,
-                                34
-                            ],
-                            "raw": "ki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 35
-                        }
-                    },
-                    "range": [
-                        26,
-                        35
-                    ],
-                    "raw": "[^wi\\-ki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 35
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 36
                         }
                     },
                     "range": [
-                        35,
+                        0,
                         36
                     ],
-                    "raw": "."
+                    "raw": "The NATO phonetic alphabet[^wi\\-ki]."
                 }
             ],
             "loc": {
@@ -142,68 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^wi\\-ki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wi",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                39,
-                                42
-                            ],
-                            "raw": "^wi"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "-",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                42,
-                                44
-                            ],
-                            "raw": "\\-"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "ki",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 6
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                44,
-                                46
-                            ],
-                            "raw": "ki"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^wi-ki]: Read more about it somewhere else.",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -211,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        38,
-                        47
-                    ],
-                    "raw": "[^wi\\-ki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Read more about it somewhere else.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 45
                         }
                     },
                     "range": [
-                        47,
+                        38,
                         83
                     ],
-                    "raw": ": Read more about it somewhere else."
+                    "raw": "[^wi\\-ki]: Read more about it somewhere else."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "This example checks that [^the generated] IDs do not overwrite the user's IDs"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "1",
                     "label": "1",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This example checks that [^the generated] IDs do not overwrite the user's IDs[^1].",
+                    "value": "This example checks that [^the generated] IDs do not overwrite the user's IDs",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 82
+                            "column": 77
                         }
                     },
                     "range": [
                         0,
+                        77
+                    ],
+                    "raw": "This example checks that [^the generated] IDs do not overwrite the user's IDs"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "1",
+                    "label": "1",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 77
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 81
+                        }
+                    },
+                    "range": [
+                        77,
+                        81
+                    ],
+                    "raw": "[^1]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 81
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 82
+                        }
+                    },
+                    "range": [
+                        81,
                         82
                     ],
-                    "raw": "This example checks that [^the generated] IDs do not overwrite the user's IDs[^1]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -41,53 +80,75 @@
             "raw": "This example checks that [^the generated] IDs do not overwrite the user's IDs[^1]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "1",
+            "label": "1",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^1]: Old behavior would, for \"generated\", generate a footnote with an ID set to ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Old behavior would, for \"generated\", generate a footnote with an ID set to ",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 81
+                                }
+                            },
+                            "range": [
+                                90,
+                                165
+                            ],
+                            "raw": "Old behavior would, for \"generated\", generate a footnote with an ID set to "
                         },
-                        "end": {
-                            "line": 3,
-                            "column": 81
-                        }
-                    },
-                    "range": [
-                        84,
-                        165
-                    ],
-                    "raw": "[^1]: Old behavior would, for \"generated\", generate a footnote with an ID set to "
-                },
-                {
-                    "type": "Code",
-                    "value": "1",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 81
+                        {
+                            "type": "Code",
+                            "value": "1",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 81
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 84
+                                }
+                            },
+                            "range": [
+                                165,
+                                168
+                            ],
+                            "raw": "`1`"
                         },
-                        "end": {
-                            "line": 3,
-                            "column": 84
+                        {
+                            "type": "Str",
+                            "value": ", thus overwriting this footnote.",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 84
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 117
+                                }
+                            },
+                            "range": [
+                                168,
+                                201
+                            ],
+                            "raw": ", thus overwriting this footnote."
                         }
-                    },
-                    "range": [
-                        165,
-                        168
                     ],
-                    "raw": "`1`"
-                },
-                {
-                    "type": "Str",
-                    "value": ", thus overwriting this footnote.",
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 84
+                            "column": 6
                         },
                         "end": {
                             "line": 3,
@@ -95,10 +156,10 @@
                         }
                     },
                     "range": [
-                        168,
+                        90,
                         201
                     ],
-                    "raw": ", thus overwriting this footnote."
+                    "raw": "Old behavior would, for \"generated\", generate a footnote with an ID set to `1`, thus overwriting this footnote."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-ids.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This example checks that ",
+                    "value": "This example checks that [^the generated] IDs do not overwrite the user's IDs[^1].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,134 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        0,
-                        25
-                    ],
-                    "raw": "This example checks that "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^the generated",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^the generated",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 26
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 40
-                                }
-                            },
-                            "range": [
-                                26,
-                                40
-                            ],
-                            "raw": "^the generated"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 41
-                        }
-                    },
-                    "range": [
-                        25,
-                        41
-                    ],
-                    "raw": "[^the generated]"
-                },
-                {
-                    "type": "Str",
-                    "value": " IDs do not overwrite the user's IDs",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 41
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 77
-                        }
-                    },
-                    "range": [
-                        41,
-                        77
-                    ],
-                    "raw": " IDs do not overwrite the user's IDs"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 78
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 80
-                                }
-                            },
-                            "range": [
-                                78,
-                                80
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 77
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 81
-                        }
-                    },
-                    "range": [
-                        77,
-                        81
-                    ],
-                    "raw": "[^1]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 81
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 82
                         }
                     },
                     "range": [
-                        81,
+                        0,
                         82
                     ],
-                    "raw": "."
+                    "raw": "This example checks that [^the generated] IDs do not overwrite the user's IDs[^1]."
                 }
             ],
             "loc": {
@@ -164,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                85,
-                                87
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^1]: Old behavior would, for \"generated\", generate a footnote with an ID set to ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -195,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        84,
-                        88
-                    ],
-                    "raw": "[^1]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Old behavior would, for \"generated\", generate a footnote with an ID set to ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 81
                         }
                     },
                     "range": [
-                        88,
+                        84,
                         165
                     ],
-                    "raw": ": Old behavior would, for \"generated\", generate a footnote with an ID set to "
+                    "raw": "[^1]: Old behavior would, for \"generated\", generate a footnote with an ID set to "
                 },
                 {
                     "type": "Code",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet",
+                    "value": "The NATO phonetic alphabet[^wiki].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        0,
-                        26
-                    ],
-                    "raw": "The NATO phonetic alphabet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 27
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 32
-                                }
-                            },
-                            "range": [
-                                27,
-                                32
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 33
-                        }
-                    },
-                    "range": [
-                        26,
-                        33
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 33
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 34
                         }
                     },
                     "range": [
-                        33,
+                        0,
                         34
                     ],
-                    "raw": "."
+                    "raw": "The NATO phonetic alphabet[^wiki]."
                 }
             ],
             "loc": {
@@ -105,71 +45,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "  ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        36,
-                        38
-                    ],
-                    "raw": "  "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                39,
-                                44
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
+                    "value": "[^wiki]: Read more about it somewhere else.",
                     "loc": {
                         "start": {
                             "line": 3,
                             "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        38,
-                        45
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Read more about it somewhere else.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
                         },
                         "end": {
                             "line": 3,
@@ -177,16 +57,16 @@
                         }
                     },
                     "range": [
-                        45,
+                        38,
                         81
                     ],
-                    "raw": ": Read more about it somewhere else."
+                    "raw": "[^wiki]: Read more about it somewhere else."
                 }
             ],
             "loc": {
                 "start": {
                     "line": 3,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 3,
@@ -194,10 +74,10 @@
                 }
             },
             "range": [
-                36,
+                38,
                 81
             ],
-            "raw": "  [^wiki]: Read more about it somewhere else."
+            "raw": "[^wiki]: Read more about it somewhere else."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "The NATO phonetic alphabet[^wiki].",
+                    "value": "The NATO phonetic alphabet",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 34
+                            "column": 26
                         }
                     },
                     "range": [
                         0,
+                        26
+                    ],
+                    "raw": "The NATO phonetic alphabet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "wiki",
+                    "label": "wiki",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 33
+                        }
+                    },
+                    "range": [
+                        26,
+                        33
+                    ],
+                    "raw": "[^wiki]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 33
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 34
+                        }
+                    },
+                    "range": [
+                        33,
                         34
                     ],
-                    "raw": "The NATO phonetic alphabet[^wiki]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -41,15 +80,37 @@
             "raw": "The NATO phonetic alphabet[^wiki]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "wiki",
+            "label": "wiki",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^wiki]: Read more about it somewhere else.",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Read more about it somewhere else.",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 45
+                                }
+                            },
+                            "range": [
+                                47,
+                                81
+                            ],
+                            "raw": "Read more about it somewhere else."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 2
+                            "column": 11
                         },
                         "end": {
                             "line": 3,
@@ -57,10 +118,10 @@
                         }
                     },
                     "range": [
-                        38,
+                        47,
                         81
                     ],
-                    "raw": "[^wiki]: Read more about it somewhere else."
+                    "raw": "Read more about it somewhere else."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-indent.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "The NATO phonetic alphabet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "wiki",
                     "label": "wiki",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-inline.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-inline.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is an example of an inline footnote.",
+                    "value": "This is an example of an inline footnote.[^This is the ",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,102 +14,61 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 41
+                            "column": 55
                         }
                     },
                     "range": [
                         0,
-                        41
+                        55
                     ],
-                    "raw": "This is an example of an inline footnote."
+                    "raw": "This is an example of an inline footnote.[^This is the "
                 },
                 {
-                    "type": "LinkReference",
-                    "identifier": "^this is the _actual_ footnote.",
-                    "referenceType": "shortcut",
+                    "type": "Emphasis",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "^This is the ",
+                            "value": "actual",
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 42
+                                    "column": 56
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 55
+                                    "column": 62
                                 }
                             },
                             "range": [
-                                42,
-                                55
+                                56,
+                                62
                             ],
-                            "raw": "^This is the "
-                        },
-                        {
-                            "type": "Emphasis",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "actual",
-                                    "loc": {
-                                        "start": {
-                                            "line": 1,
-                                            "column": 56
-                                        },
-                                        "end": {
-                                            "line": 1,
-                                            "column": 62
-                                        }
-                                    },
-                                    "range": [
-                                        56,
-                                        62
-                                    ],
-                                    "raw": "actual"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 55
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 63
-                                }
-                            },
-                            "range": [
-                                55,
-                                63
-                            ],
-                            "raw": "_actual_"
-                        },
-                        {
-                            "type": "Str",
-                            "value": " footnote.",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 63
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 73
-                                }
-                            },
-                            "range": [
-                                63,
-                                73
-                            ],
-                            "raw": " footnote."
+                            "raw": "actual"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 41
+                            "column": 55
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 63
+                        }
+                    },
+                    "range": [
+                        55,
+                        63
+                    ],
+                    "raw": "_actual_"
+                },
+                {
+                    "type": "Str",
+                    "value": " footnote.]",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 63
                         },
                         "end": {
                             "line": 1,
@@ -117,10 +76,10 @@
                         }
                     },
                     "range": [
-                        41,
+                        63,
                         74
                     ],
-                    "raw": "[^This is the _actual_ footnote.]"
+                    "raw": " footnote.]"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-like.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-like.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This one isn't even ",
+                    "value": "This one isn't even [defined][^foo].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 20
-                        }
-                    },
-                    "range": [
-                        0,
-                        20
-                    ],
-                    "raw": "This one isn't even "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^foo",
-                    "referenceType": "full",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "defined",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 21
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                21,
-                                28
-                            ],
-                            "raw": "defined"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 20
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 35
-                        }
-                    },
-                    "range": [
-                        20,
-                        35
-                    ],
-                    "raw": "[defined][^foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 35
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 36
                         }
                     },
                     "range": [
-                        35,
+                        0,
                         36
                     ],
-                    "raw": "."
+                    "raw": "This one isn't even [defined][^foo]."
                 }
             ],
             "loc": {
@@ -104,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "invalid",
-                    "referenceType": "full",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^both",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                39,
-                                44
-                            ],
-                            "raw": "^both"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^both][invalid], [^this too][].",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -135,93 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        38,
-                        54
-                    ],
-                    "raw": "[^both][invalid]"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        54,
-                        56
-                    ],
-                    "raw": ", "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^this too",
-                    "referenceType": "collapsed",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^this too",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 19
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                57,
-                                66
-                            ],
-                            "raw": "^this too"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 31
-                        }
-                    },
-                    "range": [
-                        56,
-                        69
-                    ],
-                    "raw": "[^this too][]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 31
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 32
                         }
                     },
                     "range": [
-                        69,
+                        38,
                         70
                     ],
-                    "raw": "."
+                    "raw": "[^both][invalid], [^this too][]."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
@@ -7,7 +7,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "International Radiotelephony Spelling Alphabet[^wiki]",
+                    "value": "International Radiotelephony Spelling Alphabet",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -15,14 +15,34 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 55
+                            "column": 48
                         }
                     },
                     "range": [
                         2,
+                        48
+                    ],
+                    "raw": "International Radiotelephony Spelling Alphabet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "wiki",
+                    "label": "wiki",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 48
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 55
+                        }
+                    },
+                    "range": [
+                        48,
                         55
                     ],
-                    "raw": "International Radiotelephony Spelling Alphabet[^wiki]"
+                    "raw": "[^wiki]"
                 }
             ],
             "loc": {
@@ -46,7 +66,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here's the NATO phonetic alphabet[^wiki]: Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu.",
+                    "value": "Here's the NATO phonetic alphabet",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -54,14 +74,53 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 235
+                            "column": 33
                         }
                     },
                     "range": [
                         57,
+                        90
+                    ],
+                    "raw": "Here's the NATO phonetic alphabet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "wiki",
+                    "label": "wiki",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 33
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 40
+                        }
+                    },
+                    "range": [
+                        90,
+                        97
+                    ],
+                    "raw": "[^wiki]"
+                },
+                {
+                    "type": "Str",
+                    "value": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu.",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 40
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 235
+                        }
+                    },
+                    "range": [
+                        97,
                         292
                     ],
-                    "raw": "Here's the NATO phonetic alphabet[^wiki]: Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu."
+                    "raw": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu."
                 }
             ],
             "loc": {
@@ -120,75 +179,97 @@
             "raw": "And here's some more text."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "wiki",
+            "label": "wiki",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^wiki]: Read more about it on wikipedia: ",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 42
-                        }
-                    },
-                    "range": [
-                        322,
-                        364
-                    ],
-                    "raw": "[^wiki]: Read more about it on wikipedia: "
-                },
-                {
-                    "type": "Link",
-                    "title": null,
-                    "url": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                            "value": "Read more about it on wikipedia: ",
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 43
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 94
+                                    "column": 42
                                 }
                             },
                             "range": [
-                                365,
-                                416
+                                331,
+                                364
                             ],
-                            "raw": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 42
+                            "raw": "Read more about it on wikipedia: "
                         },
-                        "end": {
-                            "line": 7,
-                            "column": 95
+                        {
+                            "type": "Link",
+                            "title": null,
+                            "url": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet",
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 43
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 94
+                                        }
+                                    },
+                                    "range": [
+                                        365,
+                                        416
+                                    ],
+                                    "raw": "http://en.wikipedia.org/wiki/NATO_phonetic_alphabet"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 42
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 95
+                                }
+                            },
+                            "range": [
+                                364,
+                                417
+                            ],
+                            "raw": "<http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 95
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 96
+                                }
+                            },
+                            "range": [
+                                417,
+                                418
+                            ],
+                            "raw": "."
                         }
-                    },
-                    "range": [
-                        364,
-                        417
                     ],
-                    "raw": "<http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 95
+                            "column": 9
                         },
                         "end": {
                             "line": 7,
@@ -196,10 +277,10 @@
                         }
                     },
                     "range": [
-                        417,
+                        331,
                         418
                     ],
-                    "raw": "."
+                    "raw": "Read more about it on wikipedia: <http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
@@ -7,7 +7,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "International Radiotelephony Spelling Alphabet",
+                    "value": "International Radiotelephony Spelling Alphabet[^wiki]",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -15,55 +15,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 48
-                        }
-                    },
-                    "range": [
-                        2,
-                        48
-                    ],
-                    "raw": "International Radiotelephony Spelling Alphabet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 49
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 54
-                                }
-                            },
-                            "range": [
-                                49,
-                                54
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 48
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 55
                         }
                     },
                     "range": [
-                        48,
+                        2,
                         55
                     ],
-                    "raw": "[^wiki]"
+                    "raw": "International Radiotelephony Spelling Alphabet[^wiki]"
                 }
             ],
             "loc": {
@@ -87,7 +46,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here's the NATO phonetic alphabet",
+                    "value": "Here's the NATO phonetic alphabet[^wiki]: Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu.",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -95,74 +54,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 33
-                        }
-                    },
-                    "range": [
-                        57,
-                        90
-                    ],
-                    "raw": "Here's the NATO phonetic alphabet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 34
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 39
-                                }
-                            },
-                            "range": [
-                                91,
-                                96
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 33
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 40
-                        }
-                    },
-                    "range": [
-                        90,
-                        97
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 40
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 235
                         }
                     },
                     "range": [
-                        97,
+                        57,
                         292
                     ],
-                    "raw": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu."
+                    "raw": "Here's the NATO phonetic alphabet[^wiki]: Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor, Whiskey, X-ray, Yankee, and Zulu."
                 }
             ],
             "loc": {
@@ -224,30 +123,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^wiki",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^wiki",
-                            "loc": {
-                                "start": {
-                                    "line": 7,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                323,
-                                328
-                            ],
-                            "raw": "^wiki"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^wiki]: Read more about it on wikipedia: ",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -255,33 +132,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        322,
-                        329
-                    ],
-                    "raw": "[^wiki]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Read more about it on wikipedia: ",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 42
                         }
                     },
                     "range": [
-                        329,
+                        322,
                         364
                     ],
-                    "raw": ": Read more about it on wikipedia: "
+                    "raw": "[^wiki]: Read more about it on wikipedia: "
                 },
                 {
                     "type": "Link",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-multiple.text/output.json
@@ -25,7 +25,7 @@
                     "raw": "International Radiotelephony Spelling Alphabet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "wiki",
                     "label": "wiki",
                     "loc": {
@@ -84,7 +84,7 @@
                     "raw": "Here's the NATO phonetic alphabet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "wiki",
                     "label": "wiki",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "A footnote[^1].",
+                    "value": "A footnote",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 15
+                            "column": 10
                         }
                     },
                     "range": [
                         0,
+                        10
+                    ],
+                    "raw": "A footnote"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "1",
+                    "label": "1",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 14
+                        }
+                    },
+                    "range": [
+                        10,
+                        14
+                    ],
+                    "raw": "[^1]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 15
+                        }
+                    },
+                    "range": [
+                        14,
                         15
                     ],
-                    "raw": "A footnote[^1]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -41,73 +80,95 @@
             "raw": "A footnote[^1]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "1",
+            "label": "1",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^1]: Including [^another ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        17,
-                        43
-                    ],
-                    "raw": "[^1]: Including [^another "
-                },
-                {
-                    "type": "Strong",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "footnote",
+                            "value": "Including [^another ",
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 28
+                                    "column": 6
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 36
+                                    "column": 26
                                 }
                             },
                             "range": [
-                                45,
-                                53
+                                23,
+                                43
                             ],
-                            "raw": "footnote"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 26
+                            "raw": "Including [^another "
                         },
-                        "end": {
-                            "line": 3,
-                            "column": 38
+                        {
+                            "type": "Strong",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "footnote",
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 28
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 36
+                                        }
+                                    },
+                                    "range": [
+                                        45,
+                                        53
+                                    ],
+                                    "raw": "footnote"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 38
+                                }
+                            },
+                            "range": [
+                                43,
+                                55
+                            ],
+                            "raw": "**footnote**"
+                        },
+                        {
+                            "type": "Str",
+                            "value": "]",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 38
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 39
+                                }
+                            },
+                            "range": [
+                                55,
+                                56
+                            ],
+                            "raw": "]"
                         }
-                    },
-                    "range": [
-                        43,
-                        55
                     ],
-                    "raw": "**footnote**"
-                },
-                {
-                    "type": "Str",
-                    "value": "]",
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 38
+                            "column": 6
                         },
                         "end": {
                             "line": 3,
@@ -115,10 +176,10 @@
                         }
                     },
                     "range": [
-                        55,
+                        23,
                         56
                     ],
-                    "raw": "]"
+                    "raw": "Including [^another **footnote**]"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "A footnote",
+                    "value": "A footnote[^1].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        0,
-                        10
-                    ],
-                    "raw": "A footnote"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 11
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                11,
-                                13
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        10,
-                        14
-                    ],
-                    "raw": "[^1]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 14
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 15
                         }
                     },
                     "range": [
-                        14,
+                        0,
                         15
                     ],
-                    "raw": "."
+                    "raw": "A footnote[^1]."
                 }
             ],
             "loc": {
@@ -104,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                18,
-                                20
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^1]: Including [^another ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -135,102 +53,61 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 4
+                            "column": 26
                         }
                     },
                     "range": [
                         17,
-                        21
+                        43
                     ],
-                    "raw": "[^1]"
+                    "raw": "[^1]: Including [^another "
                 },
                 {
-                    "type": "Str",
-                    "value": ": Including ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        21,
-                        33
-                    ],
-                    "raw": ": Including "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^another **footnote**",
-                    "referenceType": "shortcut",
+                    "type": "Strong",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "^another ",
+                            "value": "footnote",
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 17
+                                    "column": 28
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 26
+                                    "column": 36
                                 }
                             },
                             "range": [
-                                34,
-                                43
+                                45,
+                                53
                             ],
-                            "raw": "^another "
-                        },
-                        {
-                            "type": "Strong",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "footnote",
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 28
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 36
-                                        }
-                                    },
-                                    "range": [
-                                        45,
-                                        53
-                                    ],
-                                    "raw": "footnote"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 26
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 38
-                                }
-                            },
-                            "range": [
-                                43,
-                                55
-                            ],
-                            "raw": "**footnote**"
+                            "raw": "footnote"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 16
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 38
+                        }
+                    },
+                    "range": [
+                        43,
+                        55
+                    ],
+                    "raw": "**footnote**"
+                },
+                {
+                    "type": "Str",
+                    "value": "]",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 38
                         },
                         "end": {
                             "line": 3,
@@ -238,10 +115,10 @@
                         }
                     },
                     "range": [
-                        33,
+                        55,
                         56
                     ],
-                    "raw": "[^another **footnote**]"
+                    "raw": "]"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-nested.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "A footnote"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "1",
                     "label": "1",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "A footnote",
+                    "value": "A footnote[^toString] and [^",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,222 +14,61 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 10
+                            "column": 28
                         }
                     },
                     "range": [
                         0,
-                        10
+                        28
                     ],
-                    "raw": "A footnote"
+                    "raw": "A footnote[^toString] and [^"
                 },
                 {
-                    "type": "LinkReference",
-                    "identifier": "^tostring",
-                    "referenceType": "shortcut",
+                    "type": "Strong",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "^toString",
+                            "value": "proto",
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 11
+                                    "column": 30
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 20
+                                    "column": 35
                                 }
                             },
                             "range": [
-                                11,
-                                20
+                                30,
+                                35
                             ],
-                            "raw": "^toString"
+                            "raw": "proto"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 10
+                            "column": 28
                         },
                         "end": {
                             "line": 1,
-                            "column": 21
+                            "column": 37
                         }
                     },
                     "range": [
-                        10,
-                        21
+                        28,
+                        37
                     ],
-                    "raw": "[^toString]"
+                    "raw": "__proto__"
                 },
                 {
                     "type": "Str",
-                    "value": " and ",
+                    "value": "] and [^constructor].",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 21
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        21,
-                        26
-                    ],
-                    "raw": " and "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^__proto__",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 27
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                27,
-                                28
-                            ],
-                            "raw": "^"
-                        },
-                        {
-                            "type": "Strong",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "proto",
-                                    "loc": {
-                                        "start": {
-                                            "line": 1,
-                                            "column": 30
-                                        },
-                                        "end": {
-                                            "line": 1,
-                                            "column": 35
-                                        }
-                                    },
-                                    "range": [
-                                        30,
-                                        35
-                                    ],
-                                    "raw": "proto"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 37
-                                }
-                            },
-                            "range": [
-                                28,
-                                37
-                            ],
-                            "raw": "__proto__"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 38
-                        }
-                    },
-                    "range": [
-                        26,
-                        38
-                    ],
-                    "raw": "[^__proto__]"
-                },
-                {
-                    "type": "Str",
-                    "value": " and ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 38
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 43
-                        }
-                    },
-                    "range": [
-                        38,
-                        43
-                    ],
-                    "raw": " and "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^constructor",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^constructor",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 44
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 56
-                                }
-                            },
-                            "range": [
-                                44,
-                                56
-                            ],
-                            "raw": "^constructor"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 43
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 57
-                        }
-                    },
-                    "range": [
-                        43,
-                        57
-                    ],
-                    "raw": "[^constructor]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 57
+                            "column": 37
                         },
                         "end": {
                             "line": 1,
@@ -237,10 +76,10 @@
                         }
                     },
                     "range": [
-                        57,
+                        37,
                         58
                     ],
-                    "raw": "."
+                    "raw": "] and [^constructor]."
                 }
             ],
             "loc": {
@@ -263,30 +102,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^tostring",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^toString",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                61,
-                                70
-                            ],
-                            "raw": "^toString"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^toString]: See ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -294,33 +111,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        60,
-                        71
-                    ],
-                    "raw": "[^toString]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": See ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 17
                         }
                     },
                     "range": [
-                        71,
+                        60,
                         77
                     ],
-                    "raw": ": See "
+                    "raw": "[^toString]: See "
                 },
                 {
                     "type": "Code",
@@ -343,7 +141,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": ".\n",
+                    "value": ".\n[^constructor]: See ",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -351,74 +149,14 @@
                         },
                         "end": {
                             "line": 4,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        106,
-                        108
-                    ],
-                    "raw": ".\n"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^constructor",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^constructor",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                109,
-                                121
-                            ],
-                            "raw": "^constructor"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        108,
-                        122
-                    ],
-                    "raw": "[^constructor]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": See ",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 14
-                        },
-                        "end": {
-                            "line": 4,
                             "column": 20
                         }
                     },
                     "range": [
-                        122,
+                        106,
                         128
                     ],
-                    "raw": ": See "
+                    "raw": ".\n[^constructor]: See "
                 },
                 {
                     "type": "Code",
@@ -441,7 +179,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": ".\n",
+                    "value": ".\n[^",
                     "loc": {
                         "start": {
                             "line": 4,
@@ -449,102 +187,61 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 0
+                            "column": 2
                         }
                     },
                     "range": [
                         156,
-                        158
+                        160
                     ],
-                    "raw": ".\n"
+                    "raw": ".\n[^"
                 },
                 {
-                    "type": "LinkReference",
-                    "identifier": "^__proto__",
-                    "referenceType": "shortcut",
+                    "type": "Strong",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "^",
+                            "value": "proto",
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 1
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 2
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                159,
-                                160
+                                162,
+                                167
                             ],
-                            "raw": "^"
-                        },
-                        {
-                            "type": "Strong",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "proto",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        162,
-                                        167
-                                    ],
-                                    "raw": "proto"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 11
-                                }
-                            },
-                            "range": [
-                                160,
-                                169
-                            ],
-                            "raw": "__proto__"
+                            "raw": "proto"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 0
+                            "column": 2
                         },
                         "end": {
                             "line": 5,
-                            "column": 12
+                            "column": 11
                         }
                     },
                     "range": [
-                        158,
-                        170
+                        160,
+                        169
                     ],
-                    "raw": "[^__proto__]"
+                    "raw": "__proto__"
                 },
                 {
                     "type": "Str",
-                    "value": ": See ",
+                    "value": "]: See ",
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 12
+                            "column": 11
                         },
                         "end": {
                             "line": 5,
@@ -552,10 +249,10 @@
                         }
                     },
                     "range": [
-                        170,
+                        169,
                         176
                     ],
-                    "raw": ": See "
+                    "raw": "]: See "
                 },
                 {
                     "type": "Code",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "A footnote"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "tostring",
                     "label": "toString",
                     "loc": {
@@ -63,7 +63,7 @@
                     "raw": " and "
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "__proto__",
                     "label": "__proto__",
                     "loc": {
@@ -102,7 +102,7 @@
                     "raw": " and "
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "constructor",
                     "label": "constructor",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-proto.nooutput.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "A footnote[^toString] and [^",
+                    "value": "A footnote",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,61 +14,120 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 28
+                            "column": 10
                         }
                     },
                     "range": [
                         0,
-                        28
+                        10
                     ],
-                    "raw": "A footnote[^toString] and [^"
+                    "raw": "A footnote"
                 },
                 {
-                    "type": "Strong",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "proto",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 30
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 35
-                                }
-                            },
-                            "range": [
-                                30,
-                                35
-                            ],
-                            "raw": "proto"
-                        }
-                    ],
+                    "type": "footnoteReference",
+                    "identifier": "tostring",
+                    "label": "toString",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 28
+                            "column": 10
                         },
                         "end": {
                             "line": 1,
-                            "column": 37
+                            "column": 21
                         }
                     },
                     "range": [
-                        28,
-                        37
+                        10,
+                        21
                     ],
-                    "raw": "__proto__"
+                    "raw": "[^toString]"
                 },
                 {
                     "type": "Str",
-                    "value": "] and [^constructor].",
+                    "value": " and ",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 37
+                            "column": 21
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 26
+                        }
+                    },
+                    "range": [
+                        21,
+                        26
+                    ],
+                    "raw": " and "
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "__proto__",
+                    "label": "__proto__",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 38
+                        }
+                    },
+                    "range": [
+                        26,
+                        38
+                    ],
+                    "raw": "[^__proto__]"
+                },
+                {
+                    "type": "Str",
+                    "value": " and ",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 38
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 43
+                        }
+                    },
+                    "range": [
+                        38,
+                        43
+                    ],
+                    "raw": " and "
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "constructor",
+                    "label": "constructor",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 43
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 57
+                        }
+                    },
+                    "range": [
+                        43,
+                        57
+                    ],
+                    "raw": "[^constructor]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 57
                         },
                         "end": {
                             "line": 1,
@@ -76,10 +135,10 @@
                         }
                     },
                     "range": [
-                        37,
+                        57,
                         58
                     ],
-                    "raw": "] and [^constructor]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -99,198 +158,86 @@
             "raw": "A footnote[^toString] and [^__proto__] and [^constructor]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "tostring",
+            "label": "toString",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^toString]: See ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        60,
-                        77
-                    ],
-                    "raw": "[^toString]: See "
-                },
-                {
-                    "type": "Code",
-                    "value": "Object.prototype.toString()",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        77,
-                        106
-                    ],
-                    "raw": "`Object.prototype.toString()`"
-                },
-                {
-                    "type": "Str",
-                    "value": ".\n[^constructor]: See ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 20
-                        }
-                    },
-                    "range": [
-                        106,
-                        128
-                    ],
-                    "raw": ".\n[^constructor]: See "
-                },
-                {
-                    "type": "Code",
-                    "value": "Object.prototype.valueOf()",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 20
-                        },
-                        "end": {
-                            "line": 4,
-                            "column": 48
-                        }
-                    },
-                    "range": [
-                        128,
-                        156
-                    ],
-                    "raw": "`Object.prototype.valueOf()`"
-                },
-                {
-                    "type": "Str",
-                    "value": ".\n[^",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 48
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        156,
-                        160
-                    ],
-                    "raw": ".\n[^"
-                },
-                {
-                    "type": "Strong",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "proto",
+                            "value": "See ",
                             "loc": {
                                 "start": {
-                                    "line": 5,
-                                    "column": 4
+                                    "line": 3,
+                                    "column": 13
                                 },
                                 "end": {
-                                    "line": 5,
-                                    "column": 9
+                                    "line": 3,
+                                    "column": 17
                                 }
                             },
                             "range": [
-                                162,
-                                167
+                                73,
+                                77
                             ],
-                            "raw": "proto"
+                            "raw": "See "
+                        },
+                        {
+                            "type": "Code",
+                            "value": "Object.prototype.toString()",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 46
+                                }
+                            },
+                            "range": [
+                                77,
+                                106
+                            ],
+                            "raw": "`Object.prototype.toString()`"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 46
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 47
+                                }
+                            },
+                            "range": [
+                                106,
+                                107
+                            ],
+                            "raw": "."
                         }
                     ],
                     "loc": {
                         "start": {
-                            "line": 5,
-                            "column": 2
+                            "line": 3,
+                            "column": 13
                         },
                         "end": {
-                            "line": 5,
-                            "column": 11
+                            "line": 3,
+                            "column": 47
                         }
                     },
                     "range": [
-                        160,
-                        169
+                        73,
+                        107
                     ],
-                    "raw": "__proto__"
-                },
-                {
-                    "type": "Str",
-                    "value": "]: See ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        169,
-                        176
-                    ],
-                    "raw": "]: See "
-                },
-                {
-                    "type": "Code",
-                    "value": "Object.prototype.__proto__()",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 48
-                        }
-                    },
-                    "range": [
-                        176,
-                        206
-                    ],
-                    "raw": "`Object.prototype.__proto__()`"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 48
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 49
-                        }
-                    },
-                    "range": [
-                        206,
-                        207
-                    ],
-                    "raw": "."
+                    "raw": "See `Object.prototype.toString()`."
                 }
             ],
             "loc": {
@@ -299,15 +246,213 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 3,
+                    "column": 47
+                }
+            },
+            "range": [
+                60,
+                107
+            ],
+            "raw": "[^toString]: See `Object.prototype.toString()`."
+        },
+        {
+            "type": "footnoteDefinition",
+            "identifier": "constructor",
+            "label": "constructor",
+            "children": [
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "See ",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 20
+                                }
+                            },
+                            "range": [
+                                124,
+                                128
+                            ],
+                            "raw": "See "
+                        },
+                        {
+                            "type": "Code",
+                            "value": "Object.prototype.valueOf()",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 20
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 48
+                                }
+                            },
+                            "range": [
+                                128,
+                                156
+                            ],
+                            "raw": "`Object.prototype.valueOf()`"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 48
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 49
+                                }
+                            },
+                            "range": [
+                                156,
+                                157
+                            ],
+                            "raw": "."
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 49
+                        }
+                    },
+                    "range": [
+                        124,
+                        157
+                    ],
+                    "raw": "See `Object.prototype.valueOf()`."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 49
+                }
+            },
+            "range": [
+                108,
+                157
+            ],
+            "raw": "[^constructor]: See `Object.prototype.valueOf()`."
+        },
+        {
+            "type": "footnoteDefinition",
+            "identifier": "__proto__",
+            "label": "__proto__",
+            "children": [
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "See ",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 18
+                                }
+                            },
+                            "range": [
+                                172,
+                                176
+                            ],
+                            "raw": "See "
+                        },
+                        {
+                            "type": "Code",
+                            "value": "Object.prototype.__proto__()",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 48
+                                }
+                            },
+                            "range": [
+                                176,
+                                206
+                            ],
+                            "raw": "`Object.prototype.__proto__()`"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 48
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 49
+                                }
+                            },
+                            "range": [
+                                206,
+                                207
+                            ],
+                            "raw": "."
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 49
+                        }
+                    },
+                    "range": [
+                        172,
+                        207
+                    ],
+                    "raw": "See `Object.prototype.__proto__()`."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
                     "line": 5,
                     "column": 49
                 }
             },
             "range": [
-                60,
+                158,
                 207
             ],
-            "raw": "[^toString]: See `Object.prototype.toString()`.\n[^constructor]: See `Object.prototype.valueOf()`.\n[^__proto__]: See `Object.prototype.__proto__()`."
+            "raw": "[^__proto__]: See `Object.prototype.__proto__()`."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "foo[^abc] bar. foo",
+                    "value": "foo",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,41 +14,58 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 18
+                            "column": 3
                         }
                     },
                     "range": [
                         0,
-                        18
+                        3
                     ],
-                    "raw": "foo[^abc] bar. foo"
+                    "raw": "foo"
                 },
                 {
-                    "type": "LinkReference",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^xyz",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 19
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 23
-                                }
-                            },
-                            "range": [
-                                19,
-                                23
-                            ],
-                            "raw": "^xyz"
+                    "type": "footnoteReference",
+                    "identifier": "abc",
+                    "label": "abc",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 3
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 9
                         }
+                    },
+                    "range": [
+                        3,
+                        9
                     ],
-                    "identifier": "^xyz",
-                    "label": "^xyz",
-                    "referenceType": "shortcut",
+                    "raw": "[^abc]"
+                },
+                {
+                    "type": "Str",
+                    "value": " bar. foo",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        9,
+                        18
+                    ],
+                    "raw": " bar. foo"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "xyz",
+                    "label": "xyz",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -102,15 +119,37 @@
             "raw": "foo[^abc] bar. foo[^xyz] bar"
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "abc",
+            "label": "abc",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^abc]: Baz baz",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Baz baz",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 15
+                                }
+                            },
+                            "range": [
+                                38,
+                                45
+                            ],
+                            "raw": "Baz baz"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 0
+                            "column": 8
                         },
                         "end": {
                             "line": 3,
@@ -118,10 +157,10 @@
                         }
                     },
                     "range": [
-                        30,
+                        38,
                         45
                     ],
-                    "raw": "[^abc]: Baz baz"
+                    "raw": "Baz baz"
                 }
             ],
             "loc": {
@@ -141,11 +180,50 @@
             "raw": "[^abc]: Baz baz"
         },
         {
-            "type": "Definition",
-            "identifier": "^xyz",
-            "label": "^xyz",
-            "title": null,
-            "url": "Baz",
+            "type": "footnoteDefinition",
+            "identifier": "xyz",
+            "label": "xyz",
+            "children": [
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Baz",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 11
+                                }
+                            },
+                            "range": [
+                                55,
+                                58
+                            ],
+                            "raw": "Baz"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        55,
+                        58
+                    ],
+                    "raw": "Baz"
+                }
+            ],
             "loc": {
                 "start": {
                     "line": 5,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "foo"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "abc",
                     "label": "abc",
                     "loc": {
@@ -63,7 +63,7 @@
                     "raw": " bar. foo"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "xyz",
                     "label": "xyz",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote-without-space.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "foo",
+                    "value": "foo[^abc] bar. foo",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,79 +14,17 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        0,
-                        3
-                    ],
-                    "raw": "foo"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^abc",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^abc",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 8
-                                }
-                            },
-                            "range": [
-                                4,
-                                8
-                            ],
-                            "raw": "^abc"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        3,
-                        9
-                    ],
-                    "raw": "[^abc]"
-                },
-                {
-                    "type": "Str",
-                    "value": " bar. foo",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 18
                         }
                     },
                     "range": [
-                        9,
+                        0,
                         18
                     ],
-                    "raw": " bar. foo"
+                    "raw": "foo[^abc] bar. foo"
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "^xyz",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -108,6 +46,9 @@
                             "raw": "^xyz"
                         }
                     ],
+                    "identifier": "^xyz",
+                    "label": "^xyz",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -164,30 +105,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^abc",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^abc",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                31,
-                                35
-                            ],
-                            "raw": "^abc"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^abc]: Baz baz",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -195,33 +114,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        30,
-                        36
-                    ],
-                    "raw": "[^abc]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Baz baz",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 15
                         }
                     },
                     "range": [
-                        36,
+                        30,
                         45
                     ],
-                    "raw": ": Baz baz"
+                    "raw": "[^abc]: Baz baz"
                 }
             ],
             "loc": {
@@ -243,6 +143,7 @@
         {
             "type": "Definition",
             "identifier": "^xyz",
+            "label": "^xyz",
             "title": null,
             "url": "Baz",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "Lorem ipsum dolor sit amet"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "1",
                     "label": "1",
                     "loc": {
@@ -102,7 +102,7 @@
                     "raw": "Nulla finibus"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "2",
                     "label": "2",
                     "loc": {
@@ -243,7 +243,7 @@
                             "raw": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque"
                         },
                         {
-                            "type": "footnoteReference",
+                            "type": "FootnoteReference",
                             "identifier": "3",
                             "label": "3",
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Lorem ipsum dolor sit amet",
+                    "value": "Lorem ipsum dolor sit amet[^1].",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        0,
-                        26
-                    ],
-                    "raw": "Lorem ipsum dolor sit amet"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 27
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 29
-                                }
-                            },
-                            "range": [
-                                27,
-                                29
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 30
-                        }
-                    },
-                    "range": [
-                        26,
-                        30
-                    ],
-                    "raw": "[^1]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 30
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 31
                         }
                     },
                     "range": [
-                        30,
+                        0,
                         31
                     ],
-                    "raw": "."
+                    "raw": "Lorem ipsum dolor sit amet[^1]."
                 }
             ],
             "loc": {
@@ -105,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Nulla finibus",
+                    "value": "Nulla finibus[^2] neque et diam rhoncus convallis.",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -113,74 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        33,
-                        46
-                    ],
-                    "raw": "Nulla finibus"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^2",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^2",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 14
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 16
-                                }
-                            },
-                            "range": [
-                                47,
-                                49
-                            ],
-                            "raw": "^2"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        46,
-                        50
-                    ],
-                    "raw": "[^2]"
-                },
-                {
-                    "type": "Str",
-                    "value": " neque et diam rhoncus convallis.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 50
                         }
                     },
                     "range": [
-                        50,
+                        33,
                         83
                     ],
-                    "raw": " neque et diam rhoncus convallis."
+                    "raw": "Nulla finibus[^2] neque et diam rhoncus convallis."
                 }
             ],
             "loc": {
@@ -203,30 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^1",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^1",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                86,
-                                88
-                            ],
-                            "raw": "^1"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^1]: Consectetur ",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -234,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        85,
-                        89
-                    ],
-                    "raw": "[^1]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Consectetur ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 18
                         }
                     },
                     "range": [
-                        89,
+                        85,
                         103
                     ],
-                    "raw": ": Consectetur "
+                    "raw": "[^1]: Consectetur "
                 },
                 {
                     "type": "Strong",
@@ -303,7 +142,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque",
+                    "value": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3].",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -311,74 +150,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 99
-                        }
-                    },
-                    "range": [
-                        117,
-                        184
-                    ],
-                    "raw": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^3",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^3",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 100
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 102
-                                }
-                            },
-                            "range": [
-                                185,
-                                187
-                            ],
-                            "raw": "^3"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 99
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 103
-                        }
-                    },
-                    "range": [
-                        184,
-                        188
-                    ],
-                    "raw": "[^3]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 103
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 104
                         }
                     },
                     "range": [
-                        188,
+                        117,
                         189
                     ],
-                    "raw": "."
+                    "raw": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3]."
                 }
             ],
             "loc": {
@@ -400,6 +179,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "-   Containing a list.",
             "loc": {
                 "start": {
@@ -421,30 +201,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^2",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^2",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                220,
-                                222
-                            ],
-                            "raw": "^2"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^2]: Nam dictum sapien nec sem ultrices fermentum. Nulla ",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -452,33 +210,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        219,
-                        223
-                    ],
-                    "raw": "[^2]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Nam dictum sapien nec sem ultrices fermentum. Nulla ",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 58
                         }
                     },
                     "range": [
-                        223,
+                        219,
                         277
                     ],
-                    "raw": ": Nam dictum sapien nec sem ultrices fermentum. Nulla "
+                    "raw": "[^2]: Nam dictum sapien nec sem ultrices fermentum. Nulla "
                 },
                 {
                     "type": "Strong",
@@ -559,30 +298,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^3",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^3",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 3
-                                }
-                            },
-                            "range": [
-                                314,
-                                316
-                            ],
-                            "raw": "^3"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^3]: Nunc dapibus ipsum ut mi ",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -590,33 +307,14 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        313,
-                        317
-                    ],
-                    "raw": "[^3]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Nunc dapibus ipsum ut mi ",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 11,
                             "column": 31
                         }
                     },
                     "range": [
-                        317,
+                        313,
                         344
                     ],
-                    "raw": ": Nunc dapibus ipsum ut mi "
+                    "raw": "[^3]: Nunc dapibus ipsum ut mi "
                 },
                 {
                     "type": "Emphasis",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.output.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Lorem ipsum dolor sit amet[^1].",
+                    "value": "Lorem ipsum dolor sit amet",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 31
+                            "column": 26
                         }
                     },
                     "range": [
                         0,
+                        26
+                    ],
+                    "raw": "Lorem ipsum dolor sit amet"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "1",
+                    "label": "1",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 30
+                        }
+                    },
+                    "range": [
+                        26,
+                        30
+                    ],
+                    "raw": "[^1]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 30
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 31
+                        }
+                    },
+                    "range": [
+                        30,
                         31
                     ],
-                    "raw": "Lorem ipsum dolor sit amet[^1]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -45,7 +84,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Nulla finibus[^2] neque et diam rhoncus convallis.",
+                    "value": "Nulla finibus",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,14 +92,53 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 50
+                            "column": 13
                         }
                     },
                     "range": [
                         33,
+                        46
+                    ],
+                    "raw": "Nulla finibus"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "2",
+                    "label": "2",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        46,
+                        50
+                    ],
+                    "raw": "[^2]"
+                },
+                {
+                    "type": "Str",
+                    "value": " neque et diam rhoncus convallis.",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 50
+                        }
+                    },
+                    "range": [
+                        50,
                         83
                     ],
-                    "raw": "Nulla finibus[^2] neque et diam rhoncus convallis."
+                    "raw": " neque et diam rhoncus convallis."
                 }
             ],
             "loc": {
@@ -80,73 +158,134 @@
             "raw": "Nulla finibus[^2] neque et diam rhoncus convallis."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "1",
+            "label": "1",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^1]: Consectetur ",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        85,
-                        103
-                    ],
-                    "raw": "[^1]: Consectetur "
-                },
-                {
-                    "type": "Strong",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "adipiscing",
+                            "value": "Consectetur ",
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 20
+                                    "column": 6
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 30
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                105,
-                                115
+                                91,
+                                103
                             ],
-                            "raw": "adipiscing"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 18
+                            "raw": "Consectetur "
                         },
-                        "end": {
-                            "line": 5,
-                            "column": 32
+                        {
+                            "type": "Strong",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "adipiscing",
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 20
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 30
+                                        }
+                                    },
+                                    "range": [
+                                        105,
+                                        115
+                                    ],
+                                    "raw": "adipiscing"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 32
+                                }
+                            },
+                            "range": [
+                                103,
+                                117
+                            ],
+                            "raw": "**adipiscing**"
+                        },
+                        {
+                            "type": "Str",
+                            "value": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 32
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 99
+                                }
+                            },
+                            "range": [
+                                117,
+                                184
+                            ],
+                            "raw": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque"
+                        },
+                        {
+                            "type": "footnoteReference",
+                            "identifier": "3",
+                            "label": "3",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 99
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 103
+                                }
+                            },
+                            "range": [
+                                184,
+                                188
+                            ],
+                            "raw": "[^3]"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 103
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 104
+                                }
+                            },
+                            "range": [
+                                188,
+                                189
+                            ],
+                            "raw": "."
                         }
-                    },
-                    "range": [
-                        103,
-                        117
                     ],
-                    "raw": "**adipiscing**"
-                },
-                {
-                    "type": "Str",
-                    "value": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3].",
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 32
+                            "column": 6
                         },
                         "end": {
                             "line": 5,
@@ -154,36 +293,99 @@
                         }
                     },
                     "range": [
-                        117,
+                        91,
                         189
                     ],
-                    "raw": " elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3]."
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 5,
-                    "column": 0
+                    "raw": "Consectetur **adipiscing** elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3]."
                 },
-                "end": {
-                    "line": 5,
-                    "column": 104
+                {
+                    "type": "List",
+                    "ordered": false,
+                    "start": null,
+                    "spread": false,
+                    "children": [
+                        {
+                            "type": "ListItem",
+                            "spread": false,
+                            "checked": null,
+                            "children": [
+                                {
+                                    "type": "Paragraph",
+                                    "children": [
+                                        {
+                                            "type": "Str",
+                                            "value": "Containing a list.",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 7,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 7,
+                                                    "column": 26
+                                                }
+                                            },
+                                            "range": [
+                                                199,
+                                                217
+                                            ],
+                                            "raw": "Containing a list."
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 26
+                                        }
+                                    },
+                                    "range": [
+                                        199,
+                                        217
+                                    ],
+                                    "raw": "Containing a list."
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 26
+                                }
+                            },
+                            "range": [
+                                195,
+                                217
+                            ],
+                            "raw": "-   Containing a list."
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 26
+                        }
+                    },
+                    "range": [
+                        195,
+                        217
+                    ],
+                    "raw": "-   Containing a list."
                 }
-            },
-            "range": [
-                85,
-                189
             ],
-            "raw": "[^1]: Consectetur **adipiscing** elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3]."
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "meta": null,
-            "value": "-   Containing a list.",
             "loc": {
                 "start": {
-                    "line": 7,
+                    "line": 5,
                     "column": 0
                 },
                 "end": {
@@ -192,79 +394,101 @@
                 }
             },
             "range": [
-                191,
+                85,
                 217
             ],
-            "raw": "    -   Containing a list."
+            "raw": "[^1]: Consectetur **adipiscing** elit. Praesent dictum purus ullamcorper ligula semper pellentesque[^3].\n\n    -   Containing a list."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "2",
+            "label": "2",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^2]: Nam dictum sapien nec sem ultrices fermentum. Nulla ",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 58
-                        }
-                    },
-                    "range": [
-                        219,
-                        277
-                    ],
-                    "raw": "[^2]: Nam dictum sapien nec sem ultrices fermentum. Nulla "
-                },
-                {
-                    "type": "Strong",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "facilisi",
+                            "value": "Nam dictum sapien nec sem ultrices fermentum. Nulla ",
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 60
+                                    "column": 6
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 68
+                                    "column": 58
                                 }
                             },
                             "range": [
-                                279,
-                                287
+                                225,
+                                277
                             ],
-                            "raw": "facilisi"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 58
+                            "raw": "Nam dictum sapien nec sem ultrices fermentum. Nulla "
                         },
-                        "end": {
-                            "line": 9,
-                            "column": 70
+                        {
+                            "type": "Strong",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "facilisi",
+                                    "loc": {
+                                        "start": {
+                                            "line": 9,
+                                            "column": 60
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 68
+                                        }
+                                    },
+                                    "range": [
+                                        279,
+                                        287
+                                    ],
+                                    "raw": "facilisi"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 58
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 70
+                                }
+                            },
+                            "range": [
+                                277,
+                                289
+                            ],
+                            "raw": "**facilisi**"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ". In et feugiat massa.",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 70
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 92
+                                }
+                            },
+                            "range": [
+                                289,
+                                311
+                            ],
+                            "raw": ". In et feugiat massa."
                         }
-                    },
-                    "range": [
-                        277,
-                        289
                     ],
-                    "raw": "**facilisi**"
-                },
-                {
-                    "type": "Str",
-                    "value": ". In et feugiat massa.",
                     "loc": {
                         "start": {
                             "line": 9,
-                            "column": 70
+                            "column": 6
                         },
                         "end": {
                             "line": 9,
@@ -272,10 +496,10 @@
                         }
                     },
                     "range": [
-                        289,
+                        225,
                         311
                     ],
-                    "raw": ". In et feugiat massa."
+                    "raw": "Nam dictum sapien nec sem ultrices fermentum. Nulla **facilisi**. In et feugiat massa."
                 }
             ],
             "loc": {
@@ -295,73 +519,95 @@
             "raw": "[^2]: Nam dictum sapien nec sem ultrices fermentum. Nulla **facilisi**. In et feugiat massa."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "3",
+            "label": "3",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^3]: Nunc dapibus ipsum ut mi ",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 11,
-                            "column": 31
-                        }
-                    },
-                    "range": [
-                        313,
-                        344
-                    ],
-                    "raw": "[^3]: Nunc dapibus ipsum ut mi "
-                },
-                {
-                    "type": "Emphasis",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "ultrices",
+                            "value": "Nunc dapibus ipsum ut mi ",
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 32
+                                    "column": 6
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 40
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                345,
-                                353
+                                319,
+                                344
                             ],
-                            "raw": "ultrices"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 31
+                            "raw": "Nunc dapibus ipsum ut mi "
                         },
-                        "end": {
-                            "line": 11,
-                            "column": 41
+                        {
+                            "type": "Emphasis",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "ultrices",
+                                    "loc": {
+                                        "start": {
+                                            "line": 11,
+                                            "column": 32
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 40
+                                        }
+                                    },
+                                    "range": [
+                                        345,
+                                        353
+                                    ],
+                                    "raw": "ultrices"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 31
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 41
+                                }
+                            },
+                            "range": [
+                                344,
+                                354
+                            ],
+                            "raw": "_ultrices_"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ", non euismod velit pretium.",
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 41
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 69
+                                }
+                            },
+                            "range": [
+                                354,
+                                382
+                            ],
+                            "raw": ", non euismod velit pretium."
                         }
-                    },
-                    "range": [
-                        344,
-                        354
                     ],
-                    "raw": "_ultrices_"
-                },
-                {
-                    "type": "Str",
-                    "value": ", non euismod velit pretium.",
                     "loc": {
                         "start": {
                             "line": 11,
-                            "column": 41
+                            "column": 6
                         },
                         "end": {
                             "line": 11,
@@ -369,10 +615,10 @@
                         }
                     },
                     "range": [
-                        354,
+                        319,
                         382
                     ],
-                    "raw": ", non euismod velit pretium."
+                    "raw": "Nunc dapibus ipsum ut mi _ultrices_, non euismod velit pretium."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
@@ -24,7 +24,7 @@
                     "raw": "Here is some text containing a footnote"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "somesamplefootnote",
                     "label": "somesamplefootnote",
                     "loc": {
@@ -224,7 +224,7 @@
                     "raw": " and the footnotes will go to the bottom of the document"
                 },
                 {
-                    "type": "footnoteReference",
+                    "type": "FootnoteReference",
                     "identifier": "documentdetails",
                     "label": "documentdetails",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here is some text containing a footnote[^somesamplefootnote]. You can then continue your thought...",
+                    "value": "Here is some text containing a footnote",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,14 +14,53 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 99
+                            "column": 39
                         }
                     },
                     "range": [
                         0,
+                        39
+                    ],
+                    "raw": "Here is some text containing a footnote"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "somesamplefootnote",
+                    "label": "somesamplefootnote",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 39
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 60
+                        }
+                    },
+                    "range": [
+                        39,
+                        60
+                    ],
+                    "raw": "[^somesamplefootnote]"
+                },
+                {
+                    "type": "Str",
+                    "value": ". You can then continue your thought...",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 60
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 99
+                        }
+                    },
+                    "range": [
+                        60,
                         99
                     ],
-                    "raw": "Here is some text containing a footnote[^somesamplefootnote]. You can then continue your thought..."
+                    "raw": ". You can then continue your thought..."
                 }
             ],
             "loc": {
@@ -41,15 +80,37 @@
             "raw": "Here is some text containing a footnote[^somesamplefootnote]. You can then continue your thought..."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "somesamplefootnote",
+            "label": "somesamplefootnote",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^somesamplefootnote]: Here is the text of the footnote itself.",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Here is the text of the footnote itself.",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 23
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 63
+                                }
+                            },
+                            "range": [
+                                124,
+                                164
+                            ],
+                            "raw": "Here is the text of the footnote itself."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 0
+                            "column": 23
                         },
                         "end": {
                             "line": 3,
@@ -57,10 +118,10 @@
                         }
                     },
                     "range": [
-                        101,
+                        124,
                         164
                     ],
-                    "raw": "[^somesamplefootnote]: Here is the text of the footnote itself."
+                    "raw": "Here is the text of the footnote itself."
                 }
             ],
             "loc": {
@@ -145,7 +206,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": " and the footnotes will go to the bottom of the document[^documentdetails].",
+                    "value": " and the footnotes will go to the bottom of the document",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -153,14 +214,53 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 103
+                            "column": 84
                         }
                     },
                     "range": [
                         194,
+                        250
+                    ],
+                    "raw": " and the footnotes will go to the bottom of the document"
+                },
+                {
+                    "type": "footnoteReference",
+                    "identifier": "documentdetails",
+                    "label": "documentdetails",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 84
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 102
+                        }
+                    },
+                    "range": [
+                        250,
+                        268
+                    ],
+                    "raw": "[^documentdetails]"
+                },
+                {
+                    "type": "Str",
+                    "value": ".",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 102
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 103
+                        }
+                    },
+                    "range": [
+                        268,
                         269
                     ],
-                    "raw": " and the footnotes will go to the bottom of the document[^documentdetails]."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -180,73 +280,95 @@
             "raw": "Even go to a new [paragraph] and the footnotes will go to the bottom of the document[^documentdetails]."
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "documentdetails",
+            "label": "documentdetails",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^documentdetails]: Depending on the ",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 37
-                        }
-                    },
-                    "range": [
-                        271,
-                        308
-                    ],
-                    "raw": "[^documentdetails]: Depending on the "
-                },
-                {
-                    "type": "Strong",
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "final",
+                            "value": "Depending on the ",
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 39
+                                    "column": 20
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 44
+                                    "column": 37
                                 }
                             },
                             "range": [
-                                310,
-                                315
+                                291,
+                                308
                             ],
-                            "raw": "final"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 37
+                            "raw": "Depending on the "
                         },
-                        "end": {
-                            "line": 7,
-                            "column": 46
+                        {
+                            "type": "Strong",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "final",
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 39
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 44
+                                        }
+                                    },
+                                    "range": [
+                                        310,
+                                        315
+                                    ],
+                                    "raw": "final"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 37
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 46
+                                }
+                            },
+                            "range": [
+                                308,
+                                317
+                            ],
+                            "raw": "**final**"
+                        },
+                        {
+                            "type": "Str",
+                            "value": " form of your document, of course. See the documentation and experiment.",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 46
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 118
+                                }
+                            },
+                            "range": [
+                                317,
+                                389
+                            ],
+                            "raw": " form of your document, of course. See the documentation and experiment."
                         }
-                    },
-                    "range": [
-                        308,
-                        317
                     ],
-                    "raw": "**final**"
-                },
-                {
-                    "type": "Str",
-                    "value": " form of your document, of course. See the documentation and experiment.",
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 46
+                            "column": 20
                         },
                         "end": {
                             "line": 7,
@@ -254,36 +376,115 @@
                         }
                     },
                     "range": [
-                        317,
+                        291,
                         389
                     ],
-                    "raw": " form of your document, of course. See the documentation and experiment."
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 7,
-                    "column": 0
+                    "raw": "Depending on the **final** form of your document, of course. See the documentation and experiment."
                 },
-                "end": {
-                    "line": 7,
-                    "column": 118
+                {
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "This footnote has a second ",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 31
+                                }
+                            },
+                            "range": [
+                                395,
+                                422
+                            ],
+                            "raw": "This footnote has a second "
+                        },
+                        {
+                            "type": "LinkReference",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "paragraph",
+                                    "loc": {
+                                        "start": {
+                                            "line": 9,
+                                            "column": 32
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 41
+                                        }
+                                    },
+                                    "range": [
+                                        423,
+                                        432
+                                    ],
+                                    "raw": "paragraph"
+                                }
+                            ],
+                            "identifier": "paragraph",
+                            "label": "paragraph",
+                            "referenceType": "shortcut",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 31
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 42
+                                }
+                            },
+                            "range": [
+                                422,
+                                433
+                            ],
+                            "raw": "[paragraph]"
+                        },
+                        {
+                            "type": "Str",
+                            "value": ".",
+                            "loc": {
+                                "start": {
+                                    "line": 9,
+                                    "column": 42
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "column": 43
+                                }
+                            },
+                            "range": [
+                                433,
+                                434
+                            ],
+                            "raw": "."
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 9,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 43
+                        }
+                    },
+                    "range": [
+                        395,
+                        434
+                    ],
+                    "raw": "This footnote has a second [paragraph]."
                 }
-            },
-            "range": [
-                271,
-                389
             ],
-            "raw": "[^documentdetails]: Depending on the **final** form of your document, of course. See the documentation and experiment."
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "meta": null,
-            "value": "This footnote has a second [paragraph].",
             "loc": {
                 "start": {
-                    "line": 9,
+                    "line": 7,
                     "column": 0
                 },
                 "end": {
@@ -292,10 +493,10 @@
                 }
             },
             "range": [
-                391,
+                271,
                 434
             ],
-            "raw": "    This footnote has a second [paragraph]."
+            "raw": "[^documentdetails]: Depending on the **final** form of your document, of course. See the documentation and experiment.\n\n    This footnote has a second [paragraph]."
         },
         {
             "type": "Definition",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/footnote.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Here is some text containing a footnote",
+                    "value": "Here is some text containing a footnote[^somesamplefootnote]. You can then continue your thought...",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,74 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 39
-                        }
-                    },
-                    "range": [
-                        0,
-                        39
-                    ],
-                    "raw": "Here is some text containing a footnote"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^somesamplefootnote",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^somesamplefootnote",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 40
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 59
-                                }
-                            },
-                            "range": [
-                                40,
-                                59
-                            ],
-                            "raw": "^somesamplefootnote"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 39
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 60
-                        }
-                    },
-                    "range": [
-                        39,
-                        60
-                    ],
-                    "raw": "[^somesamplefootnote]"
-                },
-                {
-                    "type": "Str",
-                    "value": ". You can then continue your thought...",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 60
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 99
                         }
                     },
                     "range": [
-                        60,
+                        0,
                         99
                     ],
-                    "raw": ". You can then continue your thought..."
+                    "raw": "Here is some text containing a footnote[^somesamplefootnote]. You can then continue your thought..."
                 }
             ],
             "loc": {
@@ -104,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^somesamplefootnote",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^somesamplefootnote",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 20
-                                }
-                            },
-                            "range": [
-                                102,
-                                121
-                            ],
-                            "raw": "^somesamplefootnote"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^somesamplefootnote]: Here is the text of the footnote itself.",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -135,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 21
-                        }
-                    },
-                    "range": [
-                        101,
-                        122
-                    ],
-                    "raw": "[^somesamplefootnote]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Here is the text of the footnote itself.",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 21
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 63
                         }
                     },
                     "range": [
-                        122,
+                        101,
                         164
                     ],
-                    "raw": ": Here is the text of the footnote itself."
+                    "raw": "[^somesamplefootnote]: Here is the text of the footnote itself."
                 }
             ],
             "loc": {
@@ -204,8 +103,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "paragraph",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -227,6 +124,9 @@
                             "raw": "paragraph"
                         }
                     ],
+                    "identifier": "paragraph",
+                    "label": "paragraph",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -245,7 +145,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": " and the footnotes will go to the bottom of the document",
+                    "value": " and the footnotes will go to the bottom of the document[^documentdetails].",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -253,74 +153,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 84
-                        }
-                    },
-                    "range": [
-                        194,
-                        250
-                    ],
-                    "raw": " and the footnotes will go to the bottom of the document"
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "^documentdetails",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^documentdetails",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 85
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 101
-                                }
-                            },
-                            "range": [
-                                251,
-                                267
-                            ],
-                            "raw": "^documentdetails"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 84
-                        },
-                        "end": {
-                            "line": 5,
-                            "column": 102
-                        }
-                    },
-                    "range": [
-                        250,
-                        268
-                    ],
-                    "raw": "[^documentdetails]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 102
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 103
                         }
                     },
                     "range": [
-                        268,
+                        194,
                         269
                     ],
-                    "raw": "."
+                    "raw": " and the footnotes will go to the bottom of the document[^documentdetails]."
                 }
             ],
             "loc": {
@@ -343,30 +183,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^documentdetails",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^documentdetails",
-                            "loc": {
-                                "start": {
-                                    "line": 7,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 17
-                                }
-                            },
-                            "range": [
-                                272,
-                                288
-                            ],
-                            "raw": "^documentdetails"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^documentdetails]: Depending on the ",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -374,33 +192,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        271,
-                        289
-                    ],
-                    "raw": "[^documentdetails]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": Depending on the ",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 37
                         }
                     },
                     "range": [
-                        289,
+                        271,
                         308
                     ],
-                    "raw": ": Depending on the "
+                    "raw": "[^documentdetails]: Depending on the "
                 },
                 {
                     "type": "Strong",
@@ -480,6 +279,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This footnote has a second [paragraph].",
             "loc": {
                 "start": {
@@ -500,6 +300,7 @@
         {
             "type": "Definition",
             "identifier": "paragraph",
+            "label": "paragraph",
             "title": null,
             "url": "http://example.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-initial-lines.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-initial-lines.text/output.json
@@ -2,11 +2,50 @@
     "type": "Document",
     "children": [
         {
-            "type": "Yaml",
-            "value": "title: post",
+            "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 3
+                }
+            },
+            "range": [
+                2,
+                5
+            ],
+            "raw": "---"
+        },
+        {
+            "type": "Header",
+            "depth": 2,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "title: post",
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        6,
+                        17
+                    ],
+                    "raw": "title: post"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
                     "column": 0
                 },
                 "end": {
@@ -15,10 +54,10 @@
                 }
             },
             "range": [
-                2,
+                6,
                 21
             ],
-            "raw": "---\ntitle: post\n---"
+            "raw": "title: post\n---"
         },
         {
             "type": "Header",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/hard-wrapped-paragraphs-with-list-like-lines.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/hard-wrapped-paragraphs-with-list-like-lines.text/output.json
@@ -83,11 +83,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/heading-in-blockquote.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/heading-in-blockquote.text/output.json
@@ -9,22 +9,22 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "A blockquote\nwith some more text.",
+                            "value": "A blockquote",
                             "loc": {
                                 "start": {
                                     "line": 1,
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 2,
-                                    "column": 20
+                                    "line": 1,
+                                    "column": 14
                                 }
                             },
                             "range": [
                                 2,
-                                35
+                                14
                             ],
-                            "raw": "A blockquote\nwith some more text."
+                            "raw": "A blockquote"
                         }
                     ],
                     "loc": {
@@ -33,15 +33,15 @@
                             "column": 2
                         },
                         "end": {
-                            "line": 2,
-                            "column": 20
+                            "line": 1,
+                            "column": 14
                         }
                     },
                     "range": [
                         2,
-                        35
+                        14
                     ],
-                    "raw": "A blockquote\nwith some more text."
+                    "raw": "A blockquote"
                 }
             ],
             "loc": {
@@ -50,15 +50,54 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                0,
+                14
+            ],
+            "raw": "> A blockquote"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "with some more text.",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 20
+                        }
+                    },
+                    "range": [
+                        15,
+                        35
+                    ],
+                    "raw": "with some more text."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
                     "line": 2,
                     "column": 20
                 }
             },
             "range": [
-                0,
+                15,
                 35
             ],
-            "raw": "> A blockquote\nwith some more text."
+            "raw": "with some more text."
         },
         {
             "type": "Paragraph",
@@ -103,8 +142,7 @@
             "type": "BlockQuote",
             "children": [
                 {
-                    "type": "Header",
-                    "depth": 2,
+                    "type": "Paragraph",
                     "children": [
                         {
                             "type": "Str",
@@ -132,16 +170,54 @@
                             "column": 2
                         },
                         "end": {
-                            "line": 7,
-                            "column": 3
+                            "line": 6,
+                            "column": 61
                         }
                     },
                     "range": [
                         60,
-                        123
+                        119
                     ],
-                    "raw": "A blockquote followed by a horizontal rule (in CommonMark).\n---"
+                    "raw": "A blockquote followed by a horizontal rule (in CommonMark)."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 0
                 },
+                "end": {
+                    "line": 6,
+                    "column": 61
+                }
+            },
+            "range": [
+                58,
+                119
+            ],
+            "raw": "> A blockquote followed by a horizontal rule (in CommonMark)."
+        },
+        {
+            "type": "HorizontalRule",
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 3
+                }
+            },
+            "range": [
+                120,
+                123
+            ],
+            "raw": "---"
+        },
+        {
+            "type": "BlockQuote",
+            "children": [
                 {
                     "type": "Header",
                     "depth": 2,
@@ -185,7 +261,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 6,
+                    "line": 9,
                     "column": 0
                 },
                 "end": {
@@ -194,10 +270,10 @@
                 }
             },
             "range": [
-                58,
+                125,
                 158
             ],
-            "raw": "> A blockquote followed by a horizontal rule (in CommonMark).\n---\n\n> A heading in a blockquote\n> ---"
+            "raw": "> A heading in a blockquote\n> ---"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/heading-in-paragraph.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/heading-in-paragraph.text/output.json
@@ -2,54 +2,15 @@
     "type": "Document",
     "children": [
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "Hello",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        0,
-                        5
-                    ],
-                    "raw": "Hello"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 5
-                }
-            },
-            "range": [
-                0,
-                5
-            ],
-            "raw": "Hello"
-        },
-        {
             "type": "Header",
             "depth": 1,
             "children": [
                 {
                     "type": "Str",
-                    "value": "World",
+                    "value": "Hello\nWorld",
                     "loc": {
                         "start": {
-                            "line": 2,
+                            "line": 1,
                             "column": 0
                         },
                         "end": {
@@ -58,15 +19,15 @@
                         }
                     },
                     "range": [
-                        6,
+                        0,
                         11
                     ],
-                    "raw": "World"
+                    "raw": "Hello\nWorld"
                 }
             ],
             "loc": {
                 "start": {
-                    "line": 2,
+                    "line": 1,
                     "column": 0
                 },
                 "end": {
@@ -75,10 +36,10 @@
                 }
             },
             "range": [
-                6,
+                0,
                 15
             ],
-            "raw": "World\n==="
+            "raw": "Hello\nWorld\n==="
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/heading-setext-with-initial-spacing.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/heading-setext-with-initial-spacing.text/output.json
@@ -28,7 +28,7 @@
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 2,
@@ -36,10 +36,10 @@
                 }
             },
             "range": [
-                0,
+                2,
                 21
             ],
-            "raw": "  Heading 1\n========="
+            "raw": "Heading 1\n========="
         },
         {
             "type": "Header",
@@ -68,7 +68,7 @@
             "loc": {
                 "start": {
                     "line": 4,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 5,
@@ -76,10 +76,10 @@
                 }
             },
             "range": [
-                23,
+                26,
                 45
             ],
-            "raw": "   Heading 2\n---------"
+            "raw": "Heading 2\n---------"
         },
         {
             "type": "Paragraph",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/horizontal-rules.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/horizontal-rules.text/output.json
@@ -63,7 +63,7 @@
             "loc": {
                 "start": {
                     "line": 5,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 5,
@@ -71,17 +71,17 @@
                 }
             },
             "range": [
-                14,
+                15,
                 18
             ],
-            "raw": " ---"
+            "raw": "---"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 7,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 7,
@@ -89,17 +89,17 @@
                 }
             },
             "range": [
-                21,
+                23,
                 26
             ],
-            "raw": "  ---"
+            "raw": "---"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 9,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 9,
@@ -107,14 +107,15 @@
                 }
             },
             "range": [
-                28,
+                31,
                 34
             ],
-            "raw": "   ---"
+            "raw": "---"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "---",
             "loc": {
                 "start": {
@@ -155,7 +156,7 @@
             "loc": {
                 "start": {
                     "line": 15,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 15,
@@ -163,17 +164,17 @@
                 }
             },
             "range": [
-                49,
+                50,
                 55
             ],
-            "raw": " - - -"
+            "raw": "- - -"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 17,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 17,
@@ -181,17 +182,17 @@
                 }
             },
             "range": [
-                58,
+                60,
                 65
             ],
-            "raw": "  - - -"
+            "raw": "- - -"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 19,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 19,
@@ -199,14 +200,15 @@
                 }
             },
             "range": [
-                67,
+                70,
                 75
             ],
-            "raw": "   - - -"
+            "raw": "- - -"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "- - -",
             "loc": {
                 "start": {
@@ -286,7 +288,7 @@
             "loc": {
                 "start": {
                     "line": 28,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 28,
@@ -294,17 +296,17 @@
                 }
             },
             "range": [
-                103,
+                104,
                 107
             ],
-            "raw": " ***"
+            "raw": "***"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 30,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 30,
@@ -312,17 +314,17 @@
                 }
             },
             "range": [
-                110,
+                112,
                 115
             ],
-            "raw": "  ***"
+            "raw": "***"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 32,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 32,
@@ -330,14 +332,15 @@
                 }
             },
             "range": [
-                117,
+                120,
                 123
             ],
-            "raw": "   ***"
+            "raw": "***"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "***",
             "loc": {
                 "start": {
@@ -378,7 +381,7 @@
             "loc": {
                 "start": {
                     "line": 38,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 38,
@@ -386,17 +389,17 @@
                 }
             },
             "range": [
-                138,
+                139,
                 144
             ],
-            "raw": " * * *"
+            "raw": "* * *"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 40,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 40,
@@ -404,17 +407,17 @@
                 }
             },
             "range": [
-                147,
+                149,
                 154
             ],
-            "raw": "  * * *"
+            "raw": "* * *"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 42,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 42,
@@ -422,14 +425,15 @@
                 }
             },
             "range": [
-                156,
+                159,
                 164
             ],
-            "raw": "   * * *"
+            "raw": "* * *"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "* * *",
             "loc": {
                 "start": {
@@ -509,7 +513,7 @@
             "loc": {
                 "start": {
                     "line": 51,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 51,
@@ -517,17 +521,17 @@
                 }
             },
             "range": [
-                194,
+                195,
                 198
             ],
-            "raw": " ___"
+            "raw": "___"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 53,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 53,
@@ -535,17 +539,17 @@
                 }
             },
             "range": [
-                201,
+                203,
                 206
             ],
-            "raw": "  ___"
+            "raw": "___"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 55,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 55,
@@ -553,14 +557,15 @@
                 }
             },
             "range": [
-                208,
+                211,
                 214
             ],
-            "raw": "   ___"
+            "raw": "___"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "___",
             "loc": {
                 "start": {
@@ -601,7 +606,7 @@
             "loc": {
                 "start": {
                     "line": 61,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 61,
@@ -609,17 +614,17 @@
                 }
             },
             "range": [
-                232,
+                233,
                 238
             ],
-            "raw": " _ _ _"
+            "raw": "_ _ _"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 63,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 63,
@@ -627,17 +632,17 @@
                 }
             },
             "range": [
-                241,
+                243,
                 248
             ],
-            "raw": "  _ _ _"
+            "raw": "_ _ _"
         },
         {
             "type": "HorizontalRule",
             "loc": {
                 "start": {
                     "line": 65,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 65,
@@ -645,14 +650,15 @@
                 }
             },
             "range": [
-                250,
+                253,
                 258
             ],
-            "raw": "   _ _ _"
+            "raw": "_ _ _"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "_ _ _",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/hr-list-break.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/hr-list-break.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -246,11 +246,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -311,7 +311,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -372,7 +372,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -392,45 +392,6 @@
                                 142
                             ],
                             "raw": "* * *"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "you today?",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 0
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        143,
-                                        153
-                                    ],
-                                    "raw": "you today?"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 13,
-                                    "column": 0
-                                },
-                                "end": {
-                                    "line": 13,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                143,
-                                153
-                            ],
-                            "raw": "you today?"
                         }
                     ],
                     "loc": {
@@ -439,15 +400,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 13,
-                            "column": 10
+                            "line": 12,
+                            "column": 7
                         }
                     },
                     "range": [
                         135,
-                        153
+                        142
                     ],
-                    "raw": "- * * *\nyou today?"
+                    "raw": "- * * *"
                 }
             ],
             "loc": {
@@ -456,25 +417,64 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 12,
+                    "column": 7
+                }
+            },
+            "range": [
+                111,
+                142
+            ],
+            "raw": "- hello world\n- how are\n- * * *"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "you today?",
+                    "loc": {
+                        "start": {
+                            "line": 13,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 13,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        143,
+                        153
+                    ],
+                    "raw": "you today?"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
+                },
+                "end": {
                     "line": 13,
                     "column": 10
                 }
             },
             "range": [
-                111,
+                143,
                 153
             ],
-            "raw": "- hello world\n- how are\n- * * *\nyou today?"
+            "raw": "you today?"
         },
         {
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -535,7 +535,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -596,41 +596,46 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
-                                            "type": "Paragraph",
+                                            "type": "List",
+                                            "ordered": false,
+                                            "start": null,
+                                            "spread": false,
                                             "children": [
                                                 {
-                                                    "type": "Str",
-                                                    "value": "*\nyou today?",
+                                                    "type": "ListItem",
+                                                    "spread": false,
+                                                    "checked": null,
+                                                    "children": [],
                                                     "loc": {
                                                         "start": {
                                                             "line": 18,
                                                             "column": 4
                                                         },
                                                         "end": {
-                                                            "line": 19,
-                                                            "column": 10
+                                                            "line": 18,
+                                                            "column": 5
                                                         }
                                                     },
                                                     "range": [
                                                         189,
-                                                        201
+                                                        190
                                                     ],
-                                                    "raw": "*\nyou today?"
+                                                    "raw": "*"
                                                 }
                                             ],
                                             "loc": {
@@ -639,15 +644,15 @@
                                                     "column": 4
                                                 },
                                                 "end": {
-                                                    "line": 19,
-                                                    "column": 10
+                                                    "line": 18,
+                                                    "column": 5
                                                 }
                                             },
                                             "range": [
                                                 189,
-                                                201
+                                                190
                                             ],
-                                            "raw": "*\nyou today?"
+                                            "raw": "*"
                                         }
                                     ],
                                     "loc": {
@@ -656,15 +661,15 @@
                                             "column": 2
                                         },
                                         "end": {
-                                            "line": 19,
-                                            "column": 10
+                                            "line": 18,
+                                            "column": 5
                                         }
                                     },
                                     "range": [
                                         187,
-                                        201
+                                        190
                                     ],
-                                    "raw": "* *\nyou today?"
+                                    "raw": "* *"
                                 }
                             ],
                             "loc": {
@@ -673,15 +678,15 @@
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 19,
-                                    "column": 10
+                                    "line": 18,
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 187,
-                                201
+                                190
                             ],
-                            "raw": "* *\nyou today?"
+                            "raw": "* *"
                         }
                     ],
                     "loc": {
@@ -690,15 +695,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 19,
-                            "column": 10
+                            "line": 18,
+                            "column": 5
                         }
                     },
                     "range": [
                         185,
-                        201
+                        190
                     ],
-                    "raw": "+ * *\nyou today?"
+                    "raw": "+ * *"
                 }
             ],
             "loc": {
@@ -707,25 +712,64 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                156,
+                190
+            ],
+            "raw": "+ Neither do these\n+ how are\n+ * *"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "you today?",
+                    "loc": {
+                        "start": {
+                            "line": 19,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 19,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        191,
+                        201
+                    ],
+                    "raw": "you today?"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 0
+                },
+                "end": {
                     "line": 19,
                     "column": 10
                 }
             },
             "range": [
-                156,
+                191,
                 201
             ],
-            "raw": "+ Neither do these\n+ how are\n+ * *\nyou today?"
+            "raw": "you today?"
         },
         {
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -786,7 +830,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/html-simple.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/html-simple.text/output.json
@@ -101,6 +101,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<div>\n\tfoo\n</div>",
             "loc": {
                 "start": {
@@ -160,6 +161,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<div>foo</div>",
             "loc": {
                 "start": {
@@ -393,6 +395,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<!-- Comment -->",
             "loc": {
                 "start": {
@@ -510,6 +513,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<hr>",
             "loc": {
                 "start": {
@@ -517,15 +521,15 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 49,
-                    "column": 1
+                    "line": 48,
+                    "column": 5
                 }
             },
             "range": [
                 403,
-                410
+                408
             ],
-            "raw": "\t<hr>\n\t"
+            "raw": "\t<hr>"
         },
         {
             "type": "Paragraph",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/html-tags.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/html-tags.text/output.json
@@ -796,7 +796,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "</span  ",
+                    "value": "</span",
                     "loc": {
                         "start": {
                             "line": 95,
@@ -804,14 +804,14 @@
                         },
                         "end": {
                             "line": 95,
-                            "column": 8
+                            "column": 6
                         }
                     },
                     "range": [
                         408,
-                        416
+                        414
                     ],
-                    "raw": "</span  "
+                    "raw": "</span"
                 }
             ],
             "loc": {
@@ -952,7 +952,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "<span foo=bar ",
+                    "value": "<span foo=bar",
                     "loc": {
                         "start": {
                             "line": 107,
@@ -960,14 +960,14 @@
                         },
                         "end": {
                             "line": 107,
-                            "column": 14
+                            "column": 13
                         }
                     },
                     "range": [
                         466,
-                        480
+                        479
                     ],
-                    "raw": "<span foo=bar "
+                    "raw": "<span foo=bar"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/image-empty-alt.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/image-empty-alt.text/output.json
@@ -8,7 +8,7 @@
                     "type": "Image",
                     "title": null,
                     "url": "/xyz.png",
-                    "alt": null,
+                    "alt": "",
                     "loc": {
                         "start": {
                             "line": 1,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/issue-661-tab-indent-codeblock/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -52,13 +52,252 @@
                             "raw": "Below are the two types of parameters expected:"
                         },
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`",
+                            "type": "List",
+                            "ordered": false,
+                            "start": null,
+                            "spread": false,
+                            "children": [
+                                {
+                                    "type": "ListItem",
+                                    "spread": false,
+                                    "checked": null,
+                                    "children": [
+                                        {
+                                            "type": "Paragraph",
+                                            "children": [
+                                                {
+                                                    "type": "Str",
+                                                    "value": "Type ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 3
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 8
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        54,
+                                                        59
+                                                    ],
+                                                    "raw": "Type "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "String",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 8
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 16
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        59,
+                                                        67
+                                                    ],
+                                                    "raw": "`String`"
+                                                },
+                                                {
+                                                    "type": "Str",
+                                                    "value": " called ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 16
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 24
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        67,
+                                                        75
+                                                    ],
+                                                    "raw": " called "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "code",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 24
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 30
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        75,
+                                                        81
+                                                    ],
+                                                    "raw": "`code`"
+                                                }
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 3,
+                                                    "column": 3
+                                                },
+                                                "end": {
+                                                    "line": 3,
+                                                    "column": 30
+                                                }
+                                            },
+                                            "range": [
+                                                54,
+                                                81
+                                            ],
+                                            "raw": "Type `String` called `code`"
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 30
+                                        }
+                                    },
+                                    "range": [
+                                        52,
+                                        81
+                                    ],
+                                    "raw": "* Type `String` called `code`"
+                                },
+                                {
+                                    "type": "ListItem",
+                                    "spread": false,
+                                    "checked": null,
+                                    "children": [
+                                        {
+                                            "type": "Paragraph",
+                                            "children": [
+                                                {
+                                                    "type": "Str",
+                                                    "value": "Type ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 3
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 8
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        85,
+                                                        90
+                                                    ],
+                                                    "raw": "Type "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "boolean",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 8
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 17
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        90,
+                                                        99
+                                                    ],
+                                                    "raw": "`boolean`"
+                                                },
+                                                {
+                                                    "type": "Str",
+                                                    "value": " called ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 17
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 25
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        99,
+                                                        107
+                                                    ],
+                                                    "raw": " called "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "accepted",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 25
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 35
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        107,
+                                                        117
+                                                    ],
+                                                    "raw": "`accepted`"
+                                                }
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "column": 3
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "column": 35
+                                                }
+                                            },
+                                            "range": [
+                                                85,
+                                                117
+                                            ],
+                                            "raw": "Type `boolean` called `accepted`"
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 35
+                                        }
+                                    },
+                                    "range": [
+                                        83,
+                                        117
+                                    ],
+                                    "raw": "* Type `boolean` called `accepted`"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 0
+                                    "column": 1
                                 },
                                 "end": {
                                     "line": 4,
@@ -66,10 +305,10 @@
                                 }
                             },
                             "range": [
-                                51,
+                                52,
                                 117
                             ],
-                            "raw": "\t* Type `String` called `code`\n\t* Type `boolean` called `accepted`"
+                            "raw": "* Type `String` called `code`\n\t* Type `boolean` called `accepted`"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/lazy-blockquotes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/lazy-blockquotes.text/output.json
@@ -9,22 +9,22 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "hi there\nbud",
+                            "value": "hi there",
                             "loc": {
                                 "start": {
                                     "line": 1,
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 2,
-                                    "column": 3
+                                    "line": 1,
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 2,
-                                14
+                                10
                             ],
-                            "raw": "hi there\nbud"
+                            "raw": "hi there"
                         }
                     ],
                     "loc": {
@@ -33,15 +33,15 @@
                             "column": 2
                         },
                         "end": {
-                            "line": 2,
-                            "column": 3
+                            "line": 1,
+                            "column": 10
                         }
                     },
                     "range": [
                         2,
-                        14
+                        10
                     ],
-                    "raw": "hi there\nbud"
+                    "raw": "hi there"
                 }
             ],
             "loc": {
@@ -50,15 +50,54 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            },
+            "range": [
+                0,
+                10
+            ],
+            "raw": "> hi there"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "bud",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 3
+                        }
+                    },
+                    "range": [
+                        11,
+                        14
+                    ],
+                    "raw": "bud"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
                     "line": 2,
                     "column": 3
                 }
             },
             "range": [
-                0,
+                11,
                 14
             ],
-            "raw": "> hi there\nbud"
+            "raw": "bud"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/link-in-link.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/link-in-link.text/output.json
@@ -128,30 +128,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "An example",
-                    "url": "http://example.com",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "[](http://example.com \"An example\")",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 36
-                                }
-                            },
-                            "range": [
-                                131,
-                                166
-                            ],
-                            "raw": "[](http://example.com \"An example\")"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -159,14 +137,114 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 70
+                            "column": 1
                         }
                     },
                     "range": [
                         130,
+                        131
+                    ],
+                    "raw": "["
+                },
+                {
+                    "type": "Link",
+                    "title": "An example",
+                    "url": "http://example.com",
+                    "children": [],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 36
+                        }
+                    },
+                    "range": [
+                        131,
+                        166
+                    ],
+                    "raw": "[](http://example.com \"An example\")"
+                },
+                {
+                    "type": "Str",
+                    "value": "](",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 36
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 38
+                        }
+                    },
+                    "range": [
+                        166,
+                        168
+                    ],
+                    "raw": "]("
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "http://example.com",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "http://example.com",
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 38
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 56
+                                }
+                            },
+                            "range": [
+                                168,
+                                186
+                            ],
+                            "raw": "http://example.com"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 38
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 56
+                        }
+                    },
+                    "range": [
+                        168,
+                        186
+                    ],
+                    "raw": "http://example.com"
+                },
+                {
+                    "type": "Str",
+                    "value": " \"An example\")",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 56
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 70
+                        }
+                    },
+                    "range": [
+                        186,
                         200
                     ],
-                    "raw": "[[](http://example.com \"An example\")](http://example.com \"An example\")"
+                    "raw": " \"An example\")"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-inline-style.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-inline-style.text/output.json
@@ -424,30 +424,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "url and title",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "URL and title",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                220,
-                                233
-                            ],
-                            "raw": "URL and title"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[URL and title]( /url/has space ).",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -455,33 +433,14 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        219,
-                        234
-                    ],
-                    "raw": "[URL and title]"
-                },
-                {
-                    "type": "Str",
-                    "value": "( /url/has space ).",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 15
-                        },
-                        "end": {
-                            "line": 11,
                             "column": 34
                         }
                     },
                     "range": [
-                        234,
+                        219,
                         253
                     ],
-                    "raw": "( /url/has space )."
+                    "raw": "[URL and title]( /url/has space )."
                 }
             ],
             "loc": {
@@ -504,30 +463,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "url and title",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "URL and title",
-                            "loc": {
-                                "start": {
-                                    "line": 13,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 13,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                256,
-                                269
-                            ],
-                            "raw": "URL and title"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[URL and title]( /url/has space/ \"url has space and title\").",
                     "loc": {
                         "start": {
                             "line": 13,
@@ -535,33 +472,14 @@
                         },
                         "end": {
                             "line": 13,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        255,
-                        270
-                    ],
-                    "raw": "[URL and title]"
-                },
-                {
-                    "type": "Str",
-                    "value": "( /url/has space/ \"url has space and title\").",
-                    "loc": {
-                        "start": {
-                            "line": 13,
-                            "column": 15
-                        },
-                        "end": {
-                            "line": 13,
                             "column": 60
                         }
                     },
                     "range": [
-                        270,
+                        255,
                         315
                     ],
-                    "raw": "( /url/has space/ \"url has space and title\")."
+                    "raw": "[URL and title]( /url/has space/ \"url has space and title\")."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-reference-proto.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-reference-proto.text/output.json
@@ -25,8 +25,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "tostring",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -48,6 +46,9 @@
                             "raw": "primary"
                         }
                     ],
+                    "identifier": "tostring",
+                    "label": "toString",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -85,8 +86,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "constructor",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -108,6 +107,9 @@
                             "raw": "secondary"
                         }
                     ],
+                    "identifier": "constructor",
+                    "label": "constructor",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -145,8 +147,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "__proto__",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -168,6 +168,9 @@
                             "raw": "tertiary"
                         }
                     ],
+                    "identifier": "__proto__",
+                    "label": "__proto__",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -223,6 +226,7 @@
         {
             "type": "Definition",
             "identifier": "tostring",
+            "label": "toString",
             "title": null,
             "url": "http://primary.com",
             "loc": {
@@ -244,6 +248,7 @@
         {
             "type": "Definition",
             "identifier": "__proto__",
+            "label": "__proto__",
             "title": null,
             "url": "http://tertiary.com",
             "loc": {
@@ -265,6 +270,7 @@
         {
             "type": "Definition",
             "identifier": "constructor",
+            "label": "constructor",
             "title": null,
             "url": "http://secondary.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-reference-style.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-reference-style.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Foo ",
+                    "value": "Foo [bar] ",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,44 +14,45 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 4
+                            "column": 10
                         }
                     },
                     "range": [
                         0,
-                        4
+                        10
                     ],
-                    "raw": "Foo "
+                    "raw": "Foo [bar] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "bar",
+                            "value": "1",
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 5
+                                    "column": 11
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 8
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                5,
-                                8
+                                11,
+                                12
                             ],
-                            "raw": "bar"
+                            "raw": "1"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 4
+                            "column": 10
                         },
                         "end": {
                             "line": 1,
@@ -59,10 +60,10 @@
                         }
                     },
                     "range": [
-                        4,
+                        10,
                         13
                     ],
-                    "raw": "[bar] [1]"
+                    "raw": "[1]"
                 },
                 {
                     "type": "Str",
@@ -124,8 +125,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -147,6 +146,9 @@
                             "raw": "bar"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -204,52 +206,53 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Foo ",
+                    "value": "Foo [bar]\n",
                     "loc": {
                         "start": {
                             "line": 5,
                             "column": 0
                         },
                         "end": {
-                            "line": 5,
-                            "column": 4
+                            "line": 6,
+                            "column": 0
                         }
                     },
                     "range": [
                         31,
-                        35
+                        41
                     ],
-                    "raw": "Foo "
+                    "raw": "Foo [bar]\n"
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "bar",
+                            "value": "1",
                             "loc": {
                                 "start": {
-                                    "line": 5,
-                                    "column": 5
+                                    "line": 6,
+                                    "column": 1
                                 },
                                 "end": {
-                                    "line": 5,
-                                    "column": 8
+                                    "line": 6,
+                                    "column": 2
                                 }
                             },
                             "range": [
-                                36,
-                                39
+                                42,
+                                43
                             ],
-                            "raw": "bar"
+                            "raw": "1"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
-                            "line": 5,
-                            "column": 4
+                            "line": 6,
+                            "column": 0
                         },
                         "end": {
                             "line": 6,
@@ -257,10 +260,10 @@
                         }
                     },
                     "range": [
-                        35,
+                        41,
                         44
                     ],
-                    "raw": "[bar]\n[1]"
+                    "raw": "[1]"
                 },
                 {
                     "type": "Str",
@@ -301,6 +304,7 @@
         {
             "type": "Definition",
             "identifier": "1",
+            "label": "1",
             "title": "Title",
             "url": "/url/",
             "loc": {
@@ -324,7 +328,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "With ",
+                    "value": "With [embedded [brackets]] ",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -332,101 +336,45 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 5
+                            "column": 29
                         }
                     },
                     "range": [
                         69,
-                        74
+                        98
                     ],
-                    "raw": "With "
+                    "raw": "With [embedded \\[brackets\\]] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "b",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "embedded ",
+                            "value": "b",
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 6
+                                    "column": 30
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 15
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                75,
-                                84
+                                99,
+                                100
                             ],
-                            "raw": "embedded "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 15
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 17
-                                }
-                            },
-                            "range": [
-                                84,
-                                86
-                            ],
-                            "raw": "\\["
-                        },
-                        {
-                            "type": "Str",
-                            "value": "brackets",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 17
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 25
-                                }
-                            },
-                            "range": [
-                                86,
-                                94
-                            ],
-                            "raw": "brackets"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 25
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 27
-                                }
-                            },
-                            "range": [
-                                94,
-                                96
-                            ],
-                            "raw": "\\]"
+                            "raw": "b"
                         }
                     ],
+                    "identifier": "b",
+                    "label": "b",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 11,
-                            "column": 5
+                            "column": 29
                         },
                         "end": {
                             "line": 11,
@@ -434,10 +382,10 @@
                         }
                     },
                     "range": [
-                        74,
+                        98,
                         101
                     ],
-                    "raw": "[embedded \\[brackets\\]] [b]"
+                    "raw": "[b]"
                 },
                 {
                     "type": "Str",
@@ -499,8 +447,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "once",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -522,6 +468,9 @@
                             "raw": "once"
                         }
                     ],
+                    "identifier": "once",
+                    "label": "once",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 14,
@@ -598,8 +547,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "twice",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -621,6 +568,9 @@
                             "raw": "twice"
                         }
                     ],
+                    "identifier": "twice",
+                    "label": "twice",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -697,8 +647,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "thrice",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -720,6 +668,9 @@
                             "raw": "thrice"
                         }
                     ],
+                    "identifier": "thrice",
+                    "label": "thrice",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -777,7 +728,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Indented ",
+                    "value": "Indented [four][] times.",
                     "loc": {
                         "start": {
                             "line": 20,
@@ -785,74 +736,14 @@
                         },
                         "end": {
                             "line": 20,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        168,
-                        177
-                    ],
-                    "raw": "Indented "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "four",
-                    "referenceType": "collapsed",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "four",
-                            "loc": {
-                                "start": {
-                                    "line": 20,
-                                    "column": 10
-                                },
-                                "end": {
-                                    "line": 20,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                178,
-                                182
-                            ],
-                            "raw": "four"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 20,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 20,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        177,
-                        185
-                    ],
-                    "raw": "[four][]"
-                },
-                {
-                    "type": "Str",
-                    "value": " times.",
-                    "loc": {
-                        "start": {
-                            "line": 20,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 20,
                             "column": 24
                         }
                     },
                     "range": [
-                        185,
+                        168,
                         192
                     ],
-                    "raw": " times."
+                    "raw": "Indented [four][] times."
                 }
             ],
             "loc": {
@@ -874,12 +765,13 @@
         {
             "type": "Definition",
             "identifier": "once",
+            "label": "once",
             "title": null,
             "url": "/url",
             "loc": {
                 "start": {
                     "line": 22,
-                    "column": 0
+                    "column": 1
                 },
                 "end": {
                     "line": 22,
@@ -887,20 +779,21 @@
                 }
             },
             "range": [
-                194,
+                195,
                 207
             ],
-            "raw": " [once]: /url"
+            "raw": "[once]: /url"
         },
         {
             "type": "Definition",
             "identifier": "twice",
+            "label": "twice",
             "title": null,
             "url": "/url",
             "loc": {
                 "start": {
                     "line": 24,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 24,
@@ -908,20 +801,21 @@
                 }
             },
             "range": [
-                209,
+                211,
                 224
             ],
-            "raw": "  [twice]: /url"
+            "raw": "[twice]: /url"
         },
         {
             "type": "Definition",
             "identifier": "thrice",
+            "label": "thrice",
             "title": null,
             "url": "/url",
             "loc": {
                 "start": {
                     "line": 26,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 26,
@@ -929,14 +823,15 @@
                 }
             },
             "range": [
-                226,
+                229,
                 243
             ],
-            "raw": "   [thrice]: /url"
+            "raw": "[thrice]: /url"
         },
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[four]: /url",
             "loc": {
                 "start": {
@@ -957,6 +852,7 @@
         {
             "type": "Definition",
             "identifier": "b",
+            "label": "b",
             "title": null,
             "url": "/url/",
             "loc": {
@@ -998,8 +894,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -1021,6 +915,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 35,
@@ -1028,14 +925,75 @@
                         },
                         "end": {
                             "line": 35,
-                            "column": 13
+                            "column": 6
                         }
                     },
                     "range": [
                         283,
+                        289
+                    ],
+                    "raw": "[this]"
+                },
+                {
+                    "type": "Str",
+                    "value": " ",
+                    "loc": {
+                        "start": {
+                            "line": 35,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 35,
+                            "column": 7
+                        }
+                    },
+                    "range": [
+                        289,
+                        290
+                    ],
+                    "raw": " "
+                },
+                {
+                    "type": "LinkReference",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "this",
+                            "loc": {
+                                "start": {
+                                    "line": 35,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 35,
+                                    "column": 12
+                                }
+                            },
+                            "range": [
+                                291,
+                                295
+                            ],
+                            "raw": "this"
+                        }
+                    ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
+                    "loc": {
+                        "start": {
+                            "line": 35,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 35,
+                            "column": 13
+                        }
+                    },
+                    "range": [
+                        290,
                         296
                     ],
-                    "raw": "[this] [this]"
+                    "raw": "[this]"
                 },
                 {
                     "type": "Str",
@@ -1097,8 +1055,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -1120,6 +1076,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 37,
@@ -1196,8 +1155,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -1219,6 +1176,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 39,
@@ -1226,22 +1186,22 @@
                         },
                         "end": {
                             "line": 39,
-                            "column": 13
+                            "column": 10
                         }
                     },
                     "range": [
                         339,
-                        348
+                        345
                     ],
-                    "raw": "[this] []"
+                    "raw": "[this]"
                 },
                 {
                     "type": "Str",
-                    "value": ".",
+                    "value": " [].",
                     "loc": {
                         "start": {
                             "line": 39,
-                            "column": 13
+                            "column": 10
                         },
                         "end": {
                             "line": 39,
@@ -1249,10 +1209,10 @@
                         }
                     },
                     "range": [
-                        348,
+                        345,
                         349
                     ],
-                    "raw": "."
+                    "raw": " []."
                 }
             ],
             "loc": {
@@ -1295,8 +1255,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -1318,6 +1276,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 41,
@@ -1394,8 +1355,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -1417,6 +1376,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 43,
@@ -1474,7 +1436,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "But not ",
+                    "value": "But not [that] [].",
                     "loc": {
                         "start": {
                             "line": 45,
@@ -1482,74 +1444,14 @@
                         },
                         "end": {
                             "line": 45,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        379,
-                        387
-                    ],
-                    "raw": "But not "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "that",
-                    "referenceType": "collapsed",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "that",
-                            "loc": {
-                                "start": {
-                                    "line": 45,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 45,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                388,
-                                392
-                            ],
-                            "raw": "that"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 45,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 45,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        387,
-                        396
-                    ],
-                    "raw": "[that] []"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 45,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 45,
                             "column": 18
                         }
                     },
                     "range": [
-                        396,
+                        379,
                         397
                     ],
-                    "raw": "."
+                    "raw": "But not [that] []."
                 }
             ],
             "loc": {
@@ -1573,7 +1475,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Nor ",
+                    "value": "Nor [that][].",
                     "loc": {
                         "start": {
                             "line": 47,
@@ -1581,74 +1483,14 @@
                         },
                         "end": {
                             "line": 47,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        399,
-                        403
-                    ],
-                    "raw": "Nor "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "that",
-                    "referenceType": "collapsed",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "that",
-                            "loc": {
-                                "start": {
-                                    "line": 47,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 47,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                404,
-                                408
-                            ],
-                            "raw": "that"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 47,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 47,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        403,
-                        411
-                    ],
-                    "raw": "[that][]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 47,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 47,
                             "column": 13
                         }
                     },
                     "range": [
-                        411,
+                        399,
                         412
                     ],
-                    "raw": "."
+                    "raw": "Nor [that][]."
                 }
             ],
             "loc": {
@@ -1672,7 +1514,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Nor ",
+                    "value": "Nor [that].",
                     "loc": {
                         "start": {
                             "line": 49,
@@ -1680,74 +1522,14 @@
                         },
                         "end": {
                             "line": 49,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        414,
-                        418
-                    ],
-                    "raw": "Nor "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "that",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "that",
-                            "loc": {
-                                "start": {
-                                    "line": 49,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 49,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                419,
-                                423
-                            ],
-                            "raw": "that"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 49,
-                            "column": 4
-                        },
-                        "end": {
-                            "line": 49,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        418,
-                        424
-                    ],
-                    "raw": "[that]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 49,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 49,
                             "column": 11
                         }
                     },
                     "range": [
-                        424,
+                        414,
                         425
                     ],
-                    "raw": "."
+                    "raw": "Nor [that]."
                 }
             ],
             "loc": {
@@ -1790,8 +1572,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
@@ -1813,6 +1593,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -1889,8 +1672,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "this",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -1912,6 +1693,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 53,
@@ -2068,7 +1852,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Backslashing should suppress ",
+                    "value": "Backslashing should suppress [this] and [this].",
                     "loc": {
                         "start": {
                             "line": 57,
@@ -2076,90 +1860,14 @@
                         },
                         "end": {
                             "line": 57,
-                            "column": 29
-                        }
-                    },
-                    "range": [
-                        564,
-                        593
-                    ],
-                    "raw": "Backslashing should suppress "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 57,
-                            "column": 29
-                        },
-                        "end": {
-                            "line": 57,
-                            "column": 31
-                        }
-                    },
-                    "range": [
-                        593,
-                        595
-                    ],
-                    "raw": "\\["
-                },
-                {
-                    "type": "Str",
-                    "value": "this] and [this",
-                    "loc": {
-                        "start": {
-                            "line": 57,
-                            "column": 31
-                        },
-                        "end": {
-                            "line": 57,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        595,
-                        610
-                    ],
-                    "raw": "this] and [this"
-                },
-                {
-                    "type": "Str",
-                    "value": "]",
-                    "loc": {
-                        "start": {
-                            "line": 57,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 57,
-                            "column": 48
-                        }
-                    },
-                    "range": [
-                        610,
-                        612
-                    ],
-                    "raw": "\\]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 57,
-                            "column": 48
-                        },
-                        "end": {
-                            "line": 57,
                             "column": 49
                         }
                     },
                     "range": [
-                        612,
+                        564,
                         613
                     ],
-                    "raw": "."
+                    "raw": "Backslashing should suppress \\[this] and [this\\]."
                 }
             ],
             "loc": {
@@ -2181,6 +1889,7 @@
         {
             "type": "Definition",
             "identifier": "this",
+            "label": "this",
             "title": null,
             "url": "foo",
             "loc": {
@@ -2241,8 +1950,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "link breaks",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -2264,6 +1971,9 @@
                             "raw": "link\nbreaks"
                         }
                     ],
+                    "identifier": "link breaks",
+                    "label": "link\nbreaks",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 64,
@@ -2340,12 +2050,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "link breaks",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "link \nbreaks",
+                            "value": "link\nbreaks",
                             "loc": {
                                 "start": {
                                     "line": 67,
@@ -2363,6 +2071,9 @@
                             "raw": "link \nbreaks"
                         }
                     ],
+                    "identifier": "link breaks",
+                    "label": "link\nbreaks",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 67,
@@ -2418,6 +2129,7 @@
         {
             "type": "Definition",
             "identifier": "link breaks",
+            "label": "link breaks",
             "title": null,
             "url": "/url/",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-shortcut-references.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-shortcut-references.text/output.json
@@ -25,8 +25,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "simple case",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -48,6 +46,9 @@
                             "raw": "simple case"
                         }
                     ],
+                    "identifier": "simple case",
+                    "label": "simple case",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -103,6 +104,7 @@
         {
             "type": "Definition",
             "identifier": "simple case",
+            "label": "simple case",
             "title": null,
             "url": "/simple",
             "loc": {
@@ -145,8 +147,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "line break",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -168,6 +168,9 @@
                             "raw": "line\nbreak"
                         }
                     ],
+                    "identifier": "line break",
+                    "label": "line\nbreak",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -244,12 +247,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "line break",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "line \nbreak",
+                            "value": "line\nbreak",
                             "loc": {
                                 "start": {
                                     "line": 10,
@@ -267,6 +268,9 @@
                             "raw": "line \nbreak"
                         }
                     ],
+                    "identifier": "line break",
+                    "label": "line\nbreak",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 10,
@@ -322,6 +326,7 @@
         {
             "type": "Definition",
             "identifier": "line break",
+            "label": "line break",
             "title": null,
             "url": "/foo",
             "loc": {
@@ -345,8 +350,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "that",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -368,6 +371,9 @@
                             "raw": "this"
                         }
                     ],
+                    "identifier": "this",
+                    "label": "this",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -375,14 +381,75 @@
                         },
                         "end": {
                             "line": 16,
-                            "column": 13
+                            "column": 6
                         }
                     },
                     "range": [
                         161,
+                        167
+                    ],
+                    "raw": "[this]"
+                },
+                {
+                    "type": "Str",
+                    "value": " ",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 6
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 7
+                        }
+                    },
+                    "range": [
+                        167,
+                        168
+                    ],
+                    "raw": " "
+                },
+                {
+                    "type": "LinkReference",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "that",
+                            "loc": {
+                                "start": {
+                                    "line": 16,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 12
+                                }
+                            },
+                            "range": [
+                                169,
+                                173
+                            ],
+                            "raw": "that"
+                        }
+                    ],
+                    "identifier": "that",
+                    "label": "that",
+                    "referenceType": "shortcut",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 13
+                        }
+                    },
+                    "range": [
+                        168,
                         174
                     ],
-                    "raw": "[this] [that]"
+                    "raw": "[that]"
                 },
                 {
                     "type": "Str",
@@ -405,8 +472,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "other",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -428,6 +493,9 @@
                             "raw": "other"
                         }
                     ],
+                    "identifier": "other",
+                    "label": "other",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -464,6 +532,7 @@
         {
             "type": "Definition",
             "identifier": "this",
+            "label": "this",
             "title": null,
             "url": "/this",
             "loc": {
@@ -485,6 +554,7 @@
         {
             "type": "Definition",
             "identifier": "that",
+            "label": "that",
             "title": null,
             "url": "/that",
             "loc": {
@@ -506,6 +576,7 @@
         {
             "type": "Definition",
             "identifier": "other",
+            "label": "other",
             "title": null,
             "url": "/other",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-text-empty.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-text-empty.text/output.json
@@ -128,7 +128,7 @@
                     "type": "Image",
                     "title": null,
                     "url": "./hello-world.html",
-                    "alt": null,
+                    "alt": "",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -188,7 +188,7 @@
                     "type": "Image",
                     "title": null,
                     "url": "./hello-world.html",
-                    "alt": null,
+                    "alt": "",
                     "loc": {
                         "start": {
                             "line": 7,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-text-entity-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-text-entity-delimiters.text/output.json
@@ -11,7 +11,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -19,90 +19,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                1,
-                                7
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                7,
-                                13
-                            ],
-                            "raw": "&lsqb;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 13
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 18
-                                }
-                            },
-                            "range": [
-                                13,
-                                18
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 24
-                                }
-                            },
-                            "range": [
-                                18,
-                                24
-                            ],
-                            "raw": "&rsqb;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 24
-                                },
-                                "end": {
-                                    "line": 1,
                                     "column": 25
                                 }
                             },
                             "range": [
-                                24,
+                                1,
                                 25
                             ],
-                            "raw": "!"
+                            "raw": "Hello &lsqb;world&rsqb;!"
                         }
                     ],
                     "loc": {
@@ -167,7 +91,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 3,
@@ -175,90 +99,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                50,
-                                56
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                56,
-                                62
-                            ],
-                            "raw": "&lsqb;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 13
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 18
-                                }
-                            },
-                            "range": [
-                                62,
-                                67
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 24
-                                }
-                            },
-                            "range": [
-                                67,
-                                73
-                            ],
-                            "raw": "&rsqb;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 24
-                                },
-                                "end": {
-                                    "line": 3,
                                     "column": 25
                                 }
                             },
                             "range": [
-                                73,
+                                50,
                                 74
                             ],
-                            "raw": "!"
+                            "raw": "Hello &lsqb;world&rsqb;!"
                         }
                     ],
                     "loc": {
@@ -443,7 +291,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 9,
@@ -451,90 +299,14 @@
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                203,
-                                209
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                209,
-                                215
-                            ],
-                            "raw": "&#x5B;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 13
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 18
-                                }
-                            },
-                            "range": [
-                                215,
-                                220
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 24
-                                }
-                            },
-                            "range": [
-                                220,
-                                226
-                            ],
-                            "raw": "&#x5D;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 24
-                                },
-                                "end": {
-                                    "line": 9,
                                     "column": 25
                                 }
                             },
                             "range": [
-                                226,
+                                203,
                                 227
                             ],
-                            "raw": "!"
+                            "raw": "Hello &#x5B;world&#x5D;!"
                         }
                     ],
                     "loc": {
@@ -599,7 +371,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 11,
@@ -607,90 +379,14 @@
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                252,
-                                258
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                258,
-                                264
-                            ],
-                            "raw": "&#x5B;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 13
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 18
-                                }
-                            },
-                            "range": [
-                                264,
-                                269
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 18
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 24
-                                }
-                            },
-                            "range": [
-                                269,
-                                275
-                            ],
-                            "raw": "&#x5D;"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 24
-                                },
-                                "end": {
-                                    "line": 11,
                                     "column": 25
                                 }
                             },
                             "range": [
-                                275,
+                                252,
                                 276
                             ],
-                            "raw": "!"
+                            "raw": "Hello &#x5B;world&#x5D;!"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-text-escaped-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-text-escaped-delimiters.text/output.json
@@ -11,7 +11,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -19,90 +19,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                1,
-                                7
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                7,
-                                9
-                            ],
-                            "raw": "\\["
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                9,
-                                14
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 14
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 16
-                                }
-                            },
-                            "range": [
-                                14,
-                                16
-                            ],
-                            "raw": "\\]"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 1,
                                     "column": 17
                                 }
                             },
                             "range": [
-                                16,
+                                1,
                                 17
                             ],
-                            "raw": "!"
+                            "raw": "Hello \\[world\\]!"
                         }
                     ],
                     "loc": {
@@ -167,7 +91,7 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Hello ",
+                            "value": "Hello [world]!",
                             "loc": {
                                 "start": {
                                     "line": 3,
@@ -175,90 +99,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                42,
-                                48
-                            ],
-                            "raw": "Hello "
-                        },
-                        {
-                            "type": "Str",
-                            "value": "[",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 9
-                                }
-                            },
-                            "range": [
-                                48,
-                                50
-                            ],
-                            "raw": "\\["
-                        },
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                50,
-                                55
-                            ],
-                            "raw": "world"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "]",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 14
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 16
-                                }
-                            },
-                            "range": [
-                                55,
-                                57
-                            ],
-                            "raw": "\\]"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "!",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 16
-                                },
-                                "end": {
-                                    "line": 3,
                                     "column": 17
                                 }
                             },
                             "range": [
-                                57,
+                                42,
                                 58
                             ],
-                            "raw": "!"
+                            "raw": "Hello \\[world\\]!"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-delimiters.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello \"World\" Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html \"Hello \"World\" Hello!\").",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 44
-                        }
-                    },
-                    "range": [
-                        0,
-                        44
-                    ],
-                    "raw": "[Hello](./world.html \"Hello \"World\" Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 44
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 45
                         }
                     },
                     "range": [
-                        44,
+                        0,
                         45
                     ],
-                    "raw": "."
+                    "raw": "[Hello](./world.html \"Hello \"World\" Hello!\")."
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello \"World\" Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                48,
-                                53
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> \"Hello \"World\" Hello!\").",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        47,
-                        93
-                    ],
-                    "raw": "[Hello](<./world.html> \"Hello \"World\" Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 47
                         }
                     },
                     "range": [
-                        93,
+                        47,
                         94
                     ],
-                    "raw": "."
+                    "raw": "[Hello](<./world.html> \"Hello \"World\" Hello!\")."
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello \"World\" Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html \"Hello \"World\" Hello!\").",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 45
-                        }
-                    },
-                    "range": [
-                        96,
-                        141
-                    ],
-                    "raw": "![Hello](./world.html \"Hello \"World\" Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 45
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 46
                         }
                     },
                     "range": [
-                        141,
+                        96,
                         142
                     ],
-                    "raw": "."
+                    "raw": "![Hello](./world.html \"Hello \"World\" Hello!\")."
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello \"World\" Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> \"Hello \"World\" Hello!\").",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 47
-                        }
-                    },
-                    "range": [
-                        144,
-                        191
-                    ],
-                    "raw": "![Hello](<./world.html> \"Hello \"World\" Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 47
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 48
                         }
                     },
                     "range": [
-                        191,
+                        144,
                         192
                     ],
-                    "raw": "."
+                    "raw": "![Hello](<./world.html> \"Hello \"World\" Hello!\")."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-escaped-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-escaped-delimiters.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "Hello \\\"World\\\" Hello!",
+                    "title": "Hello \"World\" Hello!",
                     "url": "./world.html",
                     "children": [
                         {
@@ -86,7 +86,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "Hello \\\"World\\\" Hello!",
+                    "title": "Hello \"World\" Hello!",
                     "url": "./world.html",
                     "children": [
                         {
@@ -166,7 +166,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "Hello \\\"World\\\" Hello!",
+                    "title": "Hello \"World\" Hello!",
                     "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
@@ -226,7 +226,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "Hello \\\"World\\\" Hello!",
+                    "title": "Hello \"World\" Hello!",
                     "url": "./world.html",
                     "alt": "Hello",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-mismatched-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-double-quotes-mismatched-delimiters.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello \"World Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html \"Hello \"World Hello!\").",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 43
-                        }
-                    },
-                    "range": [
-                        0,
-                        43
-                    ],
-                    "raw": "[Hello](./world.html \"Hello \"World Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 43
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 44
                         }
                     },
                     "range": [
-                        43,
+                        0,
                         44
                     ],
-                    "raw": "."
+                    "raw": "[Hello](./world.html \"Hello \"World Hello!\")."
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello \"World Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                47,
-                                52
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> \"Hello \"World Hello!\").",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 45
-                        }
-                    },
-                    "range": [
-                        46,
-                        91
-                    ],
-                    "raw": "[Hello](<./world.html> \"Hello \"World Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 45
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 46
                         }
                     },
                     "range": [
-                        91,
+                        46,
                         92
                     ],
-                    "raw": "."
+                    "raw": "[Hello](<./world.html> \"Hello \"World Hello!\")."
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello \"World Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html \"Hello \"World Hello!\").",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 44
-                        }
-                    },
-                    "range": [
-                        94,
-                        138
-                    ],
-                    "raw": "![Hello](./world.html \"Hello \"World Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 44
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 45
                         }
                     },
                     "range": [
-                        138,
+                        94,
                         139
                     ],
-                    "raw": "."
+                    "raw": "![Hello](./world.html \"Hello \"World Hello!\")."
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello \"World Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> \"Hello \"World Hello!\").",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        141,
-                        187
-                    ],
-                    "raw": "![Hello](<./world.html> \"Hello \"World Hello!\")"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 47
                         }
                     },
                     "range": [
-                        187,
+                        141,
                         188
                     ],
-                    "raw": "."
+                    "raw": "![Hello](<./world.html> \"Hello \"World Hello!\")."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-empty-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-empty-parentheses.text/output.json
@@ -5,9 +5,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": null,
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -36,22 +36,22 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
+                            "column": 24
                         }
                     },
                     "range": [
                         0,
-                        7
+                        24
                     ],
-                    "raw": "[Hello]"
+                    "raw": "[Hello](./world.html ())"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.html ()).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 7
+                            "column": 24
                         },
                         "end": {
                             "line": 1,
@@ -59,10 +59,10 @@
                         }
                     },
                     "range": [
-                        7,
+                        24,
                         25
                     ],
-                    "raw": "(./world.html ())."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -85,9 +85,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": null,
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -116,22 +116,22 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 7
+                            "column": 26
                         }
                     },
                     "range": [
                         27,
-                        34
+                        53
                     ],
-                    "raw": "[Hello]"
+                    "raw": "[Hello](<./world.html> ())"
                 },
                 {
                     "type": "Str",
-                    "value": "(<./world.html> ()).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 7
+                            "column": 26
                         },
                         "end": {
                             "line": 3,
@@ -139,10 +139,10 @@
                         }
                     },
                     "range": [
-                        34,
+                        53,
                         54
                     ],
-                    "raw": "(<./world.html> ())."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -165,9 +165,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": null,
+                    "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -176,22 +176,22 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 8
+                            "column": 25
                         }
                     },
                     "range": [
                         56,
-                        64
+                        81
                     ],
-                    "raw": "![Hello]"
+                    "raw": "![Hello](./world.html ())"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.html ()).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 8
+                            "column": 25
                         },
                         "end": {
                             "line": 5,
@@ -199,10 +199,10 @@
                         }
                     },
                     "range": [
-                        64,
+                        81,
                         82
                     ],
-                    "raw": "(./world.html ())."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -225,9 +225,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": null,
+                    "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -236,22 +236,22 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 8
+                            "column": 27
                         }
                     },
                     "range": [
                         84,
-                        92
+                        111
                     ],
-                    "raw": "![Hello]"
+                    "raw": "![Hello](<./world.html> ())"
                 },
                 {
                     "type": "Str",
-                    "value": "(<./world.html> ()).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 8
+                            "column": 27
                         },
                         "end": {
                             "line": 7,
@@ -259,10 +259,10 @@
                         }
                     },
                     "range": [
-                        92,
+                        111,
                         112
                     ],
-                    "raw": "(<./world.html> ())."
+                    "raw": "."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-parentheses.text/output.json
@@ -5,9 +5,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "Hello World!",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -36,22 +36,22 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
+                            "column": 36
                         }
                     },
                     "range": [
                         0,
-                        7
+                        36
                     ],
-                    "raw": "[Hello]"
+                    "raw": "[Hello](./world.html (Hello World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.html (Hello World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 7
+                            "column": 36
                         },
                         "end": {
                             "line": 1,
@@ -59,10 +59,10 @@
                         }
                     },
                     "range": [
-                        7,
+                        36,
                         37
                     ],
-                    "raw": "(./world.html (Hello World!))."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -85,9 +85,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "Hello World!",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -116,22 +116,22 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 7
+                            "column": 38
                         }
                     },
                     "range": [
                         39,
-                        46
+                        77
                     ],
-                    "raw": "[Hello]"
+                    "raw": "[Hello](<./world.html> (Hello World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(<./world.html> (Hello World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 3,
-                            "column": 7
+                            "column": 38
                         },
                         "end": {
                             "line": 3,
@@ -139,10 +139,10 @@
                         }
                     },
                     "range": [
-                        46,
+                        77,
                         78
                     ],
-                    "raw": "(<./world.html> (Hello World!))."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -165,9 +165,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "Hello World!",
+                    "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -176,22 +176,22 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 8
+                            "column": 37
                         }
                     },
                     "range": [
                         80,
-                        88
+                        117
                     ],
-                    "raw": "![Hello]"
+                    "raw": "![Hello](./world.html (Hello World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.html (Hello World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 8
+                            "column": 37
                         },
                         "end": {
                             "line": 5,
@@ -199,10 +199,10 @@
                         }
                     },
                     "range": [
-                        88,
+                        117,
                         118
                     ],
-                    "raw": "(./world.html (Hello World!))."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -225,9 +225,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "Hello World!",
+                    "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -236,22 +236,22 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 8
+                            "column": 39
                         }
                     },
                     "range": [
                         120,
-                        128
+                        159
                     ],
-                    "raw": "![Hello]"
+                    "raw": "![Hello](<./world.html> (Hello World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(<./world.html> (Hello World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 8
+                            "column": 39
                         },
                         "end": {
                             "line": 7,
@@ -259,10 +259,10 @@
                         }
                     },
                     "range": [
-                        128,
+                        159,
                         160
                     ],
-                    "raw": "(<./world.html> (Hello World!))."
+                    "raw": "."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-delimiters.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello 'World' Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html 'Hello 'World' Hello!').",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 44
-                        }
-                    },
-                    "range": [
-                        0,
-                        44
-                    ],
-                    "raw": "[Hello](./world.html 'Hello 'World' Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 44
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 45
                         }
                     },
                     "range": [
-                        44,
+                        0,
                         45
                     ],
-                    "raw": "."
+                    "raw": "[Hello](./world.html 'Hello 'World' Hello!')."
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello 'World' Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                48,
-                                53
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> 'Hello 'World' Hello!').",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        47,
-                        93
-                    ],
-                    "raw": "[Hello](<./world.html> 'Hello 'World' Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 47
                         }
                     },
                     "range": [
-                        93,
+                        47,
                         94
                     ],
-                    "raw": "."
+                    "raw": "[Hello](<./world.html> 'Hello 'World' Hello!')."
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello 'World' Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html 'Hello 'World' Hello!').",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 45
-                        }
-                    },
-                    "range": [
-                        96,
-                        141
-                    ],
-                    "raw": "![Hello](./world.html 'Hello 'World' Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 45
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 46
                         }
                     },
                     "range": [
-                        141,
+                        96,
                         142
                     ],
-                    "raw": "."
+                    "raw": "![Hello](./world.html 'Hello 'World' Hello!')."
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello 'World' Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> 'Hello 'World' Hello!').",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 47
-                        }
-                    },
-                    "range": [
-                        144,
-                        191
-                    ],
-                    "raw": "![Hello](<./world.html> 'Hello 'World' Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 47
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 48
                         }
                     },
                     "range": [
-                        191,
+                        144,
                         192
                     ],
-                    "raw": "."
+                    "raw": "![Hello](<./world.html> 'Hello 'World' Hello!')."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-escaped-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-escaped-delimiters.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "Hello \\'World\\' Hello!",
+                    "title": "Hello 'World' Hello!",
                     "url": "./world.html",
                     "children": [
                         {
@@ -86,7 +86,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "Hello \\'World\\' Hello!",
+                    "title": "Hello 'World' Hello!",
                     "url": "./world.html",
                     "children": [
                         {
@@ -166,7 +166,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "Hello \\'World\\' Hello!",
+                    "title": "Hello 'World' Hello!",
                     "url": "./world.html",
                     "alt": "Hello",
                     "loc": {
@@ -226,7 +226,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "Hello \\'World\\' Hello!",
+                    "title": "Hello 'World' Hello!",
                     "url": "./world.html",
                     "alt": "Hello",
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-mismatched-delimiters.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-single-quotes-mismatched-delimiters.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello 'World Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html 'Hello 'World Hello!').",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 43
-                        }
-                    },
-                    "range": [
-                        0,
-                        43
-                    ],
-                    "raw": "[Hello](./world.html 'Hello 'World Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 43
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 44
                         }
                     },
                     "range": [
-                        43,
+                        0,
                         44
                     ],
-                    "raw": "."
+                    "raw": "[Hello](./world.html 'Hello 'World Hello!')."
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "Hello 'World Hello!",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                47,
-                                52
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> 'Hello 'World Hello!').",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 45
-                        }
-                    },
-                    "range": [
-                        46,
-                        91
-                    ],
-                    "raw": "[Hello](<./world.html> 'Hello 'World Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 45
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 46
                         }
                     },
                     "range": [
-                        91,
+                        46,
                         92
                     ],
-                    "raw": "."
+                    "raw": "[Hello](<./world.html> 'Hello 'World Hello!')."
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello 'World Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html 'Hello 'World Hello!').",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 44
-                        }
-                    },
-                    "range": [
-                        94,
-                        138
-                    ],
-                    "raw": "![Hello](./world.html 'Hello 'World Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 44
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 45
                         }
                     },
                     "range": [
-                        138,
+                        94,
                         139
                     ],
-                    "raw": "."
+                    "raw": "![Hello](./world.html 'Hello 'World Hello!')."
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "Hello 'World Hello!",
-                    "url": "./world.html",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> 'Hello 'World Hello!').",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        141,
-                        187
-                    ],
-                    "raw": "![Hello](<./world.html> 'Hello 'World Hello!')"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 47
                         }
                     },
                     "range": [
-                        187,
+                        141,
                         188
                     ],
-                    "raw": "."
+                    "raw": "![Hello](<./world.html> 'Hello 'World Hello!')."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-title-unclosed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-title-unclosed.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html 'Hello",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html 'Hello",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 27
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         27
                     ],
-                    "raw": "(./world.html 'Hello"
+                    "raw": "[Hello](./world.html 'Hello"
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                30,
-                                35
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> 'Hello",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        29,
-                        36
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> 'Hello",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 29
                         }
                     },
                     "range": [
-                        36,
+                        29,
                         58
                     ],
-                    "raw": "(<./world.html> 'Hello"
+                    "raw": "[Hello](<./world.html> 'Hello"
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html 'Hello",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        60,
-                        68
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html 'Hello",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 28
                         }
                     },
                     "range": [
-                        68,
+                        60,
                         88
                     ],
-                    "raw": "(./world.html 'Hello"
+                    "raw": "![Hello](./world.html 'Hello"
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> 'Hello",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        90,
-                        98
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> 'Hello",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 30
                         }
                     },
                     "range": [
-                        98,
+                        90,
                         120
                     ],
-                    "raw": "(<./world.html> 'Hello"
+                    "raw": "![Hello](<./world.html> 'Hello"
                 }
             ],
             "loc": {
@@ -285,30 +161,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 9,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 9,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                123,
-                                128
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html \"Hello",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -316,33 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        122,
-                        129
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html \"Hello",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 27
                         }
                     },
                     "range": [
-                        129,
+                        122,
                         149
                     ],
-                    "raw": "(./world.html \"Hello"
+                    "raw": "[Hello](./world.html \"Hello"
                 }
             ],
             "loc": {
@@ -365,30 +200,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                152,
-                                157
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> \"Hello",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -396,33 +209,14 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        151,
-                        158
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> \"Hello",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 11,
                             "column": 29
                         }
                     },
                     "range": [
-                        158,
+                        151,
                         180
                     ],
-                    "raw": "(<./world.html> \"Hello"
+                    "raw": "[Hello](<./world.html> \"Hello"
                 }
             ],
             "loc": {
@@ -445,10 +239,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html \"Hello",
                     "loc": {
                         "start": {
                             "line": 13,
@@ -456,33 +248,14 @@
                         },
                         "end": {
                             "line": 13,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        182,
-                        190
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html \"Hello",
-                    "loc": {
-                        "start": {
-                            "line": 13,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 13,
                             "column": 28
                         }
                     },
                     "range": [
-                        190,
+                        182,
                         210
                     ],
-                    "raw": "(./world.html \"Hello"
+                    "raw": "![Hello](./world.html \"Hello"
                 }
             ],
             "loc": {
@@ -505,10 +278,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> \"Hello",
                     "loc": {
                         "start": {
                             "line": 15,
@@ -516,33 +287,14 @@
                         },
                         "end": {
                             "line": 15,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        212,
-                        220
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> \"Hello",
-                    "loc": {
-                        "start": {
-                            "line": 15,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 15,
                             "column": 30
                         }
                     },
                     "range": [
-                        220,
+                        212,
                         242
                     ],
-                    "raw": "(<./world.html> \"Hello"
+                    "raw": "![Hello](<./world.html> \"Hello"
                 }
             ],
             "loc": {
@@ -565,30 +317,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 17,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 17,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                245,
-                                250
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html (Hello",
                     "loc": {
                         "start": {
                             "line": 17,
@@ -596,33 +326,14 @@
                         },
                         "end": {
                             "line": 17,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        244,
-                        251
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (Hello",
-                    "loc": {
-                        "start": {
-                            "line": 17,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 17,
                             "column": 27
                         }
                     },
                     "range": [
-                        251,
+                        244,
                         271
                     ],
-                    "raw": "(./world.html (Hello"
+                    "raw": "[Hello](./world.html (Hello"
                 }
             ],
             "loc": {
@@ -645,30 +356,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                274,
-                                279
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./world.html> (Hello",
                     "loc": {
                         "start": {
                             "line": 19,
@@ -676,33 +365,14 @@
                         },
                         "end": {
                             "line": 19,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        273,
-                        280
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> (Hello",
-                    "loc": {
-                        "start": {
-                            "line": 19,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 19,
                             "column": 29
                         }
                     },
                     "range": [
-                        280,
+                        273,
                         302
                     ],
-                    "raw": "(<./world.html> (Hello"
+                    "raw": "[Hello](<./world.html> (Hello"
                 }
             ],
             "loc": {
@@ -725,10 +395,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.html (Hello",
                     "loc": {
                         "start": {
                             "line": 21,
@@ -736,33 +404,14 @@
                         },
                         "end": {
                             "line": 21,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        304,
-                        312
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (Hello",
-                    "loc": {
-                        "start": {
-                            "line": 21,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 21,
                             "column": 28
                         }
                     },
                     "range": [
-                        312,
+                        304,
                         332
                     ],
-                    "raw": "(./world.html (Hello"
+                    "raw": "![Hello](./world.html (Hello"
                 }
             ],
             "loc": {
@@ -785,10 +434,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./world.html> (Hello",
                     "loc": {
                         "start": {
                             "line": 23,
@@ -796,33 +443,14 @@
                         },
                         "end": {
                             "line": 23,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        334,
-                        342
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<./world.html> (Hello",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 23,
                             "column": 30
                         }
                     },
                     "range": [
-                        342,
+                        334,
                         364
                     ],
-                    "raw": "(<./world.html> (Hello"
+                    "raw": "![Hello](<./world.html> (Hello"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-empty-title-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-empty-title-parentheses.text/output.json
@@ -165,9 +165,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "world",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "World!",
+                    "url": "",
                     "children": [
                         {
                             "type": "Str",
@@ -196,22 +196,22 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 7
+                            "column": 20
                         }
                     },
                     "range": [
                         41,
-                        48
+                        61
                     ],
-                    "raw": "[World]"
+                    "raw": "[World](<> (World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(<> (World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 7
+                            "column": 20
                         },
                         "end": {
                             "line": 5,
@@ -219,10 +219,10 @@
                         }
                     },
                     "range": [
-                        48,
+                        61,
                         62
                     ],
-                    "raw": "(<> (World!))."
+                    "raw": "."
                 }
             ],
             "loc": {
@@ -365,9 +365,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "world",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "World!",
+                    "url": "",
                     "alt": "World",
                     "loc": {
                         "start": {
@@ -376,22 +376,22 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 8
+                            "column": 21
                         }
                     },
                     "range": [
                         107,
-                        115
+                        128
                     ],
-                    "raw": "![World]"
+                    "raw": "![World](<> (World!))"
                 },
                 {
                     "type": "Str",
-                    "value": "(<> (World!)).",
+                    "value": ".",
                     "loc": {
                         "start": {
                             "line": 11,
-                            "column": 8
+                            "column": 21
                         },
                         "end": {
                             "line": 11,
@@ -399,10 +399,10 @@
                         }
                     },
                     "range": [
-                        115,
+                        128,
                         129
                     ],
-                    "raw": "(<> (World!))."
+                    "raw": "."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-mismatched-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-mismatched-parentheses.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world(and-hello(world)).",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world(and-hello(world)).",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 34
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         34
                     ],
-                    "raw": "(./world(and-hello(world))."
+                    "raw": "[Hello](./world(and-hello(world))."
                 }
             ],
             "loc": {
@@ -325,10 +284,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world(and-hello(world)).",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -336,33 +293,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        146,
-                        154
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world(and-hello(world)).",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 35
                         }
                     },
                     "range": [
-                        154,
+                        146,
                         181
                     ],
-                    "raw": "(./world(and-hello(world))."
+                    "raw": "![Hello](./world(and-hello(world))."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-new-line.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-new-line.text/output.json
@@ -5,53 +5,12 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./wo\nrld.html).",
                     "loc": {
                         "start": {
                             "line": 1,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./wo\nrld.html).",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
                         },
                         "end": {
                             "line": 2,
@@ -59,10 +18,10 @@
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         23
                     ],
-                    "raw": "(./wo\nrld.html)."
+                    "raw": "[Hello](./wo\nrld.html)."
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": null,
-                    "url": "./wo\nrld.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                26,
-                                31
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](<./wo\nrld.html>).",
                     "loc": {
                         "start": {
                             "line": 4,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        25,
-                        49
-                    ],
-                    "raw": "[Hello](<./wo\nrld.html>)"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 11
                         }
                     },
                     "range": [
-                        49,
+                        25,
                         50
                     ],
-                    "raw": "."
+                    "raw": "[Hello](<./wo\nrld.html>)."
                 }
             ],
             "loc": {
@@ -165,33 +83,12 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./wo\nrld.png).",
                     "loc": {
                         "start": {
                             "line": 7,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 7,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        52,
-                        60
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./wo\nrld.png).",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 8
                         },
                         "end": {
                             "line": 8,
@@ -199,10 +96,10 @@
                         }
                     },
                     "range": [
-                        60,
+                        52,
                         75
                     ],
-                    "raw": "(./wo\nrld.png)."
+                    "raw": "![Hello](./wo\nrld.png)."
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": null,
-                    "url": "./wo\nrld.png",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](<./wo\nrld.png>).",
                     "loc": {
                         "start": {
                             "line": 10,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 11,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        77,
-                        101
-                    ],
-                    "raw": "![Hello](<./wo\nrld.png>)"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 11,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 11,
                             "column": 10
                         }
                     },
                     "range": [
-                        101,
+                        77,
                         102
                     ],
-                    "raw": "."
+                    "raw": "![Hello](<./wo\nrld.png>)."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-unclosed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-unclosed.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 8
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         8
                     ],
-                    "raw": "("
+                    "raw": "[Hello]("
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "world",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "World",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                12,
-                                17
-                            ],
-                            "raw": "World"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[World](<",
                     "loc": {
                         "start": {
                             "line": 4,
@@ -116,33 +53,14 @@
                         },
                         "end": {
                             "line": 4,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        11,
-                        18
-                    ],
-                    "raw": "[World]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 4,
                             "column": 9
                         }
                     },
                     "range": [
-                        18,
+                        11,
                         20
                     ],
-                    "raw": "(<"
+                    "raw": "[World](<"
                 }
             ],
             "loc": {
@@ -165,10 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -176,33 +92,14 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        23,
-                        31
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 7,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 7,
                             "column": 9
                         }
                     },
                     "range": [
-                        31,
+                        23,
                         32
                     ],
-                    "raw": "("
+                    "raw": "![Hello]("
                 }
             ],
             "loc": {
@@ -225,10 +122,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "world",
-                    "referenceType": "shortcut",
-                    "alt": "World",
+                    "type": "Str",
+                    "value": "![World](<",
                     "loc": {
                         "start": {
                             "line": 10,
@@ -236,33 +131,14 @@
                         },
                         "end": {
                             "line": 10,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        35,
-                        43
-                    ],
-                    "raw": "![World]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(<",
-                    "loc": {
-                        "start": {
-                            "line": 10,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 10,
                             "column": 10
                         }
                     },
                     "range": [
-                        43,
+                        35,
                         45
                     ],
-                    "raw": "(<"
+                    "raw": "![World](<"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/links-url-white-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/links-url-white-space.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1,
-                                6
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./wo rld.html).",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./wo rld.html).",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 23
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         23
                     ],
-                    "raw": "(./wo rld.html)."
+                    "raw": "[Hello](./wo rld.html)."
                 }
             ],
             "loc": {
@@ -165,10 +124,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./wo rld.png).",
                     "loc": {
                         "start": {
                             "line": 5,
@@ -176,33 +133,14 @@
                         },
                         "end": {
                             "line": 5,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        52,
-                        60
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./wo rld.png).",
-                    "loc": {
-                        "start": {
-                            "line": 5,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 5,
                             "column": 23
                         }
                     },
                     "range": [
-                        60,
+                        52,
                         75
                     ],
-                    "raw": "(./wo rld.png)."
+                    "raw": "![Hello](./wo rld.png)."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-and-code.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-and-code.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -50,6 +50,45 @@
                                 23
                             ],
                             "raw": "This is a list item"
+                        },
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "This is code",
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 16
+                                        }
+                                    },
+                                    "range": [
+                                        30,
+                                        42
+                                    ],
+                                    "raw": "This is code"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                30,
+                                42
+                            ],
+                            "raw": "This is code"
                         }
                     ],
                     "loc": {
@@ -58,40 +97,20 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 1,
-                            "column": 23
+                            "line": 4,
+                            "column": 16
                         }
                     },
                     "range": [
                         0,
-                        23
+                        42
                     ],
-                    "raw": "*   This is a list item"
+                    "raw": "*   This is a list item\n\n\n    This is code"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 1,
-                    "column": 0
-                },
-                "end": {
-                    "line": 1,
-                    "column": 23
-                }
-            },
-            "range": [
-                0,
-                23
-            ],
-            "raw": "*   This is a list item"
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "value": "This is code",
-            "loc": {
-                "start": {
-                    "line": 4,
                     "column": 0
                 },
                 "end": {
@@ -100,10 +119,10 @@
                 }
             },
             "range": [
-                26,
+                0,
                 42
             ],
-            "raw": "    This is code"
+            "raw": "*   This is a list item\n\n\n    This is code"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
@@ -247,7 +247,7 @@
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "footnoteReference",
+                                    "type": "FootnoteReference",
                                     "identifier": "foo",
                                     "label": "foo",
                                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -107,11 +107,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -119,8 +119,6 @@
                             "children": [
                                 {
                                     "type": "LinkReference",
-                                    "identifier": "foo",
-                                    "referenceType": "collapsed",
                                     "children": [
                                         {
                                             "type": "Str",
@@ -142,6 +140,9 @@
                                             "raw": "foo"
                                         }
                                     ],
+                                    "identifier": "foo",
+                                    "label": "foo",
+                                    "referenceType": "collapsed",
                                     "loc": {
                                         "start": {
                                             "line": 5,
@@ -212,6 +213,7 @@
         {
             "type": "Definition",
             "identifier": "foo",
+            "label": "foo",
             "title": null,
             "url": "http://google.com",
             "loc": {
@@ -234,75 +236,34 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "^foo",
-                                    "referenceType": "full",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "^foo",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 9,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 9,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                55,
-                                                59
-                                            ],
-                                            "raw": "^foo"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[^foo]",
                                     "loc": {
                                         "start": {
                                             "line": 9,
                                             "column": 3
                                         },
                                         "end": {
-                                            "line": 10,
-                                            "column": 6
+                                            "line": 9,
+                                            "column": 9
                                         }
                                     },
                                     "range": [
                                         54,
-                                        67
+                                        60
                                     ],
-                                    "raw": "[^foo]\n[^foo]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ": bar baz.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 10,
-                                            "column": 6
-                                        },
-                                        "end": {
-                                            "line": 10,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        67,
-                                        77
-                                    ],
-                                    "raw": ": bar baz."
+                                    "raw": "[^foo]"
                                 }
                             ],
                             "loc": {
@@ -311,15 +272,15 @@
                                     "column": 3
                                 },
                                 "end": {
-                                    "line": 10,
-                                    "column": 16
+                                    "line": 9,
+                                    "column": 9
                                 }
                             },
                             "range": [
                                 54,
-                                77
+                                60
                             ],
-                            "raw": "[^foo]\n[^foo]: bar baz."
+                            "raw": "[^foo]"
                         }
                     ],
                     "loc": {
@@ -328,15 +289,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 10,
-                            "column": 16
+                            "line": 9,
+                            "column": 9
                         }
                     },
                     "range": [
                         51,
-                        77
+                        60
                     ],
-                    "raw": "1. [^foo]\n[^foo]: bar baz."
+                    "raw": "1. [^foo]"
                 }
             ],
             "loc": {
@@ -345,15 +306,54 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 9,
+                    "column": 9
+                }
+            },
+            "range": [
+                51,
+                60
+            ],
+            "raw": "1. [^foo]"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "[^foo]: bar baz.",
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        61,
+                        77
+                    ],
+                    "raw": "[^foo]: bar baz."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
                     "line": 10,
                     "column": 16
                 }
             },
             "range": [
-                51,
+                61,
                 77
             ],
-            "raw": "1. [^foo]\n[^foo]: bar baz."
+            "raw": "[^foo]: bar baz."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-continuation.text/output.json
@@ -247,8 +247,9 @@
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "Str",
-                                    "value": "[^foo]",
+                                    "type": "footnoteReference",
+                                    "identifier": "foo",
+                                    "label": "foo",
                                     "loc": {
                                         "start": {
                                             "line": 9,
@@ -317,15 +318,37 @@
             "raw": "1. [^foo]"
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "foo",
+            "label": "foo",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^foo]: bar baz.",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "bar baz.",
+                            "loc": {
+                                "start": {
+                                    "line": 10,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                69,
+                                77
+                            ],
+                            "raw": "bar baz."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 10,
-                            "column": 0
+                            "column": 8
                         },
                         "end": {
                             "line": 10,
@@ -333,10 +356,10 @@
                         }
                     },
                     "range": [
-                        61,
+                        69,
                         77
                     ],
-                    "raw": "[^foo]: bar baz."
+                    "raw": "bar baz."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-indentation.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-indentation.nooutput.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -50,45 +50,6 @@
                                 10
                             ],
                             "raw": "Hello 1a"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "World 1a.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 1
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        13,
-                                        22
-                                    ],
-                                    "raw": "World 1a."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 10
-                                }
-                            },
-                            "range": [
-                                13,
-                                22
-                            ],
-                            "raw": "World 1a."
                         }
                     ],
                     "loc": {
@@ -97,19 +58,81 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 4,
-                            "column": 0
+                            "line": 1,
+                            "column": 10
                         }
                     },
                     "range": [
                         0,
-                        23
+                        10
                     ],
-                    "raw": "- Hello 1a\n\n World 1a.\n"
+                    "raw": "- Hello 1a"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
                 },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            },
+            "range": [
+                0,
+                10
+            ],
+            "raw": "- Hello 1a"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "World 1a.",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        13,
+                        22
+                    ],
+                    "raw": "World 1a."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 1
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "range": [
+                13,
+                22
+            ],
+            "raw": "World 1a."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": true,
+            "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -197,19 +220,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 8,
-                            "column": 0
+                            "line": 7,
+                            "column": 11
                         }
                     },
                     "range": [
                         24,
-                        48
+                        47
                     ],
-                    "raw": "- Hello 1b\n\n  World 1b.\n"
+                    "raw": "- Hello 1b\n\n  World 1b."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -250,45 +273,6 @@
                                 60
                             ],
                             "raw": "Hello 2a"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "World 2a.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 11,
-                                            "column": 2
-                                        },
-                                        "end": {
-                                            "line": 11,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        64,
-                                        73
-                                    ],
-                                    "raw": "World 2a."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 11,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 11,
-                                    "column": 11
-                                }
-                            },
-                            "range": [
-                                64,
-                                73
-                            ],
-                            "raw": "World 2a."
                         }
                     ],
                     "loc": {
@@ -297,19 +281,81 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 12,
-                            "column": 0
+                            "line": 9,
+                            "column": 11
                         }
                     },
                     "range": [
                         49,
-                        74
+                        60
                     ],
-                    "raw": "-  Hello 2a\n\n  World 2a.\n"
+                    "raw": "-  Hello 2a"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
                 },
+                "end": {
+                    "line": 9,
+                    "column": 11
+                }
+            },
+            "range": [
+                24,
+                60
+            ],
+            "raw": "- Hello 1b\n\n  World 1b.\n\n-  Hello 2a"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "World 2a.",
+                    "loc": {
+                        "start": {
+                            "line": 11,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        64,
+                        73
+                    ],
+                    "raw": "World 2a."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 2
+                },
+                "end": {
+                    "line": 11,
+                    "column": 11
+                }
+            },
+            "range": [
+                64,
+                73
+            ],
+            "raw": "World 2a."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": true,
+            "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -397,19 +443,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 16,
-                            "column": 0
+                            "line": 15,
+                            "column": 12
                         }
                     },
                     "range": [
                         75,
-                        101
+                        100
                     ],
-                    "raw": "-  Hello 2b\n\n   World 2b.\n"
+                    "raw": "-  Hello 2b\n\n   World 2b."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -450,45 +496,6 @@
                                 114
                             ],
                             "raw": "Hello 3a"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "World 3a.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 19,
-                                            "column": 3
-                                        },
-                                        "end": {
-                                            "line": 19,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        119,
-                                        128
-                                    ],
-                                    "raw": "World 3a."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 12
-                                }
-                            },
-                            "range": [
-                                119,
-                                128
-                            ],
-                            "raw": "World 3a."
                         }
                     ],
                     "loc": {
@@ -497,19 +504,81 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 20,
-                            "column": 0
+                            "line": 17,
+                            "column": 12
                         }
                     },
                     "range": [
                         102,
-                        129
+                        114
                     ],
-                    "raw": "-   Hello 3a\n\n   World 3a.\n"
+                    "raw": "-   Hello 3a"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
                 },
+                "end": {
+                    "line": 17,
+                    "column": 12
+                }
+            },
+            "range": [
+                75,
+                114
+            ],
+            "raw": "-  Hello 2b\n\n   World 2b.\n\n-   Hello 3a"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "World 3a.",
+                    "loc": {
+                        "start": {
+                            "line": 19,
+                            "column": 3
+                        },
+                        "end": {
+                            "line": 19,
+                            "column": 12
+                        }
+                    },
+                    "range": [
+                        119,
+                        128
+                    ],
+                    "raw": "World 3a."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 3
+                },
+                "end": {
+                    "line": 19,
+                    "column": 12
+                }
+            },
+            "range": [
+                119,
+                128
+            ],
+            "raw": "World 3a."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": true,
+            "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -597,19 +666,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 24,
-                            "column": 0
+                            "line": 23,
+                            "column": 13
                         }
                     },
                     "range": [
                         130,
-                        158
+                        157
                     ],
-                    "raw": "-   Hello 3b\n\n    World 3b.\n"
+                    "raw": "-   Hello 3b\n\n    World 3b."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -650,45 +719,6 @@
                                 172
                             ],
                             "raw": "Hello 4a"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "World 4a.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 27,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 27,
-                                            "column": 13
-                                        }
-                                    },
-                                    "range": [
-                                        178,
-                                        187
-                                    ],
-                                    "raw": "World 4a."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 27,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 27,
-                                    "column": 13
-                                }
-                            },
-                            "range": [
-                                178,
-                                187
-                            ],
-                            "raw": "World 4a."
                         }
                     ],
                     "loc": {
@@ -697,19 +727,63 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 28,
-                            "column": 0
+                            "line": 25,
+                            "column": 13
                         }
                     },
                     "range": [
                         159,
-                        188
+                        172
                     ],
-                    "raw": "-    Hello 4a\n\n    World 4a.\n"
+                    "raw": "-    Hello 4a"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 0
                 },
+                "end": {
+                    "line": 25,
+                    "column": 13
+                }
+            },
+            "range": [
+                130,
+                172
+            ],
+            "raw": "-   Hello 3b\n\n    World 3b.\n\n-    Hello 4a"
+        },
+        {
+            "type": "CodeBlock",
+            "lang": null,
+            "meta": null,
+            "value": "World 4a.",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 13
+                }
+            },
+            "range": [
+                174,
+                187
+            ],
+            "raw": "    World 4a."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": true,
+            "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -797,24 +871,25 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 32,
-                            "column": 0
+                            "line": 31,
+                            "column": 14
                         }
                     },
                     "range": [
                         189,
-                        219
+                        218
                     ],
-                    "raw": "-    Hello 4b\n\n     World 4b.\n"
+                    "raw": "-    Hello 4b\n\n     World 4b."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
                             "type": "CodeBlock",
                             "lang": null,
+                            "meta": null,
                             "value": "Hello 5a",
                             "loc": {
                                 "start": {
@@ -837,11 +912,11 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "   World 5a.",
+                                    "value": "World 5a.",
                                     "loc": {
                                         "start": {
                                             "line": 35,
-                                            "column": 2
+                                            "column": 5
                                         },
                                         "end": {
                                             "line": 35,
@@ -849,16 +924,16 @@
                                         }
                                     },
                                     "range": [
-                                        238,
+                                        241,
                                         250
                                     ],
-                                    "raw": "   World 5a."
+                                    "raw": "World 5a."
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 35,
-                                    "column": 2
+                                    "column": 5
                                 },
                                 "end": {
                                     "line": 35,
@@ -866,10 +941,10 @@
                                 }
                             },
                             "range": [
-                                238,
+                                241,
                                 250
                             ],
-                            "raw": "   World 5a."
+                            "raw": "World 5a."
                         }
                     ],
                     "loc": {
@@ -878,24 +953,25 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 36,
-                            "column": 0
+                            "line": 35,
+                            "column": 14
                         }
                     },
                     "range": [
                         220,
-                        251
+                        250
                     ],
-                    "raw": "-     Hello 5a\n\n     World 5a.\n"
+                    "raw": "-     Hello 5a\n\n     World 5a."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "CodeBlock",
                             "lang": null,
+                            "meta": null,
                             "value": "Hello 5b\n\nWorld 5b.",
                             "loc": {
                                 "start": {
@@ -933,7 +1009,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 1,
+                    "line": 29,
                     "column": 0
                 },
                 "end": {
@@ -942,10 +1018,10 @@
                 }
             },
             "range": [
-                0,
+                189,
                 283
             ],
-            "raw": "- Hello 1a\n\n World 1a.\n\n- Hello 1b\n\n  World 1b.\n\n-  Hello 2a\n\n  World 2a.\n\n-  Hello 2b\n\n   World 2b.\n\n-   Hello 3a\n\n   World 3a.\n\n-   Hello 3b\n\n    World 3b.\n\n-    Hello 4a\n\n    World 4a.\n\n-    Hello 4b\n\n     World 4b.\n\n-     Hello 5a\n\n     World 5a.\n\n-     Hello 5b\n\n      World 5b."
+            "raw": "-    Hello 4b\n\n     World 4b.\n\n-     Hello 5a\n\n     World 5a.\n\n-     Hello 5b\n\n      World 5b."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-empty-with-white-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-empty-with-white-space.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-empty.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-empty.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [],
                     "loc": {
@@ -91,7 +91,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -140,19 +140,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 4,
-                            "column": 0
+                            "line": 3,
+                            "column": 7
                         }
                     },
                     "range": [
                         10,
-                        18
+                        17
                     ],
-                    "raw": "-   bar\n"
+                    "raw": "-   bar"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -198,7 +198,7 @@
                     "loc": {
                         "start": {
                             "line": 5,
-                            "column": 0
+                            "column": 2
                         },
                         "end": {
                             "line": 5,
@@ -206,20 +206,20 @@
                         }
                     },
                     "range": [
-                        19,
+                        21,
                         28
                     ],
-                    "raw": "  -   foo"
+                    "raw": "-   foo"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [],
                     "loc": {
                         "start": {
                             "line": 6,
-                            "column": 0
+                            "column": 2
                         },
                         "end": {
                             "line": 6,
@@ -227,14 +227,14 @@
                         }
                     },
                     "range": [
-                        29,
+                        31,
                         32
                     ],
-                    "raw": "  -"
+                    "raw": "-"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -280,7 +280,7 @@
                     "loc": {
                         "start": {
                             "line": 7,
-                            "column": 0
+                            "column": 2
                         },
                         "end": {
                             "line": 7,
@@ -288,10 +288,10 @@
                         }
                     },
                     "range": [
-                        33,
+                        35,
                         42
                     ],
-                    "raw": "  -   bar"
+                    "raw": "-   bar"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=1.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=1.output.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -108,11 +108,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -211,11 +211,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -314,11 +314,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -417,11 +417,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -520,11 +520,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -623,11 +623,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -726,11 +726,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=mixed.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=mixed.output.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -108,11 +108,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -211,11 +211,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -314,11 +314,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -417,11 +417,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -520,11 +520,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -623,11 +623,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -726,11 +726,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=tab.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-indent.list-item-indent=tab.output.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -108,11 +108,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -211,11 +211,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -314,11 +314,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -417,11 +417,11 @@
             "type": "List",
             "ordered": true,
             "start": 99,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -520,11 +520,11 @@
             "type": "List",
             "ordered": true,
             "start": 999,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -623,11 +623,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -726,11 +726,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-newline.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-newline.nooutput.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -78,11 +78,11 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "   Bar",
+                                    "value": "Bar",
                                     "loc": {
                                         "start": {
                                             "line": 3,
-                                            "column": 1
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 3,
@@ -90,16 +90,16 @@
                                         }
                                     },
                                     "range": [
-                                        11,
+                                        14,
                                         17
                                     ],
-                                    "raw": "   Bar"
+                                    "raw": "Bar"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 1
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 3,
@@ -107,10 +107,10 @@
                                 }
                             },
                             "range": [
-                                11,
+                                14,
                                 17
                             ],
-                            "raw": "   Bar"
+                            "raw": "Bar"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-second-paragraph/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-second-paragraph/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -55,289 +55,22 @@
                                 },
                                 {
                                     "type": "Str",
-                                    "value": " and type is Paragraph\n    - have ",
+                                    "value": " and type is Paragraph",
                                     "loc": {
                                         "start": {
                                             "line": 1,
                                             "column": 32
                                         },
                                         "end": {
-                                            "line": 2,
-                                            "column": 11
+                                            "line": 1,
+                                            "column": 54
                                         }
                                     },
                                     "range": [
                                         32,
-                                        66
+                                        54
                                     ],
-                                    "raw": " and type is Paragraph\n    - have "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "children",
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 21
-                                        }
-                                    },
-                                    "range": [
-                                        66,
-                                        76
-                                    ],
-                                    "raw": "`children`"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ", but not have ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 21
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 36
-                                        }
-                                    },
-                                    "range": [
-                                        76,
-                                        91
-                                    ],
-                                    "raw": ", but not have "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "value",
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 36
-                                        },
-                                        "end": {
-                                            "line": 2,
-                                            "column": 43
-                                        }
-                                    },
-                                    "range": [
-                                        91,
-                                        98
-                                    ],
-                                    "raw": "`value`"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\n",
-                                    "loc": {
-                                        "start": {
-                                            "line": 2,
-                                            "column": 43
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 0
-                                        }
-                                    },
-                                    "range": [
-                                        98,
-                                        99
-                                    ],
-                                    "raw": "\n"
-                                },
-                                {
-                                    "type": "Emphasis",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "Emphasis",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 3,
-                                                    "column": 1
-                                                },
-                                                "end": {
-                                                    "line": 3,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                100,
-                                                108
-                                            ],
-                                            "raw": "Emphasis"
-                                        }
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 0
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        99,
-                                        109
-                                    ],
-                                    "raw": "*Emphasis*"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " is a ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        109,
-                                        115
-                                    ],
-                                    "raw": " is a "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "TxtTextNode",
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 3,
-                                            "column": 29
-                                        }
-                                    },
-                                    "range": [
-                                        115,
-                                        128
-                                    ],
-                                    "raw": "`TxtTextNode`"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " and type is Emphasis\n    - have ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 3,
-                                            "column": 29
-                                        },
-                                        "end": {
-                                            "line": 4,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        128,
-                                        161
-                                    ],
-                                    "raw": " and type is Emphasis\n    - have "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "value",
-                                    "loc": {
-                                        "start": {
-                                            "line": 4,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 4,
-                                            "column": 18
-                                        }
-                                    },
-                                    "range": [
-                                        161,
-                                        168
-                                    ],
-                                    "raw": "`value`"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\n\"text\" is a ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 4,
-                                            "column": 18
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        168,
-                                        181
-                                    ],
-                                    "raw": "\n\"text\" is a "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "TxtTextNode",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "column": 25
-                                        }
-                                    },
-                                    "range": [
-                                        181,
-                                        194
-                                    ],
-                                    "raw": "`TxtTextNode`"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " and type is Str\n    - have ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 25
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        194,
-                                        222
-                                    ],
-                                    "raw": " and type is Str\n    - have "
-                                },
-                                {
-                                    "type": "Code",
-                                    "value": "value",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 18
-                                        }
-                                    },
-                                    "range": [
-                                        222,
-                                        229
-                                    ],
-                                    "raw": "`value`"
+                                    "raw": " and type is Paragraph"
                                 }
                             ],
                             "loc": {
@@ -346,15 +79,156 @@
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 6,
-                                    "column": 18
+                                    "line": 1,
+                                    "column": 54
                                 }
                             },
                             "range": [
                                 2,
-                                229
+                                54
                             ],
-                            "raw": "Paragraph is a `TxtParentNode` and type is Paragraph\n    - have `children`, but not have `value`\n*Emphasis* is a `TxtTextNode` and type is Emphasis\n    - have `value`\n\"text\" is a `TxtTextNode` and type is Str\n    - have `value`"
+                            "raw": "Paragraph is a `TxtParentNode` and type is Paragraph"
+                        },
+                        {
+                            "type": "List",
+                            "ordered": false,
+                            "start": null,
+                            "spread": false,
+                            "children": [
+                                {
+                                    "type": "ListItem",
+                                    "spread": false,
+                                    "checked": null,
+                                    "children": [
+                                        {
+                                            "type": "Paragraph",
+                                            "children": [
+                                                {
+                                                    "type": "Str",
+                                                    "value": "have ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 6
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 11
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        61,
+                                                        66
+                                                    ],
+                                                    "raw": "have "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "children",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 11
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 21
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        66,
+                                                        76
+                                                    ],
+                                                    "raw": "`children`"
+                                                },
+                                                {
+                                                    "type": "Str",
+                                                    "value": ", but not have ",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 21
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 36
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        76,
+                                                        91
+                                                    ],
+                                                    "raw": ", but not have "
+                                                },
+                                                {
+                                                    "type": "Code",
+                                                    "value": "value",
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 2,
+                                                            "column": 36
+                                                        },
+                                                        "end": {
+                                                            "line": 2,
+                                                            "column": 43
+                                                        }
+                                                    },
+                                                    "range": [
+                                                        91,
+                                                        98
+                                                    ],
+                                                    "raw": "`value`"
+                                                }
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 2,
+                                                    "column": 6
+                                                },
+                                                "end": {
+                                                    "line": 2,
+                                                    "column": 43
+                                                }
+                                            },
+                                            "range": [
+                                                61,
+                                                98
+                                            ],
+                                            "raw": "have `children`, but not have `value`"
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 43
+                                        }
+                                    },
+                                    "range": [
+                                        59,
+                                        98
+                                    ],
+                                    "raw": "- have `children`, but not have `value`"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 43
+                                }
+                            },
+                            "range": [
+                                59,
+                                98
+                            ],
+                            "raw": "- have `children`, but not have `value`"
                         }
                     ],
                     "loc": {
@@ -363,15 +237,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 6,
-                            "column": 18
+                            "line": 2,
+                            "column": 43
                         }
                     },
                     "range": [
                         0,
-                        229
+                        98
                     ],
-                    "raw": "- Paragraph is a `TxtParentNode` and type is Paragraph\n    - have `children`, but not have `value`\n*Emphasis* is a `TxtTextNode` and type is Emphasis\n    - have `value`\n\"text\" is a `TxtTextNode` and type is Str\n    - have `value`"
+                    "raw": "- Paragraph is a `TxtParentNode` and type is Paragraph\n    - have `children`, but not have `value`"
                 }
             ],
             "loc": {
@@ -380,15 +254,226 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 2,
+                    "column": 43
+                }
+            },
+            "range": [
+                0,
+                98
+            ],
+            "raw": "- Paragraph is a `TxtParentNode` and type is Paragraph\n    - have `children`, but not have `value`"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Emphasis",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Emphasis",
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 9
+                                }
+                            },
+                            "range": [
+                                100,
+                                108
+                            ],
+                            "raw": "Emphasis"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        99,
+                        109
+                    ],
+                    "raw": "*Emphasis*"
+                },
+                {
+                    "type": "Str",
+                    "value": " is a ",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        109,
+                        115
+                    ],
+                    "raw": " is a "
+                },
+                {
+                    "type": "Code",
+                    "value": "TxtTextNode",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 16
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 29
+                        }
+                    },
+                    "range": [
+                        115,
+                        128
+                    ],
+                    "raw": "`TxtTextNode`"
+                },
+                {
+                    "type": "Str",
+                    "value": " and type is Emphasis\n- have ",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 29
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        128,
+                        161
+                    ],
+                    "raw": " and type is Emphasis\n    - have "
+                },
+                {
+                    "type": "Code",
+                    "value": "value",
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        161,
+                        168
+                    ],
+                    "raw": "`value`"
+                },
+                {
+                    "type": "Str",
+                    "value": "\n\"text\" is a ",
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 18
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 12
+                        }
+                    },
+                    "range": [
+                        168,
+                        181
+                    ],
+                    "raw": "\n\"text\" is a "
+                },
+                {
+                    "type": "Code",
+                    "value": "TxtTextNode",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 25
+                        }
+                    },
+                    "range": [
+                        181,
+                        194
+                    ],
+                    "raw": "`TxtTextNode`"
+                },
+                {
+                    "type": "Str",
+                    "value": " and type is Str\n- have ",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        194,
+                        222
+                    ],
+                    "raw": " and type is Str\n    - have "
+                },
+                {
+                    "type": "Code",
+                    "value": "value",
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        222,
+                        229
+                    ],
+                    "raw": "`value`"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
                     "line": 6,
                     "column": 18
                 }
             },
             "range": [
-                0,
+                99,
                 229
             ],
-            "raw": "- Paragraph is a `TxtParentNode` and type is Paragraph\n    - have `children`, but not have `value`\n*Emphasis* is a `TxtTextNode` and type is Emphasis\n    - have `value`\n\"text\" is a `TxtTextNode` and type is Str\n    - have `value`"
+            "raw": "*Emphasis* is a `TxtTextNode` and type is Emphasis\n    - have `value`\n\"text\" is a `TxtTextNode` and type is Str\n    - have `value`"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-item-text.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-item-text.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -55,11 +55,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -105,7 +105,7 @@
                                     "loc": {
                                         "start": {
                                             "line": 3,
-                                            "column": 2
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 3,
@@ -113,16 +113,16 @@
                                         }
                                     },
                                     "range": [
-                                        13,
+                                        15,
                                         22
                                     ],
-                                    "raw": "  * item2"
+                                    "raw": "* item2"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 3,
@@ -130,55 +130,55 @@
                                 }
                             },
                             "range": [
-                                13,
+                                15,
                                 22
                             ],
-                            "raw": "  * item2"
-                        },
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "text",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 2
-                                        },
-                                        "end": {
-                                            "line": 5,
-                                            "column": 6
-                                        }
-                                    },
-                                    "range": [
-                                        26,
-                                        30
-                                    ],
-                                    "raw": "text"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                26,
-                                30
-                            ],
-                            "raw": "text"
+                            "raw": "* item2"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 1,
-                            "column": 0
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        2,
+                        22
+                    ],
+                    "raw": "* item1\n\n    * item2"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 2
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            },
+            "range": [
+                2,
+                22
+            ],
+            "raw": "* item1\n\n    * item2"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "text",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 2
                         },
                         "end": {
                             "line": 5,
@@ -186,16 +186,16 @@
                         }
                     },
                     "range": [
-                        0,
+                        26,
                         30
                     ],
-                    "raw": "  * item1\n\n    * item2\n\n  text"
+                    "raw": "text"
                 }
             ],
             "loc": {
                 "start": {
-                    "line": 1,
-                    "column": 0
+                    "line": 5,
+                    "column": 2
                 },
                 "end": {
                     "line": 5,
@@ -203,10 +203,10 @@
                 }
             },
             "range": [
-                0,
+                26,
                 30
             ],
-            "raw": "  * item1\n\n    * item2\n\n  text"
+            "raw": "text"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-ordered.increment-list-marker.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-ordered.increment-list-marker.output.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 2,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list-ordered.noincrement-list-marker.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list-ordered.noincrement-list-marker.output.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 2,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=+.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=+.text/output.json
@@ -45,11 +45,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -95,11 +95,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -160,7 +160,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -206,11 +206,11 @@
                                             "type": "List",
                                             "ordered": false,
                                             "start": null,
-                                            "loose": false,
+                                            "spread": false,
                                             "children": [
                                                 {
                                                     "type": "ListItem",
-                                                    "loose": false,
+                                                    "spread": false,
                                                     "checked": null,
                                                     "children": [
                                                         {
@@ -339,7 +339,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -400,7 +400,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=-.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=-.text/output.json
@@ -45,11 +45,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -95,11 +95,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -160,7 +160,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -206,11 +206,11 @@
                                             "type": "List",
                                             "ordered": false,
                                             "start": null,
-                                            "loose": false,
+                                            "spread": false,
                                             "children": [
                                                 {
                                                     "type": "ListItem",
-                                                    "loose": false,
+                                                    "spread": false,
                                                     "checked": null,
                                                     "children": [
                                                         {
@@ -339,7 +339,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -400,7 +400,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=__.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/list.output.bullet=__.text/output.json
@@ -45,11 +45,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -95,11 +95,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -160,7 +160,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -206,11 +206,11 @@
                                             "type": "List",
                                             "ordered": false,
                                             "start": null,
-                                            "loose": false,
+                                            "spread": false,
                                             "children": [
                                                 {
                                                     "type": "ListItem",
-                                                    "loose": false,
+                                                    "spread": false,
                                                     "checked": null,
                                                     "children": [
                                                         {
@@ -339,7 +339,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -400,7 +400,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/lists-with-code-and-rules.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/lists-with-code-and-rules.text/output.json
@@ -45,11 +45,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -98,11 +98,11 @@
                                     "type": "List",
                                     "ordered": false,
                                     "start": null,
-                                    "loose": false,
+                                    "spread": false,
                                     "children": [
                                         {
                                             "type": "ListItem",
-                                            "loose": false,
+                                            "spread": false,
                                             "checked": null,
                                             "children": [
                                                 {
@@ -143,296 +143,6 @@
                                                         28
                                                     ],
                                                     "raw": "one"
-                                                },
-                                                {
-                                                    "type": "List",
-                                                    "ordered": false,
-                                                    "start": null,
-                                                    "loose": false,
-                                                    "children": [
-                                                        {
-                                                            "type": "ListItem",
-                                                            "loose": false,
-                                                            "checked": null,
-                                                            "children": [
-                                                                {
-                                                                    "type": "Paragraph",
-                                                                    "children": [
-                                                                        {
-                                                                            "type": "Str",
-                                                                            "value": "two",
-                                                                            "loc": {
-                                                                                "start": {
-                                                                                    "line": 6,
-                                                                                    "column": 10
-                                                                                },
-                                                                                "end": {
-                                                                                    "line": 6,
-                                                                                    "column": 13
-                                                                                }
-                                                                            },
-                                                                            "range": [
-                                                                                39,
-                                                                                42
-                                                                            ],
-                                                                            "raw": "two"
-                                                                        }
-                                                                    ],
-                                                                    "loc": {
-                                                                        "start": {
-                                                                            "line": 6,
-                                                                            "column": 10
-                                                                        },
-                                                                        "end": {
-                                                                            "line": 6,
-                                                                            "column": 13
-                                                                        }
-                                                                    },
-                                                                    "range": [
-                                                                        39,
-                                                                        42
-                                                                    ],
-                                                                    "raw": "two"
-                                                                },
-                                                                {
-                                                                    "type": "List",
-                                                                    "ordered": false,
-                                                                    "start": null,
-                                                                    "loose": false,
-                                                                    "children": [
-                                                                        {
-                                                                            "type": "ListItem",
-                                                                            "loose": false,
-                                                                            "checked": null,
-                                                                            "children": [
-                                                                                {
-                                                                                    "type": "Paragraph",
-                                                                                    "children": [
-                                                                                        {
-                                                                                            "type": "Str",
-                                                                                            "value": "three",
-                                                                                            "loc": {
-                                                                                                "start": {
-                                                                                                    "line": 7,
-                                                                                                    "column": 14
-                                                                                                },
-                                                                                                "end": {
-                                                                                                    "line": 7,
-                                                                                                    "column": 19
-                                                                                                }
-                                                                                            },
-                                                                                            "range": [
-                                                                                                57,
-                                                                                                62
-                                                                                            ],
-                                                                                            "raw": "three"
-                                                                                        }
-                                                                                    ],
-                                                                                    "loc": {
-                                                                                        "start": {
-                                                                                            "line": 7,
-                                                                                            "column": 14
-                                                                                        },
-                                                                                        "end": {
-                                                                                            "line": 7,
-                                                                                            "column": 19
-                                                                                        }
-                                                                                    },
-                                                                                    "range": [
-                                                                                        57,
-                                                                                        62
-                                                                                    ],
-                                                                                    "raw": "three"
-                                                                                }
-                                                                            ],
-                                                                            "loc": {
-                                                                                "start": {
-                                                                                    "line": 7,
-                                                                                    "column": 10
-                                                                                },
-                                                                                "end": {
-                                                                                    "line": 7,
-                                                                                    "column": 19
-                                                                                }
-                                                                            },
-                                                                            "range": [
-                                                                                53,
-                                                                                62
-                                                                            ],
-                                                                            "raw": "  - three"
-                                                                        },
-                                                                        {
-                                                                            "type": "ListItem",
-                                                                            "loose": false,
-                                                                            "checked": null,
-                                                                            "children": [
-                                                                                {
-                                                                                    "type": "Paragraph",
-                                                                                    "children": [
-                                                                                        {
-                                                                                            "type": "Str",
-                                                                                            "value": "four",
-                                                                                            "loc": {
-                                                                                                "start": {
-                                                                                                    "line": 8,
-                                                                                                    "column": 14
-                                                                                                },
-                                                                                                "end": {
-                                                                                                    "line": 8,
-                                                                                                    "column": 18
-                                                                                                }
-                                                                                            },
-                                                                                            "range": [
-                                                                                                77,
-                                                                                                81
-                                                                                            ],
-                                                                                            "raw": "four"
-                                                                                        }
-                                                                                    ],
-                                                                                    "loc": {
-                                                                                        "start": {
-                                                                                            "line": 8,
-                                                                                            "column": 14
-                                                                                        },
-                                                                                        "end": {
-                                                                                            "line": 8,
-                                                                                            "column": 18
-                                                                                        }
-                                                                                    },
-                                                                                    "range": [
-                                                                                        77,
-                                                                                        81
-                                                                                    ],
-                                                                                    "raw": "four"
-                                                                                }
-                                                                            ],
-                                                                            "loc": {
-                                                                                "start": {
-                                                                                    "line": 8,
-                                                                                    "column": 10
-                                                                                },
-                                                                                "end": {
-                                                                                    "line": 8,
-                                                                                    "column": 18
-                                                                                }
-                                                                            },
-                                                                            "range": [
-                                                                                73,
-                                                                                81
-                                                                            ],
-                                                                            "raw": "  - four"
-                                                                        },
-                                                                        {
-                                                                            "type": "ListItem",
-                                                                            "loose": false,
-                                                                            "checked": null,
-                                                                            "children": [
-                                                                                {
-                                                                                    "type": "Paragraph",
-                                                                                    "children": [
-                                                                                        {
-                                                                                            "type": "Str",
-                                                                                            "value": "five",
-                                                                                            "loc": {
-                                                                                                "start": {
-                                                                                                    "line": 9,
-                                                                                                    "column": 14
-                                                                                                },
-                                                                                                "end": {
-                                                                                                    "line": 9,
-                                                                                                    "column": 18
-                                                                                                }
-                                                                                            },
-                                                                                            "range": [
-                                                                                                96,
-                                                                                                100
-                                                                                            ],
-                                                                                            "raw": "five"
-                                                                                        }
-                                                                                    ],
-                                                                                    "loc": {
-                                                                                        "start": {
-                                                                                            "line": 9,
-                                                                                            "column": 14
-                                                                                        },
-                                                                                        "end": {
-                                                                                            "line": 9,
-                                                                                            "column": 18
-                                                                                        }
-                                                                                    },
-                                                                                    "range": [
-                                                                                        96,
-                                                                                        100
-                                                                                    ],
-                                                                                    "raw": "five"
-                                                                                }
-                                                                            ],
-                                                                            "loc": {
-                                                                                "start": {
-                                                                                    "line": 9,
-                                                                                    "column": 10
-                                                                                },
-                                                                                "end": {
-                                                                                    "line": 9,
-                                                                                    "column": 18
-                                                                                }
-                                                                            },
-                                                                            "range": [
-                                                                                92,
-                                                                                100
-                                                                            ],
-                                                                            "raw": "  - five"
-                                                                        }
-                                                                    ],
-                                                                    "loc": {
-                                                                        "start": {
-                                                                            "line": 7,
-                                                                            "column": 10
-                                                                        },
-                                                                        "end": {
-                                                                            "line": 9,
-                                                                            "column": 18
-                                                                        }
-                                                                    },
-                                                                    "range": [
-                                                                        53,
-                                                                        100
-                                                                    ],
-                                                                    "raw": "  - three\n            - four\n            - five"
-                                                                }
-                                                            ],
-                                                            "loc": {
-                                                                "start": {
-                                                                    "line": 6,
-                                                                    "column": 6
-                                                                },
-                                                                "end": {
-                                                                    "line": 9,
-                                                                    "column": 18
-                                                                }
-                                                            },
-                                                            "range": [
-                                                                35,
-                                                                100
-                                                            ],
-                                                            "raw": "  - two\n            - three\n            - four\n            - five"
-                                                        }
-                                                    ],
-                                                    "loc": {
-                                                        "start": {
-                                                            "line": 6,
-                                                            "column": 6
-                                                        },
-                                                        "end": {
-                                                            "line": 9,
-                                                            "column": 18
-                                                        }
-                                                    },
-                                                    "range": [
-                                                        35,
-                                                        100
-                                                    ],
-                                                    "raw": "  - two\n            - three\n            - four\n            - five"
                                                 }
                                             ],
                                             "loc": {
@@ -441,15 +151,15 @@
                                                     "column": 6
                                                 },
                                                 "end": {
-                                                    "line": 9,
-                                                    "column": 18
+                                                    "line": 5,
+                                                    "column": 11
                                                 }
                                             },
                                             "range": [
                                                 23,
-                                                100
+                                                28
                                             ],
-                                            "raw": "- one\n        - two\n            - three\n            - four\n            - five"
+                                            "raw": "- one"
                                         }
                                     ],
                                     "loc": {
@@ -458,15 +168,15 @@
                                             "column": 6
                                         },
                                         "end": {
-                                            "line": 9,
-                                            "column": 18
+                                            "line": 5,
+                                            "column": 11
                                         }
                                     },
                                     "range": [
                                         23,
-                                        100
+                                        28
                                     ],
-                                    "raw": "- one\n        - two\n            - three\n            - four\n            - five"
+                                    "raw": "- one"
                                 }
                             ],
                             "loc": {
@@ -475,15 +185,36 @@
                                     "column": 4
                                 },
                                 "end": {
+                                    "line": 5,
+                                    "column": 11
+                                }
+                            },
+                            "range": [
+                                21,
+                                28
+                            ],
+                            "raw": "> - one"
+                        },
+                        {
+                            "type": "CodeBlock",
+                            "lang": null,
+                            "meta": null,
+                            "value": " - two\n     - three\n     - four\n     - five",
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 3
+                                },
+                                "end": {
                                     "line": 9,
                                     "column": 18
                                 }
                             },
                             "range": [
-                                21,
+                                32,
                                 100
                             ],
-                            "raw": "> - one\n        - two\n            - three\n            - four\n            - five"
+                            "raw": "     - two\n            - three\n            - four\n            - five"
                         }
                     ],
                     "loc": {
@@ -492,19 +223,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 10,
-                            "column": 0
+                            "line": 9,
+                            "column": 18
                         }
                     },
                     "range": [
                         8,
-                        101
+                        100
                     ],
-                    "raw": "1. bar:\n\n    > - one\n        - two\n            - three\n            - four\n            - five\n"
+                    "raw": "1. bar:\n\n    > - one\n        - two\n            - three\n            - four\n            - five"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -549,6 +280,7 @@
                         {
                             "type": "CodeBlock",
                             "lang": null,
+                            "meta": null,
                             "value": "line 1\nline 2",
                             "loc": {
                                 "start": {
@@ -573,19 +305,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 17,
-                            "column": 0
+                            "line": 16,
+                            "column": 7
                         }
                     },
                     "range": [
                         102,
-                        149
+                        148
                     ],
-                    "raw": "1. foo:\n\n    ```\n    line 1\n    line 2\n    ```\n"
+                    "raw": "1. foo:\n\n    ```\n    line 1\n    line 2\n    ```"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -631,11 +363,11 @@
                             "type": "List",
                             "ordered": true,
                             "start": 1,
-                            "loose": true,
+                            "spread": true,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": true,
+                                    "spread": true,
                                     "checked": null,
                                     "children": [
                                         {
@@ -718,6 +450,7 @@
                                         {
                                             "type": "CodeBlock",
                                             "lang": "erb",
+                                            "meta": null,
                                             "value": "some code here",
                                             "loc": {
                                                 "start": {
@@ -742,19 +475,19 @@
                                             "column": 4
                                         },
                                         "end": {
-                                            "line": 25,
-                                            "column": 0
+                                            "line": 24,
+                                            "column": 11
                                         }
                                     },
                                     "range": [
                                         163,
-                                        233
+                                        232
                                     ],
-                                    "raw": "1. foo `bar` bar:\n\n        ``` erb\n        some code here\n        ```\n"
+                                    "raw": "1. foo `bar` bar:\n\n        ``` erb\n        some code here\n        ```"
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": true,
+                                    "spread": true,
                                     "checked": null,
                                     "children": [
                                         {
@@ -837,6 +570,7 @@
                                         {
                                             "type": "CodeBlock",
                                             "lang": "erb",
+                                            "meta": null,
                                             "value": "foo\n---\nbar\n---\nfoo\nbar",
                                             "loc": {
                                                 "start": {
@@ -861,19 +595,19 @@
                                             "column": 4
                                         },
                                         "end": {
-                                            "line": 36,
-                                            "column": 0
+                                            "line": 35,
+                                            "column": 11
                                         }
                                     },
                                     "range": [
                                         238,
-                                        357
+                                        356
                                     ],
-                                    "raw": "2. foo `bar` bar:\n\n        ``` erb\n        foo\n        ---\n        bar\n        ---\n        foo\n        bar\n        ```\n"
+                                    "raw": "2. foo `bar` bar:\n\n        ``` erb\n        foo\n        ---\n        bar\n        ---\n        foo\n        bar\n        ```"
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": true,
+                                    "spread": true,
                                     "checked": null,
                                     "children": [
                                         {
@@ -956,6 +690,7 @@
                                         {
                                             "type": "CodeBlock",
                                             "lang": "html",
+                                            "meta": null,
                                             "value": "---\nfoo\nfoo\n---\nbar",
                                             "loc": {
                                                 "start": {
@@ -980,19 +715,19 @@
                                             "column": 4
                                         },
                                         "end": {
-                                            "line": 46,
-                                            "column": 0
+                                            "line": 45,
+                                            "column": 11
                                         }
                                     },
                                     "range": [
                                         362,
-                                        470
+                                        469
                                     ],
-                                    "raw": "3. foo `bar` bar:\n\n        ``` html\n        ---\n        foo\n        foo\n        ---\n        bar\n        ```\n"
+                                    "raw": "3. foo `bar` bar:\n\n        ``` html\n        ---\n        foo\n        foo\n        ---\n        bar\n        ```"
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": true,
+                                    "spread": true,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1075,11 +810,12 @@
                                         {
                                             "type": "CodeBlock",
                                             "lang": null,
-                                            "value": "foo\n---\nbar",
+                                            "meta": null,
+                                            "value": " foo\n ---\n bar",
                                             "loc": {
                                                 "start": {
                                                     "line": 49,
-                                                    "column": 8
+                                                    "column": 7
                                                 },
                                                 "end": {
                                                     "line": 51,
@@ -1087,10 +823,10 @@
                                                 }
                                             },
                                             "range": [
-                                                502,
+                                                501,
                                                 541
                                             ],
-                                            "raw": "    foo\n            ---\n            bar"
+                                            "raw": "     foo\n            ---\n            bar"
                                         }
                                     ],
                                     "loc": {
@@ -1099,19 +835,19 @@
                                             "column": 4
                                         },
                                         "end": {
-                                            "line": 52,
-                                            "column": 0
+                                            "line": 51,
+                                            "column": 15
                                         }
                                     },
                                     "range": [
                                         475,
-                                        542
+                                        541
                                     ],
-                                    "raw": "4. foo `bar` bar:\n\n            foo\n            ---\n            bar\n"
+                                    "raw": "4. foo `bar` bar:\n\n            foo\n            ---\n            bar"
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/loose-lists.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/loose-lists.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -109,7 +109,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -228,11 +228,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -278,11 +278,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": true,
+                            "spread": true,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": true,
+                                    "spread": true,
                                     "checked": null,
                                     "children": [
                                         {
@@ -370,19 +370,19 @@
                                             "column": 2
                                         },
                                         "end": {
-                                            "line": 18,
-                                            "column": 0
+                                            "line": 17,
+                                            "column": 7
                                         }
                                     },
                                     "range": [
                                         66,
-                                        99
+                                        98
                                     ],
-                                    "raw": "* world\n    how\n\n    are\n    you\n"
+                                    "raw": "* world\n    how\n\n    are\n    you"
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -477,7 +477,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -535,33 +535,10 @@
                         114
                     ],
                     "raw": "* hi"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 12,
-                    "column": 0
                 },
-                "end": {
-                    "line": 20,
-                    "column": 4
-                }
-            },
-            "range": [
-                56,
-                114
-            ],
-            "raw": "* hello\n  * world\n    how\n\n    are\n    you\n\n  * today\n* hi"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": true,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -610,19 +587,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 25,
-                            "column": 0
+                            "line": 24,
+                            "column": 7
                         }
                     },
                     "range": [
                         118,
-                        126
+                        125
                     ],
-                    "raw": "* hello\n"
+                    "raw": "* hello"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -683,7 +660,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -741,33 +718,10 @@
                         139
                     ],
                     "raw": "* hi"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 24,
-                    "column": 0
                 },
-                "end": {
-                    "line": 27,
-                    "column": 4
-                }
-            },
-            "range": [
-                118,
-                139
-            ],
-            "raw": "* hello\n\n* world\n* hi"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": true,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -828,7 +782,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -877,19 +831,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 33,
-                            "column": 0
+                            "line": 32,
+                            "column": 7
                         }
                     },
                     "range": [
                         151,
-                        159
+                        158
                     ],
-                    "raw": "* world\n"
+                    "raw": "* world"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -947,33 +901,10 @@
                         164
                     ],
                     "raw": "* hi"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 31,
-                    "column": 0
                 },
-                "end": {
-                    "line": 34,
-                    "column": 4
-                }
-            },
-            "range": [
-                143,
-                164
-            ],
-            "raw": "* hello\n* world\n\n* hi"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": true,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1034,7 +965,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -1134,7 +1065,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1192,33 +1123,10 @@
                         195
                     ],
                     "raw": "* hi"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 38,
-                    "column": 0
                 },
-                "end": {
-                    "line": 42,
-                    "column": 4
-                }
-            },
-            "range": [
-                168,
-                195
-            ],
-            "raw": "* hello\n* world\n\n  how\n* hi"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": false,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1279,7 +1187,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1340,7 +1248,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1398,33 +1306,10 @@
                         226
                     ],
                     "raw": "* how\n  are"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 46,
-                    "column": 0
                 },
-                "end": {
-                    "line": 49,
-                    "column": 5
-                }
-            },
-            "range": [
-                199,
-                226
-            ],
-            "raw": "* hello\n* world\n* how\n  are"
-        },
-        {
-            "type": "List",
-            "ordered": false,
-            "start": null,
-            "loose": true,
-            "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1485,7 +1370,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1534,19 +1419,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 55,
-                            "column": 0
+                            "line": 54,
+                            "column": 7
                         }
                     },
                     "range": [
                         238,
-                        246
+                        245
                     ],
-                    "raw": "* world\n"
+                    "raw": "* world"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1608,7 +1493,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 53,
+                    "line": 12,
                     "column": 0
                 },
                 "end": {
@@ -1617,10 +1502,10 @@
                 }
             },
             "range": [
-                230,
+                56,
                 258
             ],
-            "raw": "* hello\n* world\n\n* how\n  are"
+            "raw": "* hello\n  * world\n    how\n\n    are\n    you\n\n  * today\n* hi\n\n\n\n* hello\n\n* world\n* hi\n\n\n\n* hello\n* world\n\n* hi\n\n\n\n* hello\n* world\n\n  how\n* hi\n\n\n\n* hello\n* world\n* how\n  are\n\n\n\n* hello\n* world\n\n* how\n  are"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/main.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/main.text/output.json
@@ -4,6 +4,7 @@
         {
             "type": "Definition",
             "identifier": "test",
+            "label": "test",
             "title": "Google",
             "url": "http://google.com/",
             "loc": {
@@ -86,8 +87,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "test",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -109,6 +108,9 @@
                             "raw": "inconsistent"
                         }
                     ],
+                    "identifier": "test",
+                    "label": "test",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -223,11 +225,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -276,19 +278,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 15,
-                            "column": 0
+                            "line": 14,
+                            "column": 13
                         }
                     },
                     "range": [
                         415,
-                        429
+                        428
                     ],
-                    "raw": "* List Item 1\n"
+                    "raw": "* List Item 1"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -334,11 +336,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -399,7 +401,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -407,7 +409,7 @@
                                             "children": [
                                                 {
                                                     "type": "Str",
-                                                    "value": "New List Item 2\nAnother item\n    Code goes here.\n    Lots of it...",
+                                                    "value": "New List Item 2\nAnother item\nCode goes here.\nLots of it...",
                                                     "loc": {
                                                         "start": {
                                                             "line": 19,
@@ -460,7 +462,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -543,19 +545,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 25,
-                            "column": 0
+                            "line": 24,
+                            "column": 17
                         }
                     },
                     "range": [
                         430,
-                        614
+                        613
                     ],
-                    "raw": "* List Item 2\n  * New List Item 1\n    Hi, this is a list item.\n  * New List Item 2\n    Another item\n        Code goes here.\n        Lots of it...\n  * New List Item 3\n    The last item\n"
+                    "raw": "* List Item 2\n  * New List Item 1\n    Hi, this is a list item.\n  * New List Item 2\n    Another item\n        Code goes here.\n        Lots of it...\n  * New List Item 3\n    The last item"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -563,22 +565,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "List Item 3\nThe final item.",
+                                    "value": "List Item 3",
                                     "loc": {
                                         "start": {
                                             "line": 26,
                                             "column": 2
                                         },
                                         "end": {
-                                            "line": 27,
-                                            "column": 15
+                                            "line": 26,
+                                            "column": 13
                                         }
                                     },
                                     "range": [
                                         617,
-                                        644
+                                        628
                                     ],
-                                    "raw": "List Item 3\nThe final item."
+                                    "raw": "List Item 3"
                                 }
                             ],
                             "loc": {
@@ -587,15 +589,15 @@
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 27,
-                                    "column": 15
+                                    "line": 26,
+                                    "column": 13
                                 }
                             },
                             "range": [
                                 617,
-                                644
+                                628
                             ],
-                            "raw": "List Item 3\nThe final item."
+                            "raw": "List Item 3"
                         }
                     ],
                     "loc": {
@@ -604,76 +606,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 28,
-                            "column": 0
+                            "line": 26,
+                            "column": 13
                         }
                     },
                     "range": [
                         615,
-                        645
+                        628
                     ],
-                    "raw": "* List Item 3\nThe final item.\n"
-                },
-                {
-                    "type": "ListItem",
-                    "loose": false,
-                    "checked": null,
-                    "children": [
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "Str",
-                                    "value": "List Item 4\nThe real final item.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 29,
-                                            "column": 2
-                                        },
-                                        "end": {
-                                            "line": 30,
-                                            "column": 20
-                                        }
-                                    },
-                                    "range": [
-                                        648,
-                                        680
-                                    ],
-                                    "raw": "List Item 4\nThe real final item."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 29,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 30,
-                                    "column": 20
-                                }
-                            },
-                            "range": [
-                                648,
-                                680
-                            ],
-                            "raw": "List Item 4\nThe real final item."
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 29,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 30,
-                            "column": 20
-                        }
-                    },
-                    "range": [
-                        646,
-                        680
-                    ],
-                    "raw": "* List Item 4\nThe real final item."
+                    "raw": "* List Item 3"
                 }
             ],
             "loc": {
@@ -682,15 +623,177 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 26,
+                    "column": 13
+                }
+            },
+            "range": [
+                415,
+                628
+            ],
+            "raw": "* List Item 1\n\n* List Item 2\n  * New List Item 1\n    Hi, this is a list item.\n  * New List Item 2\n    Another item\n        Code goes here.\n        Lots of it...\n  * New List Item 3\n    The last item\n\n* List Item 3"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "The final item.",
+                    "loc": {
+                        "start": {
+                            "line": 27,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 27,
+                            "column": 15
+                        }
+                    },
+                    "range": [
+                        629,
+                        644
+                    ],
+                    "raw": "The final item."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 15
+                }
+            },
+            "range": [
+                629,
+                644
+            ],
+            "raw": "The final item."
+        },
+        {
+            "type": "List",
+            "ordered": false,
+            "start": null,
+            "spread": false,
+            "children": [
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "List Item 4",
+                                    "loc": {
+                                        "start": {
+                                            "line": 29,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 29,
+                                            "column": 13
+                                        }
+                                    },
+                                    "range": [
+                                        648,
+                                        659
+                                    ],
+                                    "raw": "List Item 4"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 29,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 13
+                                }
+                            },
+                            "range": [
+                                648,
+                                659
+                            ],
+                            "raw": "List Item 4"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 29,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 29,
+                            "column": 13
+                        }
+                    },
+                    "range": [
+                        646,
+                        659
+                    ],
+                    "raw": "* List Item 4"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 0
+                },
+                "end": {
+                    "line": 29,
+                    "column": 13
+                }
+            },
+            "range": [
+                646,
+                659
+            ],
+            "raw": "* List Item 4"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "The real final item.",
+                    "loc": {
+                        "start": {
+                            "line": 30,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 30,
+                            "column": 20
+                        }
+                    },
+                    "range": [
+                        660,
+                        680
+                    ],
+                    "raw": "The real final item."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 0
+                },
+                "end": {
                     "line": 30,
                     "column": 20
                 }
             },
             "range": [
-                415,
+                660,
                 680
             ],
-            "raw": "* List Item 1\n\n* List Item 2\n  * New List Item 1\n    Hi, this is a list item.\n  * New List Item 2\n    Another item\n        Code goes here.\n        Lots of it...\n  * New List Item 3\n    The last item\n\n* List Item 3\nThe final item.\n\n* List Item 4\nThe real final item."
+            "raw": "The real final item."
         },
         {
             "type": "Paragraph",
@@ -738,11 +841,11 @@
                     "type": "List",
                     "ordered": false,
                     "start": null,
-                    "loose": false,
+                    "spread": false,
                     "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -803,7 +906,7 @@
                         },
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -849,11 +952,11 @@
                                     "type": "List",
                                     "ordered": false,
                                     "start": null,
-                                    "loose": false,
+                                    "spread": false,
                                     "children": [
                                         {
                                             "type": "ListItem",
-                                            "loose": false,
+                                            "spread": false,
                                             "checked": null,
                                             "children": [
                                                 {
@@ -914,7 +1017,7 @@
                                         },
                                         {
                                             "type": "ListItem",
-                                            "loose": false,
+                                            "spread": false,
                                             "checked": null,
                                             "children": [
                                                 {
@@ -922,22 +1025,22 @@
                                                     "children": [
                                                         {
                                                             "type": "Str",
-                                                            "value": "New bq Item 2\nText here",
+                                                            "value": "New bq Item 2",
                                                             "loc": {
                                                                 "start": {
                                                                     "line": 37,
                                                                     "column": 6
                                                                 },
                                                                 "end": {
-                                                                    "line": 38,
-                                                                    "column": 13
+                                                                    "line": 37,
+                                                                    "column": 19
                                                                 }
                                                             },
                                                             "range": [
                                                                 748,
-                                                                775
+                                                                761
                                                             ],
-                                                            "raw": "New bq Item 2\n>   Text here"
+                                                            "raw": "New bq Item 2"
                                                         }
                                                     ],
                                                     "loc": {
@@ -946,15 +1049,15 @@
                                                             "column": 6
                                                         },
                                                         "end": {
-                                                            "line": 38,
-                                                            "column": 13
+                                                            "line": 37,
+                                                            "column": 19
                                                         }
                                                     },
                                                     "range": [
                                                         748,
-                                                        775
+                                                        761
                                                     ],
-                                                    "raw": "New bq Item 2\n>   Text here"
+                                                    "raw": "New bq Item 2"
                                                 }
                                             ],
                                             "loc": {
@@ -963,15 +1066,15 @@
                                                     "column": 4
                                                 },
                                                 "end": {
-                                                    "line": 38,
-                                                    "column": 13
+                                                    "line": 37,
+                                                    "column": 19
                                                 }
                                             },
                                             "range": [
                                                 746,
-                                                775
+                                                761
                                             ],
-                                            "raw": "* New bq Item 2\n>   Text here"
+                                            "raw": "* New bq Item 2"
                                         }
                                     ],
                                     "loc": {
@@ -980,15 +1083,54 @@
                                             "column": 4
                                         },
                                         "end": {
+                                            "line": 37,
+                                            "column": 19
+                                        }
+                                    },
+                                    "range": [
+                                        726,
+                                        761
+                                    ],
+                                    "raw": "* New bq Item 1\n>   * New bq Item 2"
+                                },
+                                {
+                                    "type": "Paragraph",
+                                    "children": [
+                                        {
+                                            "type": "Str",
+                                            "value": "Text here",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 38,
+                                                    "column": 4
+                                                },
+                                                "end": {
+                                                    "line": 38,
+                                                    "column": 13
+                                                }
+                                            },
+                                            "range": [
+                                                766,
+                                                775
+                                            ],
+                                            "raw": "Text here"
+                                        }
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 38,
+                                            "column": 4
+                                        },
+                                        "end": {
                                             "line": 38,
                                             "column": 13
                                         }
                                     },
                                     "range": [
-                                        726,
+                                        766,
                                         775
                                     ],
-                                    "raw": "* New bq Item 1\n>   * New bq Item 2\n>   Text here"
+                                    "raw": "Text here"
                                 }
                             ],
                             "loc": {
@@ -1342,7 +1484,7 @@
                     "type": "Image",
                     "title": null,
                     "url": "src",
-                    "alt": null,
+                    "alt": "",
                     "loc": {
                         "start": {
                             "line": 53,
@@ -1398,6 +1540,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Code goes here.\nLots of it...",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/markdown-documentation-basics.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/markdown-documentation-basics.text/output.json
@@ -105,7 +105,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This page offers a brief overview of what it's like to use Markdown.\nThe ",
+                    "value": "This page offers a brief overview of what it's like to use Markdown.\nThe [syntax page] ",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -113,44 +113,45 @@
                         },
                         "end": {
                             "line": 17,
-                            "column": 4
+                            "column": 18
                         }
                     },
                     "range": [
                         610,
-                        683
+                        697
                     ],
-                    "raw": "This page offers a brief overview of what it's like to use Markdown.\nThe "
+                    "raw": "This page offers a brief overview of what it's like to use Markdown.\nThe [syntax page] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "s",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "syntax page",
+                            "value": "s",
                             "loc": {
                                 "start": {
                                     "line": 17,
-                                    "column": 5
+                                    "column": 19
                                 },
                                 "end": {
                                     "line": 17,
-                                    "column": 16
+                                    "column": 20
                                 }
                             },
                             "range": [
-                                684,
-                                695
+                                698,
+                                699
                             ],
-                            "raw": "syntax page"
+                            "raw": "s"
                         }
                     ],
+                    "identifier": "s",
+                    "label": "s",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 17,
-                            "column": 4
+                            "column": 18
                         },
                         "end": {
                             "line": 17,
@@ -158,10 +159,10 @@
                         }
                     },
                     "range": [
-                        683,
+                        697,
                         700
                     ],
-                    "raw": "[syntax page] [s]"
+                    "raw": "[s]"
                 },
                 {
                     "type": "Str",
@@ -204,7 +205,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "It's also helpful to simply try Markdown out; the ",
+                    "value": "It's also helpful to simply try Markdown out; the [Dingus] ",
                     "loc": {
                         "start": {
                             "line": 23,
@@ -212,44 +213,45 @@
                         },
                         "end": {
                             "line": 23,
-                            "column": 50
+                            "column": 59
                         }
                     },
                     "range": [
                         988,
-                        1038
+                        1047
                     ],
-                    "raw": "It's also helpful to simply try Markdown out; the "
+                    "raw": "It's also helpful to simply try Markdown out; the [Dingus] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "d",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Dingus",
+                            "value": "d",
                             "loc": {
                                 "start": {
                                     "line": 23,
-                                    "column": 51
+                                    "column": 60
                                 },
                                 "end": {
                                     "line": 23,
-                                    "column": 57
+                                    "column": 61
                                 }
                             },
                             "range": [
-                                1039,
-                                1045
+                                1048,
+                                1049
                             ],
-                            "raw": "Dingus"
+                            "raw": "d"
                         }
                     ],
+                    "identifier": "d",
+                    "label": "d",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 23,
-                            "column": 50
+                            "column": 59
                         },
                         "end": {
                             "line": 23,
@@ -257,10 +259,10 @@
                         }
                     },
                     "range": [
-                        1038,
+                        1047,
                         1050
                     ],
-                    "raw": "[Dingus] [d]"
+                    "raw": "[d]"
                 },
                 {
                     "type": "Str",
@@ -342,7 +344,7 @@
                 },
                 {
                     "type": "Str",
-                    "value": " This document is itself written using Markdown; you\ncan ",
+                    "value": " This document is itself written using Markdown; you\ncan [see the source for it by adding '.text' to the URL] ",
                     "loc": {
                         "start": {
                             "line": 27,
@@ -350,44 +352,45 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 4
+                            "column": 57
                         }
                     },
                     "range": [
                         1163,
-                        1220
+                        1273
                     ],
-                    "raw": " This document is itself written using Markdown; you\ncan "
+                    "raw": " This document is itself written using Markdown; you\ncan [see the source for it by adding '.text' to the URL] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "src",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "see the source for it by adding '.text' to the URL",
+                            "value": "src",
                             "loc": {
                                 "start": {
                                     "line": 28,
-                                    "column": 5
+                                    "column": 58
                                 },
                                 "end": {
                                     "line": 28,
-                                    "column": 55
+                                    "column": 61
                                 }
                             },
                             "range": [
-                                1221,
-                                1271
+                                1274,
+                                1277
                             ],
-                            "raw": "see the source for it by adding '.text' to the URL"
+                            "raw": "src"
                         }
                     ],
+                    "identifier": "src",
+                    "label": "src",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 28,
-                            "column": 4
+                            "column": 57
                         },
                         "end": {
                             "line": 28,
@@ -395,10 +398,10 @@
                         }
                     },
                     "range": [
-                        1220,
+                        1273,
                         1278
                     ],
-                    "raw": "[see the source for it by adding '.text' to the URL] [src]"
+                    "raw": "[src]"
                 },
                 {
                     "type": "Str",
@@ -439,12 +442,13 @@
         {
             "type": "Definition",
             "identifier": "s",
+            "label": "s",
             "title": "Markdown Syntax",
             "url": "/projects/markdown/syntax",
             "loc": {
                 "start": {
                     "line": 30,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 30,
@@ -452,20 +456,21 @@
                 }
             },
             "range": [
-                1281,
+                1283,
                 1332
             ],
-            "raw": "  [s]: /projects/markdown/syntax  \"Markdown Syntax\""
+            "raw": "[s]: /projects/markdown/syntax  \"Markdown Syntax\""
         },
         {
             "type": "Definition",
             "identifier": "d",
+            "label": "d",
             "title": "Markdown Dingus",
             "url": "/projects/markdown/dingus",
             "loc": {
                 "start": {
                     "line": 31,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 31,
@@ -473,20 +478,21 @@
                 }
             },
             "range": [
-                1333,
+                1335,
                 1384
             ],
-            "raw": "  [d]: /projects/markdown/dingus  \"Markdown Dingus\""
+            "raw": "[d]: /projects/markdown/dingus  \"Markdown Dingus\""
         },
         {
             "type": "Definition",
             "identifier": "src",
+            "label": "src",
             "title": null,
             "url": "/projects/markdown/basics.text",
             "loc": {
                 "start": {
                     "line": 32,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 32,
@@ -494,10 +500,10 @@
                 }
             },
             "range": [
-                1385,
+                1387,
                 1424
             ],
-            "raw": "  [src]: /projects/markdown/basics.text"
+            "raw": "[src]: /projects/markdown/basics.text"
         },
         {
             "type": "Header",
@@ -1042,6 +1048,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "A First Level Header\n====================\n\nA Second Level Header\n---------------------\n\nNow is the time for all good men to come to\nthe aid of their country. This is just a\nregular paragraph.\n\nThe quick brown fox jumped over the lazy\ndog's back.\n\n### Header 3\n\n> This is a blockquote.\n> \n> This is the second paragraph in the blockquote.\n>\n> ## This is an H2 in a blockquote",
             "loc": {
                 "start": {
@@ -1101,6 +1108,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<h1>A First Level Header</h1>\n\n<h2>A Second Level Header</h2>\n\n<p>Now is the time for all good men to come to\nthe aid of their country. This is just a\nregular paragraph.</p>\n\n<p>The quick brown fox jumped over the lazy\ndog's back.</p>\n\n<h3>Header 3</h3>\n\n<blockquote>\n    <p>This is a blockquote.</p>\n    \n    <p>This is the second paragraph in the blockquote.</p>\n    \n    <h2>This is an H2 in a blockquote</h2>\n</blockquote>",
             "loc": {
                 "start": {
@@ -1239,6 +1247,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Some of these words *are emphasized*.\nSome of these words _are emphasized also_.\n\nUse two asterisks for **strong emphasis**.\nOr, if you prefer, __use two underscores instead__.",
             "loc": {
                 "start": {
@@ -1298,6 +1307,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>Some of these words <em>are emphasized</em>.\nSome of these words <em>are emphasized also</em>.</p>\n\n<p>Use two asterisks for <strong>strong emphasis</strong>.\nOr, if you prefer, <strong>use two underscores instead</strong>.</p>",
             "loc": {
                 "start": {
@@ -1511,6 +1521,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Candy.\n*   Gum.\n*   Booze.",
             "loc": {
                 "start": {
@@ -1570,6 +1581,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "+   Candy.\n+   Gum.\n+   Booze.",
             "loc": {
                 "start": {
@@ -1629,6 +1641,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "-   Candy.\n-   Gum.\n-   Booze.",
             "loc": {
                 "start": {
@@ -1688,6 +1701,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ul>\n<li>Candy.</li>\n<li>Gum.</li>\n<li>Booze.</li>\n</ul>",
             "loc": {
                 "start": {
@@ -1747,6 +1761,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1.  Red\n2.  Green\n3.  Blue",
             "loc": {
                 "start": {
@@ -1806,6 +1821,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ol>\n<li>Red</li>\n<li>Green</li>\n<li>Blue</li>\n</ol>",
             "loc": {
                 "start": {
@@ -1903,6 +1919,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   A list item.\n\n    With multiple paragraphs.\n\n*   Another item in the list.",
             "loc": {
                 "start": {
@@ -1962,6 +1979,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ul>\n<li><p>A list item.</p>\n<p>With multiple paragraphs.</p></li>\n<li><p>Another item in the list.</p></li>\n</ul>",
             "loc": {
                 "start": {
@@ -1969,15 +1987,15 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 184,
-                    "column": 4
+                    "line": 183,
+                    "column": 9
                 }
             },
             "range": [
                 4612,
-                4751
+                4746
             ],
-            "raw": "    <ul>\n    <li><p>A list item.</p>\n    <p>With multiple paragraphs.</p></li>\n    <li><p>Another item in the list.</p></li>\n    </ul>\n    "
+            "raw": "    <ul>\n    <li><p>A list item.</p>\n    <p>With multiple paragraphs.</p></li>\n    <li><p>Another item in the list.</p></li>\n    </ul>"
         },
         {
             "type": "Header",
@@ -2216,6 +2234,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is an [example link](http://example.com/).",
             "loc": {
                 "start": {
@@ -2275,6 +2294,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>This is an <a href=\"http://example.com/\">\nexample link</a>.</p>",
             "loc": {
                 "start": {
@@ -2334,6 +2354,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is an [example link](http://example.com/ \"With a Title\").",
             "loc": {
                 "start": {
@@ -2393,6 +2414,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>This is an <a href=\"http://example.com/\" title=\"With a Title\">\nexample link</a>.</p>",
             "loc": {
                 "start": {
@@ -2452,6 +2474,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I get 10 times more traffic from [Google][1] than from\n[Yahoo][2] or [MSN][3].\n\n[1]: http://google.com/        \"Google\"\n[2]: http://search.yahoo.com/  \"Yahoo Search\"\n[3]: http://search.msn.com/    \"MSN Search\"",
             "loc": {
                 "start": {
@@ -2511,6 +2534,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>I get 10 times more traffic from <a href=\"http://google.com/\"\ntitle=\"Google\">Google</a> than from <a href=\"http://search.yahoo.com/\"\ntitle=\"Yahoo Search\">Yahoo</a> or <a href=\"http://search.msn.com/\"\ntitle=\"MSN Search\">MSN</a>.</p>",
             "loc": {
                 "start": {
@@ -2628,6 +2652,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I start my morning with a cup of coffee and\n[The New York Times][NY Times].\n\n[ny times]: http://www.nytimes.com/",
             "loc": {
                 "start": {
@@ -2687,6 +2712,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>I start my morning with a cup of coffee and\n<a href=\"http://www.nytimes.com/\">The New York Times</a>.</p>",
             "loc": {
                 "start": {
@@ -2825,6 +2851,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "![alt text](/path/to/img.jpg \"Title\")",
             "loc": {
                 "start": {
@@ -2884,6 +2911,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "![alt text][id]\n\n[id]: /path/to/img.jpg \"Title\"",
             "loc": {
                 "start": {
@@ -2943,6 +2971,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<img src=\"/path/to/img.jpg\" alt=\"alt text\" title=\"Title\" />",
             "loc": {
                 "start": {
@@ -3156,6 +3185,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I strongly recommend against using any `<blink>` tags.\n\nI wish SmartyPants used named entities like `&mdash;`\ninstead of decimal-encoded entites like `&#8212;`.",
             "loc": {
                 "start": {
@@ -3215,6 +3245,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>I strongly recommend against using any\n<code>&lt;blink&gt;</code> tags.</p>\n\n<p>I wish SmartyPants used named entities like\n<code>&amp;mdash;</code> instead of decimal-encoded\nentites like <code>&amp;#8212;</code>.</p>",
             "loc": {
                 "start": {
@@ -3427,6 +3458,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "If you want your page to validate under XHTML 1.0 Strict,\nyou've got to put paragraph tags in your blockquotes:\n\n    <blockquote>\n        <p>For example.</p>\n    </blockquote>",
             "loc": {
                 "start": {
@@ -3486,6 +3518,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>If you want your page to validate under XHTML 1.0 Strict,\nyou've got to put paragraph tags in your blockquotes:</p>\n\n<pre><code>&lt;blockquote&gt;\n    &lt;p&gt;For example.&lt;/p&gt;\n&lt;/blockquote&gt;\n</code></pre>",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/markdown-documentation-syntax.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/markdown-documentation-syntax.text/output.json
@@ -64,11 +64,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -136,11 +136,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -223,7 +223,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -306,7 +306,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -423,7 +423,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -491,11 +491,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -578,7 +578,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -661,7 +661,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -744,7 +744,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -827,7 +827,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -910,7 +910,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1027,7 +1027,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1095,11 +1095,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1182,7 +1182,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1265,7 +1265,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1348,7 +1348,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1465,7 +1465,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1533,11 +1533,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1620,7 +1620,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -1815,8 +1815,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "src",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -1838,6 +1836,9 @@
                             "raw": "see the source for it by adding '.text' to the URL"
                         }
                     ],
+                    "identifier": "src",
+                    "label": "src",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 35,
@@ -1893,12 +1894,13 @@
         {
             "type": "Definition",
             "identifier": "src",
+            "label": "src",
             "title": null,
             "url": "/projects/markdown/syntax.text",
             "loc": {
                 "start": {
                     "line": 37,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 37,
@@ -1906,10 +1908,10 @@
                 }
             },
             "range": [
-                1235,
+                1237,
                 1274
             ],
-            "raw": "  [src]: /projects/markdown/syntax.text"
+            "raw": "[src]: /projects/markdown/syntax.text"
         },
         {
             "type": "HorizontalRule",
@@ -2011,7 +2013,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Readability, however, is emphasized above all else. A Markdown-formatted\ndocument should be publishable as-is, as plain text, without looking\nlike it's been marked up with tags or formatting instructions. While\nMarkdown's syntax has been influenced by several existing text-to-HTML\nfilters -- including ",
+                    "value": "Readability, however, is emphasized above all else. A Markdown-formatted\ndocument should be publishable as-is, as plain text, without looking\nlike it's been marked up with tags or formatting instructions. While\nMarkdown's syntax has been influenced by several existing text-to-HTML\nfilters -- including [Setext] ",
                     "loc": {
                         "start": {
                             "line": 47,
@@ -2019,44 +2021,45 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 21
+                            "column": 30
                         }
                     },
                     "range": [
                         1431,
-                        1734
+                        1743
                     ],
-                    "raw": "Readability, however, is emphasized above all else. A Markdown-formatted\ndocument should be publishable as-is, as plain text, without looking\nlike it's been marked up with tags or formatting instructions. While\nMarkdown's syntax has been influenced by several existing text-to-HTML\nfilters -- including "
+                    "raw": "Readability, however, is emphasized above all else. A Markdown-formatted\ndocument should be publishable as-is, as plain text, without looking\nlike it's been marked up with tags or formatting instructions. While\nMarkdown's syntax has been influenced by several existing text-to-HTML\nfilters -- including [Setext] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Setext",
+                            "value": "1",
                             "loc": {
                                 "start": {
                                     "line": 51,
-                                    "column": 22
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 51,
-                                    "column": 28
+                                    "column": 32
                                 }
                             },
                             "range": [
-                                1735,
-                                1741
+                                1744,
+                                1745
                             ],
-                            "raw": "Setext"
+                            "raw": "1"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 21
+                            "column": 30
                         },
                         "end": {
                             "line": 51,
@@ -2064,14 +2067,14 @@
                         }
                     },
                     "range": [
-                        1734,
+                        1743,
                         1746
                     ],
-                    "raw": "[Setext] [1]"
+                    "raw": "[1]"
                 },
                 {
                     "type": "Str",
-                    "value": ", ",
+                    "value": ", [atx] ",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2079,44 +2082,45 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 35
+                            "column": 41
                         }
                     },
                     "range": [
                         1746,
-                        1748
+                        1754
                     ],
-                    "raw": ", "
+                    "raw": ", [atx] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "2",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "atx",
+                            "value": "2",
                             "loc": {
                                 "start": {
                                     "line": 51,
-                                    "column": 36
+                                    "column": 42
                                 },
                                 "end": {
                                     "line": 51,
-                                    "column": 39
+                                    "column": 43
                                 }
                             },
                             "range": [
-                                1749,
-                                1752
+                                1755,
+                                1756
                             ],
-                            "raw": "atx"
+                            "raw": "2"
                         }
                     ],
+                    "identifier": "2",
+                    "label": "2",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 35
+                            "column": 41
                         },
                         "end": {
                             "line": 51,
@@ -2124,14 +2128,14 @@
                         }
                     },
                     "range": [
-                        1748,
+                        1754,
                         1757
                     ],
-                    "raw": "[atx] [2]"
+                    "raw": "[2]"
                 },
                 {
                     "type": "Str",
-                    "value": ", ",
+                    "value": ", [Textile] ",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2139,44 +2143,45 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 46
+                            "column": 56
                         }
                     },
                     "range": [
                         1757,
-                        1759
+                        1769
                     ],
-                    "raw": ", "
+                    "raw": ", [Textile] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "3",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Textile",
+                            "value": "3",
                             "loc": {
                                 "start": {
                                     "line": 51,
-                                    "column": 47
+                                    "column": 57
                                 },
                                 "end": {
                                     "line": 51,
-                                    "column": 54
+                                    "column": 58
                                 }
                             },
                             "range": [
-                                1760,
-                                1767
+                                1770,
+                                1771
                             ],
-                            "raw": "Textile"
+                            "raw": "3"
                         }
                     ],
+                    "identifier": "3",
+                    "label": "3",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 46
+                            "column": 56
                         },
                         "end": {
                             "line": 51,
@@ -2184,14 +2189,14 @@
                         }
                     },
                     "range": [
-                        1759,
+                        1769,
                         1772
                     ],
-                    "raw": "[Textile] [3]"
+                    "raw": "[3]"
                 },
                 {
                     "type": "Str",
-                    "value": ", ",
+                    "value": ", [reStructuredText] ",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2199,44 +2204,45 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 61
+                            "column": 80
                         }
                     },
                     "range": [
                         1772,
-                        1774
+                        1793
                     ],
-                    "raw": ", "
+                    "raw": ", [reStructuredText] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "4",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "reStructuredText",
+                            "value": "4",
                             "loc": {
                                 "start": {
                                     "line": 51,
-                                    "column": 62
+                                    "column": 81
                                 },
                                 "end": {
                                     "line": 51,
-                                    "column": 78
+                                    "column": 82
                                 }
                             },
                             "range": [
-                                1775,
-                                1791
+                                1794,
+                                1795
                             ],
-                            "raw": "reStructuredText"
+                            "raw": "4"
                         }
                     ],
+                    "identifier": "4",
+                    "label": "4",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 61
+                            "column": 80
                         },
                         "end": {
                             "line": 51,
@@ -2244,14 +2250,14 @@
                         }
                     },
                     "range": [
-                        1774,
+                        1793,
                         1796
                     ],
-                    "raw": "[reStructuredText] [4]"
+                    "raw": "[4]"
                 },
                 {
                     "type": "Str",
-                    "value": ",\n",
+                    "value": ",\n[Grutatext] ",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2259,44 +2265,45 @@
                         },
                         "end": {
                             "line": 52,
-                            "column": 0
+                            "column": 12
                         }
                     },
                     "range": [
                         1796,
-                        1798
+                        1810
                     ],
-                    "raw": ",\n"
+                    "raw": ",\n[Grutatext] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "5",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Grutatext",
+                            "value": "5",
                             "loc": {
                                 "start": {
                                     "line": 52,
-                                    "column": 1
+                                    "column": 13
                                 },
                                 "end": {
                                     "line": 52,
-                                    "column": 10
+                                    "column": 14
                                 }
                             },
                             "range": [
-                                1799,
-                                1808
+                                1811,
+                                1812
                             ],
-                            "raw": "Grutatext"
+                            "raw": "5"
                         }
                     ],
+                    "identifier": "5",
+                    "label": "5",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 52,
-                            "column": 0
+                            "column": 12
                         },
                         "end": {
                             "line": 52,
@@ -2304,14 +2311,14 @@
                         }
                     },
                     "range": [
-                        1798,
+                        1810,
                         1813
                     ],
-                    "raw": "[Grutatext] [5]"
+                    "raw": "[5]"
                 },
                 {
                     "type": "Str",
-                    "value": ", and ",
+                    "value": ", and [EtText] ",
                     "loc": {
                         "start": {
                             "line": 52,
@@ -2319,44 +2326,45 @@
                         },
                         "end": {
                             "line": 52,
-                            "column": 21
+                            "column": 30
                         }
                     },
                     "range": [
                         1813,
-                        1819
+                        1828
                     ],
-                    "raw": ", and "
+                    "raw": ", and [EtText] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "6",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "EtText",
+                            "value": "6",
                             "loc": {
                                 "start": {
                                     "line": 52,
-                                    "column": 22
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 52,
-                                    "column": 28
+                                    "column": 32
                                 }
                             },
                             "range": [
-                                1820,
-                                1826
+                                1829,
+                                1830
                             ],
-                            "raw": "EtText"
+                            "raw": "6"
                         }
                     ],
+                    "identifier": "6",
+                    "label": "6",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 52,
-                            "column": 21
+                            "column": 30
                         },
                         "end": {
                             "line": 52,
@@ -2364,10 +2372,10 @@
                         }
                     },
                     "range": [
-                        1819,
+                        1828,
                         1831
                     ],
-                    "raw": "[EtText] [6]"
+                    "raw": "[6]"
                 },
                 {
                     "type": "Str",
@@ -2408,12 +2416,13 @@
         {
             "type": "Definition",
             "identifier": "1",
+            "label": "1",
             "title": null,
             "url": "http://docutils.sourceforge.net/mirror/setext.html",
             "loc": {
                 "start": {
                     "line": 55,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 55,
@@ -2421,20 +2430,21 @@
                 }
             },
             "range": [
-                1934,
+                1936,
                 1991
             ],
-            "raw": "  [1]: http://docutils.sourceforge.net/mirror/setext.html"
+            "raw": "[1]: http://docutils.sourceforge.net/mirror/setext.html"
         },
         {
             "type": "Definition",
             "identifier": "2",
+            "label": "2",
             "title": null,
             "url": "http://www.aaronsw.com/2002/atx/",
             "loc": {
                 "start": {
                     "line": 56,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 56,
@@ -2442,20 +2452,21 @@
                 }
             },
             "range": [
-                1992,
+                1994,
                 2031
             ],
-            "raw": "  [2]: http://www.aaronsw.com/2002/atx/"
+            "raw": "[2]: http://www.aaronsw.com/2002/atx/"
         },
         {
             "type": "Definition",
             "identifier": "3",
+            "label": "3",
             "title": null,
             "url": "http://textism.com/tools/textile/",
             "loc": {
                 "start": {
                     "line": 57,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 57,
@@ -2463,20 +2474,21 @@
                 }
             },
             "range": [
-                2032,
+                2034,
                 2072
             ],
-            "raw": "  [3]: http://textism.com/tools/textile/"
+            "raw": "[3]: http://textism.com/tools/textile/"
         },
         {
             "type": "Definition",
             "identifier": "4",
+            "label": "4",
             "title": null,
             "url": "http://docutils.sourceforge.net/rst.html",
             "loc": {
                 "start": {
                     "line": 58,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 58,
@@ -2484,20 +2496,21 @@
                 }
             },
             "range": [
-                2073,
+                2075,
                 2120
             ],
-            "raw": "  [4]: http://docutils.sourceforge.net/rst.html"
+            "raw": "[4]: http://docutils.sourceforge.net/rst.html"
         },
         {
             "type": "Definition",
             "identifier": "5",
+            "label": "5",
             "title": null,
             "url": "http://www.triptico.com/software/grutatxt.html",
             "loc": {
                 "start": {
                     "line": 59,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 59,
@@ -2505,20 +2518,21 @@
                 }
             },
             "range": [
-                2121,
+                2123,
                 2174
             ],
-            "raw": "  [5]: http://www.triptico.com/software/grutatxt.html"
+            "raw": "[5]: http://www.triptico.com/software/grutatxt.html"
         },
         {
             "type": "Definition",
             "identifier": "6",
+            "label": "6",
             "title": null,
             "url": "http://ettext.taint.org/doc/",
             "loc": {
                 "start": {
                     "line": 60,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 60,
@@ -2526,97 +2540,21 @@
                 }
             },
             "range": [
-                2175,
+                2177,
                 2210
             ],
-            "raw": "  [6]: http://ettext.taint.org/doc/"
+            "raw": "[6]: http://ettext.taint.org/doc/"
         },
         {
             "type": "Paragraph",
             "children": [
                 {
                     "type": "Str",
-                    "value": "To this end, Markdown's syntax is comprised entirely of punctuation\ncharacters, which punctuation characters have been carefully chosen so\nas to look like what they mean. E.g., asterisks around a word actually\nlook like ",
+                    "value": "To this end, Markdown's syntax is comprised entirely of punctuation\ncharacters, which punctuation characters have been carefully chosen so\nas to look like what they mean. E.g., asterisks around a word actually\nlook like *emphasis*. Markdown lists look like, well, lists. Even\nblockquotes look like quoted passages of text, assuming you've ever\nused email.",
                     "loc": {
                         "start": {
                             "line": 62,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 65,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        2212,
-                        2432
-                    ],
-                    "raw": "To this end, Markdown's syntax is comprised entirely of punctuation\ncharacters, which punctuation characters have been carefully chosen so\nas to look like what they mean. E.g., asterisks around a word actually\nlook like "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 65,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 65,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        2432,
-                        2434
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": "emphasis",
-                    "loc": {
-                        "start": {
-                            "line": 65,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 65,
-                            "column": 20
-                        }
-                    },
-                    "range": [
-                        2434,
-                        2442
-                    ],
-                    "raw": "emphasis"
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 65,
-                            "column": 20
-                        },
-                        "end": {
-                            "line": 65,
-                            "column": 22
-                        }
-                    },
-                    "range": [
-                        2442,
-                        2444
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": ". Markdown lists look like, well, lists. Even\nblockquotes look like quoted passages of text, assuming you've ever\nused email.",
-                    "loc": {
-                        "start": {
-                            "line": 65,
-                            "column": 22
                         },
                         "end": {
                             "line": 67,
@@ -2624,10 +2562,10 @@
                         }
                     },
                     "range": [
-                        2444,
+                        2212,
                         2569
                     ],
-                    "raw": ". Markdown lists look like, well, lists. Even\nblockquotes look like quoted passages of text, assuming you've ever\nused email."
+                    "raw": "To this end, Markdown's syntax is comprised entirely of punctuation\ncharacters, which punctuation characters have been carefully chosen so\nas to look like what they mean. E.g., asterisks around a word actually\nlook like \\*emphasis\\*. Markdown lists look like, well, lists. Even\nblockquotes look like quoted passages of text, assuming you've ever\nused email."
                 }
             ],
             "loc": {
@@ -3285,6 +3223,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is a regular paragraph.\n\n<table>\n    <tr>\n        <td>Foo</td>\n    </tr>\n</table>\n\nThis is another regular paragraph.",
             "loc": {
                 "start": {
@@ -3995,6 +3934,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "http://images.google.com/images?num=30&q=larry+bird",
             "loc": {
                 "start": {
@@ -4054,6 +3994,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "http://images.google.com/images?num=30&amp;q=larry+bird",
             "loc": {
                 "start": {
@@ -4267,6 +4208,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "&copy;",
             "loc": {
                 "start": {
@@ -4326,6 +4268,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "AT&T",
             "loc": {
                 "start": {
@@ -4385,6 +4328,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "AT&amp;T",
             "loc": {
                 "start": {
@@ -4504,6 +4448,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "4 < 5",
             "loc": {
                 "start": {
@@ -4563,6 +4508,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "4 &lt; 5",
             "loc": {
                 "start": {
@@ -5160,8 +5106,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "bq",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -5183,6 +5127,9 @@
                             "raw": "blockquoting"
                         }
                     ],
+                    "identifier": "bq",
+                    "label": "bq",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 201,
@@ -5220,8 +5167,6 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "l",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -5243,6 +5188,9 @@
                             "raw": "list items"
                         }
                     ],
+                    "identifier": "l",
+                    "label": "l",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 201,
@@ -5298,12 +5246,13 @@
         {
             "type": "Definition",
             "identifier": "bq",
+            "label": "bq",
             "title": null,
             "url": "#blockquote",
             "loc": {
                 "start": {
                     "line": 204,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 204,
@@ -5311,20 +5260,21 @@
                 }
             },
             "range": [
-                7526,
+                7528,
                 7545
             ],
-            "raw": "  [bq]: #blockquote"
+            "raw": "[bq]: #blockquote"
         },
         {
             "type": "Definition",
             "identifier": "l",
+            "label": "l",
             "title": null,
             "url": "#list",
             "loc": {
                 "start": {
                     "line": 205,
-                    "column": 0
+                    "column": 2
                 },
                 "end": {
                     "line": 205,
@@ -5332,10 +5282,10 @@
                 }
             },
             "range": [
-                7546,
+                7548,
                 7559
             ],
-            "raw": "  [l]:  #list"
+            "raw": "[l]:  #list"
         },
         {
             "type": "Html",
@@ -5361,7 +5311,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Markdown supports two styles of headers, ",
+                    "value": "Markdown supports two styles of headers, [Setext] ",
                     "loc": {
                         "start": {
                             "line": 211,
@@ -5369,44 +5319,45 @@
                         },
                         "end": {
                             "line": 211,
-                            "column": 41
+                            "column": 50
                         }
                     },
                     "range": [
                         7593,
-                        7634
+                        7643
                     ],
-                    "raw": "Markdown supports two styles of headers, "
+                    "raw": "Markdown supports two styles of headers, [Setext] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "1",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "Setext",
+                            "value": "1",
                             "loc": {
                                 "start": {
                                     "line": 211,
-                                    "column": 42
+                                    "column": 51
                                 },
                                 "end": {
                                     "line": 211,
-                                    "column": 48
+                                    "column": 52
                                 }
                             },
                             "range": [
-                                7635,
-                                7641
+                                7644,
+                                7645
                             ],
-                            "raw": "Setext"
+                            "raw": "1"
                         }
                     ],
+                    "identifier": "1",
+                    "label": "1",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 211,
-                            "column": 41
+                            "column": 50
                         },
                         "end": {
                             "line": 211,
@@ -5414,14 +5365,14 @@
                         }
                     },
                     "range": [
-                        7634,
+                        7643,
                         7646
                     ],
-                    "raw": "[Setext] [1]"
+                    "raw": "[1]"
                 },
                 {
                     "type": "Str",
-                    "value": " and ",
+                    "value": " and [atx] ",
                     "loc": {
                         "start": {
                             "line": 211,
@@ -5429,44 +5380,45 @@
                         },
                         "end": {
                             "line": 211,
-                            "column": 58
+                            "column": 64
                         }
                     },
                     "range": [
                         7646,
-                        7651
+                        7657
                     ],
-                    "raw": " and "
+                    "raw": " and [atx] "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "2",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "atx",
+                            "value": "2",
                             "loc": {
                                 "start": {
                                     "line": 211,
-                                    "column": 59
+                                    "column": 65
                                 },
                                 "end": {
                                     "line": 211,
-                                    "column": 62
+                                    "column": 66
                                 }
                             },
                             "range": [
-                                7652,
-                                7655
+                                7658,
+                                7659
                             ],
-                            "raw": "atx"
+                            "raw": "2"
                         }
                     ],
+                    "identifier": "2",
+                    "label": "2",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 211,
-                            "column": 58
+                            "column": 64
                         },
                         "end": {
                             "line": 211,
@@ -5474,10 +5426,10 @@
                         }
                     },
                     "range": [
-                        7651,
+                        7657,
                         7660
                     ],
-                    "raw": "[atx] [2]"
+                    "raw": "[2]"
                 },
                 {
                     "type": "Str",
@@ -5557,6 +5509,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is an H1\n=============\n\nThis is an H2\n-------------",
             "loc": {
                 "start": {
@@ -5731,6 +5684,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "# This is an H1\n\n## This is an H2\n\n###### This is an H6",
             "loc": {
                 "start": {
@@ -5790,6 +5744,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "# This is an H1 #\n\n## This is an H2 ##\n\n### This is an H3 ######",
             "loc": {
                 "start": {
@@ -5944,6 +5899,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,\n> consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.\n> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.\n> \n> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse\n> id sem consectetuer libero luctus adipiscing.",
             "loc": {
                 "start": {
@@ -6041,6 +5997,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "> This is a blockquote with two paragraphs. Lorem ipsum dolor sit amet,\nconsectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.\nVestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.\n\n> Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse\nid sem consectetuer libero luctus adipiscing.",
             "loc": {
                 "start": {
@@ -6138,6 +6095,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "> This is the first level of quoting.\n>\n> > This is nested blockquote.\n>\n> Back to the first level.",
             "loc": {
                 "start": {
@@ -6197,6 +6155,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "> ## This is a header.\n> \n> 1.   This is the first list item.\n> 2.   This is the second list item.\n> \n> Here's some example code:\n> \n>     return shell_exec(\"echo $input | $markdown_script\");",
             "loc": {
                 "start": {
@@ -6353,6 +6312,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Red\n*   Green\n*   Blue",
             "loc": {
                 "start": {
@@ -6412,6 +6372,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "+   Red\n+   Green\n+   Blue",
             "loc": {
                 "start": {
@@ -6471,6 +6432,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "-   Red\n-   Green\n-   Blue",
             "loc": {
                 "start": {
@@ -6530,6 +6492,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1.  Bird\n2.  McHale\n3.  Parish",
             "loc": {
                 "start": {
@@ -6589,6 +6552,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ol>\n<li>Bird</li>\n<li>McHale</li>\n<li>Parish</li>\n</ol>",
             "loc": {
                 "start": {
@@ -6648,6 +6612,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1.  Bird\n1.  McHale\n1.  Parish",
             "loc": {
                 "start": {
@@ -6707,6 +6672,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "3. Bird\n1. McHale\n8. Parish",
             "loc": {
                 "start": {
@@ -6883,6 +6849,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.\n    Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,\n    viverra nec, fringilla in, laoreet vitae, risus.\n*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.\n    Suspendisse id sem consectetuer libero luctus adipiscing.",
             "loc": {
                 "start": {
@@ -6942,6 +6909,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Lorem ipsum dolor sit amet, consectetuer adipiscing elit.\nAliquam hendrerit mi posuere lectus. Vestibulum enim wisi,\nviverra nec, fringilla in, laoreet vitae, risus.\n*   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.\nSuspendisse id sem consectetuer libero luctus adipiscing.",
             "loc": {
                 "start": {
@@ -7039,6 +7007,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Bird\n*   Magic",
             "loc": {
                 "start": {
@@ -7098,6 +7067,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ul>\n<li>Bird</li>\n<li>Magic</li>\n</ul>",
             "loc": {
                 "start": {
@@ -7157,6 +7127,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   Bird\n\n*   Magic",
             "loc": {
                 "start": {
@@ -7216,6 +7187,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<ul>\n<li><p>Bird</p></li>\n<li><p>Magic</p></li>\n</ul>",
             "loc": {
                 "start": {
@@ -7275,6 +7247,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1.  This is a list item with two paragraphs. Lorem ipsum dolor\n    sit amet, consectetuer adipiscing elit. Aliquam hendrerit\n    mi posuere lectus.\n\n    Vestibulum enim wisi, viverra nec, fringilla in, laoreet\n    vitae, risus. Donec sit amet nisl. Aliquam semper ipsum\n    sit amet velit.\n\n2.  Suspendisse id sem consectetuer libero luctus adipiscing.",
             "loc": {
                 "start": {
@@ -7334,6 +7307,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   This is a list item with two paragraphs.\n\n    This is the second paragraph in the list item. You're\nonly required to indent the first line. Lorem ipsum dolor\nsit amet, consectetuer adipiscing elit.\n\n*   Another item in the same list.",
             "loc": {
                 "start": {
@@ -7431,6 +7405,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   A list item with a blockquote:\n\n    > This is a blockquote\n    > inside a list item.",
             "loc": {
                 "start": {
@@ -7548,6 +7523,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*   A list item with a code block:\n\n        <code goes here>",
             "loc": {
                 "start": {
@@ -7607,6 +7583,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1986. What a great season.",
             "loc": {
                 "start": {
@@ -7724,6 +7701,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "1986\\. What a great season.",
             "loc": {
                 "start": {
@@ -7917,6 +7895,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is a normal paragraph:\n\n    This is a code block.",
             "loc": {
                 "start": {
@@ -7976,6 +7955,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>This is a normal paragraph:</p>\n\n<pre><code>This is a code block.\n</code></pre>",
             "loc": {
                 "start": {
@@ -8035,6 +8015,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Here is an example of AppleScript:\n\n    tell application \"Foo\"\n        beep\n    end tell",
             "loc": {
                 "start": {
@@ -8094,6 +8075,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>Here is an example of AppleScript:</p>\n\n<pre><code>tell application \"Foo\"\n    beep\nend tell\n</code></pre>",
             "loc": {
                 "start": {
@@ -8306,6 +8288,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "    <div class=\"footer\">\n        &copy; 2004 Foo Corporation\n    </div>",
             "loc": {
                 "start": {
@@ -8365,6 +8348,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<pre><code>&lt;div class=\"footer\"&gt;\n    &amp;copy; 2004 Foo Corporation\n&lt;/div&gt;\n</code></pre>",
             "loc": {
                 "start": {
@@ -8520,6 +8504,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "* * *\n\n***\n\n*****\n\n- - -\n\n---------------------------------------\n\n_ _ _",
             "loc": {
                 "start": {
@@ -8753,7 +8738,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "In both styles, the link text is delimited by ",
+                    "value": "In both styles, the link text is delimited by [square brackets].",
                     "loc": {
                         "start": {
                             "line": 549,
@@ -8761,74 +8746,14 @@
                         },
                         "end": {
                             "line": 549,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        16752,
-                        16798
-                    ],
-                    "raw": "In both styles, the link text is delimited by "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "square brackets",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "square brackets",
-                            "loc": {
-                                "start": {
-                                    "line": 549,
-                                    "column": 47
-                                },
-                                "end": {
-                                    "line": 549,
-                                    "column": 62
-                                }
-                            },
-                            "range": [
-                                16799,
-                                16814
-                            ],
-                            "raw": "square brackets"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 549,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 549,
-                            "column": 63
-                        }
-                    },
-                    "range": [
-                        16798,
-                        16815
-                    ],
-                    "raw": "[square brackets]"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 549,
-                            "column": 63
-                        },
-                        "end": {
-                            "line": 549,
                             "column": 64
                         }
                     },
                     "range": [
-                        16815,
+                        16752,
                         16816
                     ],
-                    "raw": "."
+                    "raw": "In both styles, the link text is delimited by [square brackets]."
                 }
             ],
             "loc": {
@@ -8947,6 +8872,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is [an example](http://example.com/ \"Title\") inline link.\n\n[This link](http://example.net/) has no title attribute.",
             "loc": {
                 "start": {
@@ -9006,6 +8932,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>This is <a href=\"http://example.com/\" title=\"Title\">\nan example</a> inline link.</p>\n\n<p><a href=\"http://example.net/\">This link</a> has no\ntitle attribute.</p>",
             "loc": {
                 "start": {
@@ -9065,6 +8992,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "See my [About](/about/) page for details.",
             "loc": {
                 "start": {
@@ -9124,6 +9052,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is [an example][id] reference-style link.",
             "loc": {
                 "start": {
@@ -9183,6 +9112,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "This is [an example] [id] reference-style link.",
             "loc": {
                 "start": {
@@ -9242,6 +9172,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[id]: http://example.com/  \"Optional Title Here\"",
             "loc": {
                 "start": {
@@ -9302,11 +9233,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -9367,7 +9298,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -9428,7 +9359,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -9489,7 +9420,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -9550,7 +9481,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -9668,6 +9599,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[id]: <http://example.com/>  \"Optional Title Here\"",
             "loc": {
                 "start": {
@@ -9727,6 +9659,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[id]: http://example.com/longish/path/to/resource/here\n    \"Optional Title Here\"",
             "loc": {
                 "start": {
@@ -9883,6 +9816,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[link text][a]\n[link text][A]",
             "loc": {
                 "start": {
@@ -10039,6 +9973,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[Google][]",
             "loc": {
                 "start": {
@@ -10098,6 +10033,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[Google]: http://google.com/",
             "loc": {
                 "start": {
@@ -10157,6 +10093,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Visit [Daring Fireball][] for more information.",
             "loc": {
                 "start": {
@@ -10216,6 +10153,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[Daring Fireball]: http://daringfireball.net/",
             "loc": {
                 "start": {
@@ -10314,6 +10252,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I get 10 times more traffic from [Google] [1] than from\n[Yahoo] [2] or [MSN] [3].\n\n  [1]: http://google.com/        \"Google\"\n  [2]: http://search.yahoo.com/  \"Yahoo Search\"\n  [3]: http://search.msn.com/    \"MSN Search\"",
             "loc": {
                 "start": {
@@ -10373,6 +10312,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I get 10 times more traffic from [Google][] than from\n[Yahoo][] or [MSN][].\n\n  [google]: http://google.com/        \"Google\"\n  [yahoo]:  http://search.yahoo.com/  \"Yahoo Search\"\n  [msn]:    http://search.msn.com/    \"MSN Search\"",
             "loc": {
                 "start": {
@@ -10432,6 +10372,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>I get 10 times more traffic from <a href=\"http://google.com/\"\ntitle=\"Google\">Google</a> than from\n<a href=\"http://search.yahoo.com/\" title=\"Yahoo Search\">Yahoo</a>\nor <a href=\"http://search.msn.com/\" title=\"MSN Search\">MSN</a>.</p>",
             "loc": {
                 "start": {
@@ -10491,6 +10432,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "I get 10 times more traffic from [Google](http://google.com/ \"Google\")\nthan from [Yahoo](http://search.yahoo.com/ \"Yahoo Search\") or\n[MSN](http://search.msn.com/ \"MSN Search\").",
             "loc": {
                 "start": {
@@ -10951,6 +10893,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "*single asterisks*\n\n_single underscores_\n\n**double asterisks**\n\n__double underscores__",
             "loc": {
                 "start": {
@@ -11010,6 +10953,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<em>single asterisks</em>\n\n<em>single underscores</em>\n\n<strong>double asterisks</strong>\n\n<strong>double underscores</strong>",
             "loc": {
                 "start": {
@@ -11108,6 +11052,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "un*fucking*believable",
             "loc": {
                 "start": {
@@ -11282,6 +11227,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "\\*this text is surrounded by literal asterisks\\*",
             "loc": {
                 "start": {
@@ -11398,6 +11344,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Use the `printf()` function.",
             "loc": {
                 "start": {
@@ -11457,6 +11404,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>Use the <code>printf()</code> function.</p>",
             "loc": {
                 "start": {
@@ -11516,6 +11464,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "``There is a literal backtick (`) here.``",
             "loc": {
                 "start": {
@@ -11575,6 +11524,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p><code>There is a literal backtick (`) here.</code></p>",
             "loc": {
                 "start": {
@@ -11634,6 +11584,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "A single backtick in a code span: `` ` ``\n\nA backtick-delimited string in a code span: `` `foo` ``",
             "loc": {
                 "start": {
@@ -11693,6 +11644,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>A single backtick in a code span: <code>`</code></p>\n\n<p>A backtick-delimited string in a code span: <code>`foo`</code></p>",
             "loc": {
                 "start": {
@@ -11752,6 +11704,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Please don't use any `<blink>` tags.",
             "loc": {
                 "start": {
@@ -11811,6 +11764,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p>Please don't use any <code>&lt;blink&gt;</code> tags.</p>",
             "loc": {
                 "start": {
@@ -11870,6 +11824,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "`&#8212;` is the decimal-encoded equivalent of `&mdash;`.",
             "loc": {
                 "start": {
@@ -11929,6 +11884,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<p><code>&amp;#8212;</code> is the decimal-encoded\nequivalent of <code>&amp;mdash;</code>.</p>",
             "loc": {
                 "start": {
@@ -12201,6 +12157,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "![Alt text](/path/to/img.jpg)\n\n![Alt text](/path/to/img.jpg \"Optional title\")",
             "loc": {
                 "start": {
@@ -12261,11 +12218,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -12364,7 +12321,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -12463,7 +12420,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -12619,6 +12576,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "![Alt text][id]",
             "loc": {
                 "start": {
@@ -12678,6 +12636,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "[id]: url/to/image  \"Optional title attribute\"",
             "loc": {
                 "start": {
@@ -12870,6 +12829,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<http://example.com/>",
             "loc": {
                 "start": {
@@ -12877,15 +12837,15 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 835,
-                    "column": 4
+                    "line": 834,
+                    "column": 25
                 }
             },
             "range": [
                 25744,
-                25774
+                25769
             ],
-            "raw": "    <http://example.com/>\n    "
+            "raw": "    <http://example.com/>"
         },
         {
             "type": "Paragraph",
@@ -12929,6 +12889,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<a href=\"http://example.com/\">http://example.com/</a>",
             "loc": {
                 "start": {
@@ -12988,6 +12949,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<address@example.com>",
             "loc": {
                 "start": {
@@ -13047,6 +13009,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "<a href=\"&#x6D;&#x61;i&#x6C;&#x74;&#x6F;:&#x61;&#x64;&#x64;&#x72;&#x65;\n&#115;&#115;&#64;&#101;&#120;&#x61;&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;\n&#109;\">&#x61;&#x64;&#x64;&#x72;&#x65;&#115;&#115;&#64;&#101;&#120;&#x61;\n&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;&#109;</a>",
             "loc": {
                 "start": {
@@ -13069,7 +13032,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "which will render in a browser as a clickable link to \"address@example.com\".",
+                    "value": "which will render in a browser as a clickable link to \"",
                     "loc": {
                         "start": {
                             "line": 854,
@@ -13077,14 +13040,74 @@
                         },
                         "end": {
                             "line": 854,
-                            "column": 76
+                            "column": 55
                         }
                     },
                     "range": [
                         26446,
+                        26501
+                    ],
+                    "raw": "which will render in a browser as a clickable link to \""
+                },
+                {
+                    "type": "Link",
+                    "title": null,
+                    "url": "mailto:address@example.com",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "address@example.com",
+                            "loc": {
+                                "start": {
+                                    "line": 854,
+                                    "column": 55
+                                },
+                                "end": {
+                                    "line": 854,
+                                    "column": 74
+                                }
+                            },
+                            "range": [
+                                26501,
+                                26520
+                            ],
+                            "raw": "address@example.com"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 854,
+                            "column": 55
+                        },
+                        "end": {
+                            "line": 854,
+                            "column": 74
+                        }
+                    },
+                    "range": [
+                        26501,
+                        26520
+                    ],
+                    "raw": "address@example.com"
+                },
+                {
+                    "type": "Str",
+                    "value": "\".",
+                    "loc": {
+                        "start": {
+                            "line": 854,
+                            "column": 74
+                        },
+                        "end": {
+                            "line": 854,
+                            "column": 76
+                        }
+                    },
+                    "range": [
+                        26520,
                         26522
                     ],
-                    "raw": "which will render in a browser as a clickable link to \"address@example.com\"."
+                    "raw": "\"."
                 }
             ],
             "loc": {
@@ -13241,6 +13264,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "\\*literal asterisks\\*",
             "loc": {
                 "start": {
@@ -13300,6 +13324,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "\\   backslash\n`   backtick\n*   asterisk\n_   underscore\n{}  curly braces\n[]  square brackets\n()  parentheses\n#   hash mark\n+\tplus sign\n-\tminus sign (hyphen)\n.   dot\n!   exclamation mark",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/mixed-indentation.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/mixed-indentation.text/output.json
@@ -45,11 +45,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -57,7 +57,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "Very long\n\t\t\tparagraph",
+                                    "value": "Very long\nparagraph",
                                     "loc": {
                                         "start": {
                                             "line": 3,
@@ -129,11 +129,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -141,7 +141,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "Very long\n\tparagraph",
+                                    "value": "Very long\nparagraph",
                                     "loc": {
                                         "start": {
                                             "line": 6,
@@ -213,11 +213,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -225,7 +225,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "Very long\n\tparagraph",
+                                    "value": "Very long\nparagraph",
                                     "loc": {
                                         "start": {
                                             "line": 9,
@@ -297,11 +297,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -309,7 +309,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "Very long\n\tparagraph",
+                                    "value": "Very long\nparagraph",
                                     "loc": {
                                         "start": {
                                             "line": 12,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
@@ -332,7 +332,7 @@
                     "type": "LinkReference",
                     "children": [
                         {
-                            "type": "footnoteReference",
+                            "type": "FootnoteReference",
                             "identifier": "foo",
                             "label": "foo",
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
@@ -45,14 +45,13 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "ImageReference",
-                            "identifier": "bar",
-                            "referenceType": "full",
                             "alt": "Foo",
+                            "identifier": "bar",
+                            "label": "bar",
+                            "referenceType": "full",
                             "loc": {
                                 "start": {
                                     "line": 3,
@@ -70,6 +69,9 @@
                             "raw": "![Foo][bar]"
                         }
                     ],
+                    "identifier": "baz",
+                    "label": "baz",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -146,30 +148,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "full",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "[Foo][bar]",
-                            "loc": {
-                                "start": {
-                                    "line": 7,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 7,
-                                    "column": 11
-                                }
-                            },
-                            "range": [
-                                88,
-                                98
-                            ],
-                            "raw": "[Foo][bar]"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[",
                     "loc": {
                         "start": {
                             "line": 7,
@@ -177,14 +157,117 @@
                         },
                         "end": {
                             "line": 7,
-                            "column": 17
+                            "column": 1
                         }
                     },
                     "range": [
                         87,
+                        88
+                    ],
+                    "raw": "["
+                },
+                {
+                    "type": "LinkReference",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "Foo",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 5
+                                }
+                            },
+                            "range": [
+                                89,
+                                92
+                            ],
+                            "raw": "Foo"
+                        }
+                    ],
+                    "identifier": "bar",
+                    "label": "bar",
+                    "referenceType": "full",
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        88,
+                        98
+                    ],
+                    "raw": "[Foo][bar]"
+                },
+                {
+                    "type": "Str",
+                    "value": "]",
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 12
+                        }
+                    },
+                    "range": [
+                        98,
+                        99
+                    ],
+                    "raw": "]"
+                },
+                {
+                    "type": "LinkReference",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "baz",
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                100,
+                                103
+                            ],
+                            "raw": "baz"
+                        }
+                    ],
+                    "identifier": "baz",
+                    "label": "baz",
+                    "referenceType": "shortcut",
+                    "loc": {
+                        "start": {
+                            "line": 7,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        99,
                         104
                     ],
-                    "raw": "[[Foo][bar]][baz]"
+                    "raw": "[baz]"
                 }
             ],
             "loc": {
@@ -247,8 +330,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "baz",
-                    "referenceType": "full",
                     "children": [
                         {
                             "type": "Str",
@@ -270,6 +351,9 @@
                             "raw": "[^foo]"
                         }
                     ],
+                    "identifier": "baz",
+                    "label": "baz",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 11,
@@ -306,6 +390,7 @@
         {
             "type": "Definition",
             "identifier": "bar",
+            "label": "bar",
             "title": "bar",
             "url": "https://bar.com",
             "loc": {
@@ -327,6 +412,7 @@
         {
             "type": "Definition",
             "identifier": "baz",
+            "label": "baz",
             "title": "baz",
             "url": "https://baz.com",
             "loc": {
@@ -349,30 +435,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "^foo",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "^foo",
-                            "loc": {
-                                "start": {
-                                    "line": 16,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 16,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                213,
-                                217
-                            ],
-                            "raw": "^foo"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[^foo]: A footnote.",
                     "loc": {
                         "start": {
                             "line": 16,
@@ -380,33 +444,14 @@
                         },
                         "end": {
                             "line": 16,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        212,
-                        218
-                    ],
-                    "raw": "[^foo]"
-                },
-                {
-                    "type": "Str",
-                    "value": ": A footnote.",
-                    "loc": {
-                        "start": {
-                            "line": 16,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 16,
                             "column": 19
                         }
                     },
                     "range": [
-                        218,
+                        212,
                         231
                     ],
-                    "raw": ": A footnote."
+                    "raw": "[^foo]: A footnote."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/nested-references.text/output.json
@@ -332,8 +332,9 @@
                     "type": "LinkReference",
                     "children": [
                         {
-                            "type": "Str",
-                            "value": "[^foo]",
+                            "type": "footnoteReference",
+                            "identifier": "foo",
+                            "label": "foo",
                             "loc": {
                                 "start": {
                                     "line": 11,
@@ -432,15 +433,37 @@
             "raw": "[baz]: https://baz.com \"baz\""
         },
         {
-            "type": "Paragraph",
+            "type": "footnoteDefinition",
+            "identifier": "foo",
+            "label": "foo",
             "children": [
                 {
-                    "type": "Str",
-                    "value": "[^foo]: A footnote.",
+                    "type": "Paragraph",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "A footnote.",
+                            "loc": {
+                                "start": {
+                                    "line": 16,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 19
+                                }
+                            },
+                            "range": [
+                                220,
+                                231
+                            ],
+                            "raw": "A footnote."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 16,
-                            "column": 0
+                            "column": 8
                         },
                         "end": {
                             "line": 16,
@@ -448,10 +471,10 @@
                         }
                     },
                     "range": [
-                        212,
+                        220,
                         231
                     ],
-                    "raw": "[^foo]: A footnote."
+                    "raw": "A footnote."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/nested-square-link.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/nested-square-link.text/output.json
@@ -5,13 +5,13 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "the `",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": null,
+                    "url": "/url",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "the `",
+                            "value": "the ",
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -19,14 +19,52 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 6
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 1,
-                                6
+                                5
                             ],
-                            "raw": "the `"
+                            "raw": "the "
+                        },
+                        {
+                            "type": "Code",
+                            "value": "]",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                5,
+                                8
+                            ],
+                            "raw": "`]`"
+                        },
+                        {
+                            "type": "Str",
+                            "value": " character",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 18
+                                }
+                            },
+                            "range": [
+                                8,
+                                18
+                            ],
+                            "raw": " character"
                         }
                     ],
                     "loc": {
@@ -36,33 +74,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        0,
-                        7
-                    ],
-                    "raw": "[the `]"
-                },
-                {
-                    "type": "Str",
-                    "value": "` character](/url)",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 25
                         }
                     },
                     "range": [
-                        7,
+                        0,
                         25
                     ],
-                    "raw": "` character](/url)"
+                    "raw": "[the `]` character](/url)"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/no-positionals.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/no-positionals.nooutput.text/output.json
@@ -86,11 +86,11 @@
                     "children": [
                         {
                             "type": "Str",
-                            "value": "  Block-quotes",
+                            "value": "Block-quotes",
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 4,
@@ -98,16 +98,16 @@
                                 }
                             },
                             "range": [
-                                79,
+                                81,
                                 93
                             ],
-                            "raw": "  Block-quotes"
+                            "raw": "Block-quotes"
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 4,
-                            "column": 2
+                            "column": 4
                         },
                         "end": {
                             "line": 4,
@@ -115,20 +115,20 @@
                         }
                     },
                     "range": [
-                        79,
+                        81,
                         93
                     ],
-                    "raw": "  Block-quotes"
+                    "raw": "Block-quotes"
                 },
                 {
                     "type": "List",
                     "ordered": false,
                     "start": null,
-                    "loose": false,
+                    "spread": false,
                     "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -174,7 +174,7 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 6,
@@ -182,16 +182,16 @@
                                 }
                             },
                             "range": [
-                                98,
+                                100,
                                 120
                             ],
-                            "raw": "  *   With list items."
+                            "raw": "*   With list items."
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 6,
-                            "column": 2
+                            "column": 4
                         },
                         "end": {
                             "line": 6,
@@ -199,10 +199,10 @@
                         }
                     },
                     "range": [
-                        98,
+                        100,
                         120
                     ],
-                    "raw": "  *   With list items."
+                    "raw": "*   With list items."
                 }
             ],
             "loc": {
@@ -267,11 +267,11 @@
                     "type": "List",
                     "ordered": true,
                     "start": 1,
-                    "loose": false,
+                    "spread": false,
                     "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -317,7 +317,7 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 10,
@@ -325,16 +325,16 @@
                                 }
                             },
                             "range": [
-                                146,
+                                148,
                                 169
                             ],
-                            "raw": "  1.  And another list."
+                            "raw": "1.  And another list."
                         }
                     ],
                     "loc": {
                         "start": {
                             "line": 10,
-                            "column": 2
+                            "column": 4
                         },
                         "end": {
                             "line": 10,
@@ -342,10 +342,10 @@
                         }
                     },
                     "range": [
-                        146,
+                        148,
                         169
                     ],
-                    "raw": "  1.  And another list."
+                    "raw": "1.  And another list."
                 }
             ],
             "loc": {
@@ -527,7 +527,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "An entity: ",
+                    "value": "An entity: ©, and an warning entity: &copy.",
                     "loc": {
                         "start": {
                             "line": 14,
@@ -535,90 +535,14 @@
                         },
                         "end": {
                             "line": 14,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        228,
-                        239
-                    ],
-                    "raw": "An entity: "
-                },
-                {
-                    "type": "Str",
-                    "value": "©",
-                    "loc": {
-                        "start": {
-                            "line": 14,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 14,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        239,
-                        245
-                    ],
-                    "raw": "&copy;"
-                },
-                {
-                    "type": "Str",
-                    "value": ", and an warning entity: ",
-                    "loc": {
-                        "start": {
-                            "line": 14,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 14,
-                            "column": 42
-                        }
-                    },
-                    "range": [
-                        245,
-                        270
-                    ],
-                    "raw": ", and an warning entity: "
-                },
-                {
-                    "type": "Str",
-                    "value": "©",
-                    "loc": {
-                        "start": {
-                            "line": 14,
-                            "column": 42
-                        },
-                        "end": {
-                            "line": 14,
-                            "column": 47
-                        }
-                    },
-                    "range": [
-                        270,
-                        275
-                    ],
-                    "raw": "&copy"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 14,
-                            "column": 47
-                        },
-                        "end": {
-                            "line": 14,
                             "column": 48
                         }
                     },
                     "range": [
-                        275,
+                        228,
                         276
                     ],
-                    "raw": "."
+                    "raw": "An entity: &copy;, and an warning entity: &copy."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/not-a-link.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/not-a-link.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "[",
+                    "value": "[test](not a link)",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -14,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        0,
-                        2
-                    ],
-                    "raw": "\\["
-                },
-                {
-                    "type": "Str",
-                    "value": "test](not a link)",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 19
                         }
                     },
                     "range": [
-                        2,
+                        0,
                         19
                     ],
-                    "raw": "test](not a link)"
+                    "raw": "\\[test](not a link)"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/ordered-and-unordered-lists.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/ordered-and-unordered-lists.text/output.json
@@ -84,11 +84,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -149,7 +149,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -210,7 +210,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -329,11 +329,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -382,19 +382,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 13,
-                            "column": 0
+                            "line": 12,
+                            "column": 12
                         }
                     },
                     "range": [
                         91,
-                        104
+                        103
                     ],
-                    "raw": "*\tasterisk 1\n"
+                    "raw": "*\tasterisk 1"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -443,19 +443,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 15,
-                            "column": 0
+                            "line": 14,
+                            "column": 12
                         }
                     },
                     "range": [
                         105,
-                        118
+                        117
                     ],
-                    "raw": "*\tasterisk 2\n"
+                    "raw": "*\tasterisk 2"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -592,11 +592,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -657,7 +657,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -718,7 +718,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -837,11 +837,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -890,19 +890,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 30,
-                            "column": 0
+                            "line": 29,
+                            "column": 8
                         }
                     },
                     "range": [
                         199,
-                        208
+                        207
                     ],
-                    "raw": "+\tPlus 1\n"
+                    "raw": "+\tPlus 1"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -951,19 +951,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 32,
-                            "column": 0
+                            "line": 31,
+                            "column": 8
                         }
                     },
                     "range": [
                         209,
-                        218
+                        217
                     ],
-                    "raw": "+\tPlus 2\n"
+                    "raw": "+\tPlus 2"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1100,11 +1100,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1165,7 +1165,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1226,7 +1226,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1345,11 +1345,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1398,19 +1398,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 48,
-                            "column": 0
+                            "line": 47,
+                            "column": 9
                         }
                     },
                     "range": [
                         301,
-                        311
+                        310
                     ],
-                    "raw": "-\tMinus 1\n"
+                    "raw": "-\tMinus 1"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1459,19 +1459,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 50,
-                            "column": 0
+                            "line": 49,
+                            "column": 9
                         }
                     },
                     "range": [
                         312,
-                        322
+                        321
                     ],
-                    "raw": "-\tMinus 2\n"
+                    "raw": "-\tMinus 2"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1630,11 +1630,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1695,7 +1695,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1756,7 +1756,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1875,11 +1875,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -1940,7 +1940,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2001,7 +2001,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2120,11 +2120,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2173,19 +2173,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 72,
-                            "column": 0
+                            "line": 71,
+                            "column": 8
                         }
                     },
                     "range": [
                         434,
-                        443
+                        442
                     ],
-                    "raw": "1.\tFirst\n"
+                    "raw": "1.\tFirst"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2234,19 +2234,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 74,
-                            "column": 0
+                            "line": 73,
+                            "column": 9
                         }
                     },
                     "range": [
                         444,
-                        454
+                        453
                     ],
-                    "raw": "2.\tSecond\n"
+                    "raw": "2.\tSecond"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2365,11 +2365,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2418,19 +2418,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 80,
-                            "column": 0
+                            "line": 79,
+                            "column": 6
                         }
                     },
                     "range": [
                         484,
-                        491
+                        490
                     ],
-                    "raw": "1. One\n"
+                    "raw": "1. One"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2479,19 +2479,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 82,
-                            "column": 0
+                            "line": 81,
+                            "column": 6
                         }
                     },
                     "range": [
                         492,
-                        499
+                        498
                     ],
-                    "raw": "2. Two\n"
+                    "raw": "2. Two"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2610,11 +2610,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -2702,19 +2702,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 91,
-                            "column": 1
+                            "line": 90,
+                            "column": 6
                         }
                     },
                     "range": [
                         532,
-                        628
+                        626
                     ],
-                    "raw": "1.\tItem 1, graf one.\n\n\tItem 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback.\n\t"
+                    "raw": "1.\tItem 1, graf one.\n\n\tItem 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback."
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2763,19 +2763,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 93,
-                            "column": 0
+                            "line": 92,
+                            "column": 10
                         }
                     },
                     "range": [
                         629,
-                        640
+                        639
                     ],
-                    "raw": "2.\tItem 2.\n"
+                    "raw": "2.\tItem 2."
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2895,11 +2895,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2945,11 +2945,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -2995,11 +2995,11 @@
                                             "type": "List",
                                             "ordered": false,
                                             "start": null,
-                                            "loose": false,
+                                            "spread": false,
                                             "children": [
                                                 {
                                                     "type": "ListItem",
-                                                    "loose": false,
+                                                    "spread": false,
                                                     "checked": null,
                                                     "children": [
                                                         {
@@ -3186,11 +3186,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3251,7 +3251,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3297,11 +3297,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3362,7 +3362,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3423,7 +3423,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3518,7 +3518,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3637,11 +3637,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3690,19 +3690,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 116,
-                            "column": 0
+                            "line": 115,
+                            "column": 8
                         }
                     },
                     "range": [
                         789,
-                        798
+                        797
                     ],
-                    "raw": "1. First\n"
+                    "raw": "1. First"
                 },
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3748,11 +3748,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3813,7 +3813,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3874,7 +3874,7 @@
                                 },
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {
@@ -3957,19 +3957,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 121,
-                            "column": 0
+                            "line": 120,
+                            "column": 6
                         }
                     },
                     "range": [
                         799,
-                        831
+                        830
                     ],
-                    "raw": "2. Second:\n\t* Fee\n\t* Fie\n\t* Foe\n"
+                    "raw": "2. Second:\n\t* Fee\n\t* Fie\n\t* Foe"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -4088,11 +4088,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": true,
                     "checked": null,
                     "children": [
                         {
@@ -4138,11 +4138,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": null,
                                     "children": [
                                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/ordered-different-types.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/ordered-different-types.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -78,22 +78,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "bar\n3) baz",
+                                    "value": "bar",
                                     "loc": {
                                         "start": {
                                             "line": 2,
                                             "column": 3
                                         },
                                         "end": {
-                                            "line": 3,
+                                            "line": 2,
                                             "column": 6
                                         }
                                     },
                                     "range": [
                                         10,
-                                        20
+                                        13
                                     ],
-                                    "raw": "bar\n3) baz"
+                                    "raw": "bar"
                                 }
                             ],
                             "loc": {
@@ -102,15 +102,15 @@
                                     "column": 3
                                 },
                                 "end": {
-                                    "line": 3,
+                                    "line": 2,
                                     "column": 6
                                 }
                             },
                             "range": [
                                 10,
-                                20
+                                13
                             ],
-                            "raw": "bar\n3) baz"
+                            "raw": "bar"
                         }
                     ],
                     "loc": {
@@ -119,15 +119,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 3,
+                            "line": 2,
                             "column": 6
                         }
                     },
                     "range": [
                         7,
-                        20
+                        13
                     ],
-                    "raw": "2. bar\n3) baz"
+                    "raw": "2. bar"
                 }
             ],
             "loc": {
@@ -136,15 +136,99 @@
                     "column": 0
                 },
                 "end": {
-                    "line": 3,
+                    "line": 2,
                     "column": 6
                 }
             },
             "range": [
                 0,
+                13
+            ],
+            "raw": "1. foo\n2. bar"
+        },
+        {
+            "type": "List",
+            "ordered": true,
+            "start": 3,
+            "spread": false,
+            "children": [
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "baz",
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        17,
+                                        20
+                                    ],
+                                    "raw": "baz"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                17,
+                                20
+                            ],
+                            "raw": "baz"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 6
+                        }
+                    },
+                    "range": [
+                        14,
+                        20
+                    ],
+                    "raw": "3) baz"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 6
+                }
+            },
+            "range": [
+                14,
                 20
             ],
-            "raw": "1. foo\n2. bar\n3) baz"
+            "raw": "3) baz"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/ordered-with-parentheses.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/ordered-with-parentheses.text/output.json
@@ -81,14 +81,181 @@
             "raw": "Tight:"
         },
         {
-            "type": "Paragraph",
+            "type": "List",
+            "ordered": true,
+            "start": 1,
+            "spread": false,
             "children": [
                 {
-                    "type": "Str",
-                    "value": "1)\tFirst\n2)\tSecond\n3)\tThird",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "First",
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        23,
+                                        28
+                                    ],
+                                    "raw": "First"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                23,
+                                28
+                            ],
+                            "raw": "First"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 5,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 8
+                        }
+                    },
+                    "range": [
+                        20,
+                        28
+                    ],
+                    "raw": "1)\tFirst"
+                },
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Second",
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 9
+                                        }
+                                    },
+                                    "range": [
+                                        32,
+                                        38
+                                    ],
+                                    "raw": "Second"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 6,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 6,
+                                    "column": 9
+                                }
+                            },
+                            "range": [
+                                32,
+                                38
+                            ],
+                            "raw": "Second"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 6,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        29,
+                        38
+                    ],
+                    "raw": "2)\tSecond"
+                },
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Third",
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        42,
+                                        47
+                                    ],
+                                    "raw": "Third"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 7,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                42,
+                                47
+                            ],
+                            "raw": "Third"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 7,
                             "column": 0
                         },
                         "end": {
@@ -97,10 +264,10 @@
                         }
                     },
                     "range": [
-                        20,
+                        39,
                         47
                     ],
-                    "raw": "1)\tFirst\n2)\tSecond\n3)\tThird"
+                    "raw": "3)\tThird"
                 }
             ],
             "loc": {
@@ -159,14 +326,181 @@
             "raw": "and:"
         },
         {
-            "type": "Paragraph",
+            "type": "List",
+            "ordered": true,
+            "start": 1,
+            "spread": false,
             "children": [
                 {
-                    "type": "Str",
-                    "value": "1) One\n2) Two\n3) Three",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "One",
+                                    "loc": {
+                                        "start": {
+                                            "line": 11,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        58,
+                                        61
+                                    ],
+                                    "raw": "One"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 11,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                58,
+                                61
+                            ],
+                            "raw": "One"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 11,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 11,
+                            "column": 6
+                        }
+                    },
+                    "range": [
+                        55,
+                        61
+                    ],
+                    "raw": "1) One"
+                },
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Two",
+                                    "loc": {
+                                        "start": {
+                                            "line": 12,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 12,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        65,
+                                        68
+                                    ],
+                                    "raw": "Two"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 12,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                65,
+                                68
+                            ],
+                            "raw": "Two"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 12,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 12,
+                            "column": 6
+                        }
+                    },
+                    "range": [
+                        62,
+                        68
+                    ],
+                    "raw": "2) Two"
+                },
+                {
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Three",
+                                    "loc": {
+                                        "start": {
+                                            "line": 13,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        72,
+                                        77
+                                    ],
+                                    "raw": "Three"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                72,
+                                77
+                            ],
+                            "raw": "Three"
+                        }
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 13,
                             "column": 0
                         },
                         "end": {
@@ -175,10 +509,10 @@
                         }
                     },
                     "range": [
-                        55,
+                        69,
                         77
                     ],
-                    "raw": "1) One\n2) Two\n3) Three"
+                    "raw": "3) Three"
                 }
             ],
             "loc": {
@@ -237,11 +571,56 @@
             "raw": "Loose using tabs:"
         },
         {
-            "type": "Paragraph",
+            "type": "List",
+            "ordered": true,
+            "start": 1,
+            "spread": true,
             "children": [
                 {
-                    "type": "Str",
-                    "value": "1)\tFirst",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "First",
+                                    "loc": {
+                                        "start": {
+                                            "line": 17,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 17,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        101,
+                                        106
+                                    ],
+                                    "raw": "First"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 17,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                101,
+                                106
+                            ],
+                            "raw": "First"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 17,
@@ -257,30 +636,52 @@
                         106
                     ],
                     "raw": "1)\tFirst"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 17,
-                    "column": 0
                 },
-                "end": {
-                    "line": 17,
-                    "column": 8
-                }
-            },
-            "range": [
-                98,
-                106
-            ],
-            "raw": "1)\tFirst"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "2)\tSecond",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Second",
+                                    "loc": {
+                                        "start": {
+                                            "line": 19,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 9
+                                        }
+                                    },
+                                    "range": [
+                                        111,
+                                        117
+                                    ],
+                                    "raw": "Second"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 19,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 19,
+                                    "column": 9
+                                }
+                            },
+                            "range": [
+                                111,
+                                117
+                            ],
+                            "raw": "Second"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 19,
@@ -296,30 +697,52 @@
                         117
                     ],
                     "raw": "2)\tSecond"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 19,
-                    "column": 0
                 },
-                "end": {
-                    "line": 19,
-                    "column": 9
-                }
-            },
-            "range": [
-                108,
-                117
-            ],
-            "raw": "2)\tSecond"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "3)\tThird",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Third",
+                                    "loc": {
+                                        "start": {
+                                            "line": 21,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 21,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        122,
+                                        127
+                                    ],
+                                    "raw": "Third"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 21,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 21,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                122,
+                                127
+                            ],
+                            "raw": "Third"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 21,
@@ -339,7 +762,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 21,
+                    "line": 17,
                     "column": 0
                 },
                 "end": {
@@ -348,10 +771,10 @@
                 }
             },
             "range": [
-                119,
+                98,
                 127
             ],
-            "raw": "3)\tThird"
+            "raw": "1)\tFirst\n\n2)\tSecond\n\n3)\tThird"
         },
         {
             "type": "Paragraph",
@@ -393,11 +816,56 @@
             "raw": "and using spaces:"
         },
         {
-            "type": "Paragraph",
+            "type": "List",
+            "ordered": true,
+            "start": 1,
+            "spread": true,
             "children": [
                 {
-                    "type": "Str",
-                    "value": "1) One",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "One",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        151,
+                                        154
+                                    ],
+                                    "raw": "One"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 25,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                151,
+                                154
+                            ],
+                            "raw": "One"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 25,
@@ -413,30 +881,52 @@
                         154
                     ],
                     "raw": "1) One"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 25,
-                    "column": 0
                 },
-                "end": {
-                    "line": 25,
-                    "column": 6
-                }
-            },
-            "range": [
-                148,
-                154
-            ],
-            "raw": "1) One"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "2) Two",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Two",
+                                    "loc": {
+                                        "start": {
+                                            "line": 27,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 27,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        159,
+                                        162
+                                    ],
+                                    "raw": "Two"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 27,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 27,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                159,
+                                162
+                            ],
+                            "raw": "Two"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 27,
@@ -452,30 +942,52 @@
                         162
                     ],
                     "raw": "2) Two"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 27,
-                    "column": 0
                 },
-                "end": {
-                    "line": 27,
-                    "column": 6
-                }
-            },
-            "range": [
-                156,
-                162
-            ],
-            "raw": "2) Two"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "3) Three",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Three",
+                                    "loc": {
+                                        "start": {
+                                            "line": 29,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 29,
+                                            "column": 8
+                                        }
+                                    },
+                                    "range": [
+                                        167,
+                                        172
+                                    ],
+                                    "raw": "Three"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 29,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 8
+                                }
+                            },
+                            "range": [
+                                167,
+                                172
+                            ],
+                            "raw": "Three"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 29,
@@ -495,7 +1007,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 29,
+                    "line": 25,
                     "column": 0
                 },
                 "end": {
@@ -504,10 +1016,10 @@
                 }
             },
             "range": [
-                164,
+                148,
                 172
             ],
-            "raw": "3) Three"
+            "raw": "1) One\n\n2) Two\n\n3) Three"
         },
         {
             "type": "Paragraph",
@@ -549,70 +1061,156 @@
             "raw": "Multiple paragraphs:"
         },
         {
-            "type": "Paragraph",
+            "type": "List",
+            "ordered": true,
+            "start": 1,
+            "spread": true,
             "children": [
                 {
-                    "type": "Str",
-                    "value": "1)\tItem 1, graf one.",
+                    "type": "ListItem",
+                    "spread": true,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Item 1, graf one.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 33,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 33,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        199,
+                                        216
+                                    ],
+                                    "raw": "Item 1, graf one."
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 33,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 33,
+                                    "column": 20
+                                }
+                            },
+                            "range": [
+                                199,
+                                216
+                            ],
+                            "raw": "Item 1, graf one."
+                        },
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Item 2. graf two. The quick brown fox jumped over the lazy dog's\nback.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 35,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 36,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        219,
+                                        290
+                                    ],
+                                    "raw": "Item 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback."
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 35,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                219,
+                                290
+                            ],
+                            "raw": "Item 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 33,
                             "column": 0
                         },
                         "end": {
-                            "line": 33,
-                            "column": 20
+                            "line": 36,
+                            "column": 6
                         }
                     },
                     "range": [
                         196,
-                        216
+                        290
                     ],
-                    "raw": "1)\tItem 1, graf one."
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 33,
-                    "column": 0
+                    "raw": "1)\tItem 1, graf one.\n\n\tItem 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback."
                 },
-                "end": {
-                    "line": 33,
-                    "column": 20
-                }
-            },
-            "range": [
-                196,
-                216
-            ],
-            "raw": "1)\tItem 1, graf one."
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "value": "Item 2. graf two. The quick brown fox jumped over the lazy dog's\nback.",
-            "loc": {
-                "start": {
-                    "line": 35,
-                    "column": 0
-                },
-                "end": {
-                    "line": 37,
-                    "column": 1
-                }
-            },
-            "range": [
-                218,
-                292
-            ],
-            "raw": "\tItem 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback.\n\t"
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "2)\tItem 2.",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Item 2.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 38,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 38,
+                                            "column": 10
+                                        }
+                                    },
+                                    "range": [
+                                        296,
+                                        303
+                                    ],
+                                    "raw": "Item 2."
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 38,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 38,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                296,
+                                303
+                            ],
+                            "raw": "Item 2."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 38,
@@ -628,30 +1226,52 @@
                         303
                     ],
                     "raw": "2)\tItem 2."
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 38,
-                    "column": 0
                 },
-                "end": {
-                    "line": 38,
-                    "column": 10
-                }
-            },
-            "range": [
-                293,
-                303
-            ],
-            "raw": "2)\tItem 2."
-        },
-        {
-            "type": "Paragraph",
-            "children": [
                 {
-                    "type": "Str",
-                    "value": "3)\tItem 3.",
+                    "type": "ListItem",
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "Item 3.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 40,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 40,
+                                            "column": 10
+                                        }
+                                    },
+                                    "range": [
+                                        308,
+                                        315
+                                    ],
+                                    "raw": "Item 3."
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 40,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 40,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                308,
+                                315
+                            ],
+                            "raw": "Item 3."
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 40,
@@ -671,7 +1291,7 @@
             ],
             "loc": {
                 "start": {
-                    "line": 40,
+                    "line": 33,
                     "column": 0
                 },
                 "end": {
@@ -680,10 +1300,10 @@
                 }
             },
             "range": [
-                305,
+                196,
                 315
             ],
-            "raw": "3)\tItem 3."
+            "raw": "1)\tItem 1, graf one.\n\n\tItem 2. graf two. The quick brown fox jumped over the lazy dog's\n\tback.\n\t\n2)\tItem 2.\n\n3)\tItem 3."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/paragraphs-and-indentation.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/paragraphs-and-indentation.text/output.json
@@ -46,7 +46,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is a paragraph\n    and this is further text",
+                    "value": "This is a paragraph\nand this is further text",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -85,7 +85,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is a paragraph\n   and this is further text",
+                    "value": "This is a paragraph\nand this is further text",
                     "loc": {
                         "start": {
                             "line": 6,
@@ -124,47 +124,27 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "This is a paragraph with some asterisks",
+                    "value": "This is a paragraph with some asterisks\n***",
                     "loc": {
                         "start": {
                             "line": 9,
                             "column": 0
                         },
                         "end": {
-                            "line": 9,
-                            "column": 39
+                            "line": 10,
+                            "column": 7
                         }
                     },
                     "range": [
                         117,
-                        156
+                        164
                     ],
-                    "raw": "This is a paragraph with some asterisks"
+                    "raw": "This is a paragraph with some asterisks\n    ***"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 9,
-                    "column": 0
-                },
-                "end": {
-                    "line": 9,
-                    "column": 39
-                }
-            },
-            "range": [
-                117,
-                156
-            ],
-            "raw": "This is a paragraph with some asterisks"
-        },
-        {
-            "type": "CodeBlock",
-            "lang": null,
-            "value": "***",
-            "loc": {
-                "start": {
-                    "line": 10,
                     "column": 0
                 },
                 "end": {
@@ -173,10 +153,10 @@
                 }
             },
             "range": [
-                157,
+                117,
                 164
             ],
-            "raw": "    ***"
+            "raw": "This is a paragraph with some asterisks\n    ***"
         },
         {
             "type": "Paragraph",
@@ -222,7 +202,7 @@
             "loc": {
                 "start": {
                     "line": 13,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 13,
@@ -230,10 +210,10 @@
                 }
             },
             "range": [
-                216,
+                219,
                 222
             ],
-            "raw": "   ***"
+            "raw": "***"
         },
         {
             "type": "Header",
@@ -317,6 +297,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "and this is code",
             "loc": {
                 "start": {
@@ -378,11 +359,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "   and this is a new paragraph",
+                    "value": "and this is a new paragraph",
                     "loc": {
                         "start": {
                             "line": 23,
-                            "column": 0
+                            "column": 3
                         },
                         "end": {
                             "line": 23,
@@ -390,16 +371,16 @@
                         }
                     },
                     "range": [
-                        303,
+                        306,
                         333
                     ],
-                    "raw": "   and this is a new paragraph"
+                    "raw": "and this is a new paragraph"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 23,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 23,
@@ -407,10 +388,10 @@
                 }
             },
             "range": [
-                303,
+                306,
                 333
             ],
-            "raw": "   and this is a new paragraph"
+            "raw": "and this is a new paragraph"
         },
         {
             "type": "Paragraph",
@@ -454,6 +435,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "***",
             "loc": {
                 "start": {
@@ -515,7 +497,7 @@
             "loc": {
                 "start": {
                     "line": 31,
-                    "column": 0
+                    "column": 3
                 },
                 "end": {
                     "line": 31,
@@ -523,10 +505,10 @@
                 }
             },
             "range": [
-                452,
+                455,
                 458
             ],
-            "raw": "   ***"
+            "raw": "***"
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/ref-paren.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/ref-paren.text/output.json
@@ -6,8 +6,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "hi",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -29,6 +27,9 @@
                             "raw": "hi"
                         }
                     ],
+                    "identifier": "hi",
+                    "label": "hi",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -65,6 +66,7 @@
         {
             "type": "Definition",
             "identifier": "hi",
+            "label": "hi",
             "title": "there",
             "url": "/url",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-image-empty-alt.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-image-empty-alt.text/output.json
@@ -6,9 +6,10 @@
             "children": [
                 {
                     "type": "ImageReference",
+                    "alt": "",
                     "identifier": "1",
+                    "label": "1",
                     "referenceType": "full",
-                    "alt": null,
                     "loc": {
                         "start": {
                             "line": 1,
@@ -45,6 +46,7 @@
         {
             "type": "Definition",
             "identifier": "1",
+            "label": "1",
             "title": null,
             "url": "/xyz.png",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-escape.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-escape.nooutput.text/output.json
@@ -5,68 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "b\\-r",
-                    "referenceType": "full",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "b",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 2
-                                }
-                            },
-                            "range": [
-                                1,
-                                2
-                            ],
-                            "raw": "b"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                2,
-                                4
-                            ],
-                            "raw": "\\*"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "r*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 4
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                4,
-                                6
-                            ],
-                            "raw": "r*"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[b*r*][b-r], ",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -74,42 +14,21 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        0,
-                        13
-                    ],
-                    "raw": "[b\\*r*][b\\-r]"
-                },
-                {
-                    "type": "Str",
-                    "value": ", ",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 15
                         }
                     },
                     "range": [
-                        13,
+                        0,
                         15
                     ],
-                    "raw": ", "
+                    "raw": "[b\\*r*][b\\-r], "
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "b\\*r*",
-                    "referenceType": "collapsed",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "b",
+                            "value": "b*r*",
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -117,54 +36,19 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 17
-                                }
-                            },
-                            "range": [
-                                16,
-                                17
-                            ],
-                            "raw": "b"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 17
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 19
-                                }
-                            },
-                            "range": [
-                                17,
-                                19
-                            ],
-                            "raw": "\\*"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "r*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 19
-                                },
-                                "end": {
-                                    "line": 1,
                                     "column": 21
                                 }
                             },
                             "range": [
-                                19,
+                                16,
                                 21
                             ],
-                            "raw": "r*"
+                            "raw": "b\\*r*"
                         }
                     ],
+                    "identifier": "b\\*r*",
+                    "label": "b*r*",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -202,12 +86,10 @@
                 },
                 {
                     "type": "LinkReference",
-                    "identifier": "b\\*r*",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
-                            "value": "b",
+                            "value": "b*r*",
                             "loc": {
                                 "start": {
                                     "line": 1,
@@ -215,54 +97,19 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 28
-                                }
-                            },
-                            "range": [
-                                27,
-                                28
-                            ],
-                            "raw": "b"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 28
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 30
-                                }
-                            },
-                            "range": [
-                                28,
-                                30
-                            ],
-                            "raw": "\\*"
-                        },
-                        {
-                            "type": "Str",
-                            "value": "r*",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 30
-                                },
-                                "end": {
-                                    "line": 1,
                                     "column": 32
                                 }
                             },
                             "range": [
-                                30,
+                                27,
                                 32
                             ],
-                            "raw": "r*"
+                            "raw": "b\\*r*"
                         }
                     ],
+                    "identifier": "b\\*r*",
+                    "label": "b*r*",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -320,9 +167,10 @@
             "children": [
                 {
                     "type": "ImageReference",
-                    "identifier": "b\\*r*",
-                    "referenceType": "full",
                     "alt": "foo",
+                    "identifier": "b\\*r*",
+                    "label": "b*r*",
+                    "referenceType": "full",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -360,9 +208,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "b\\*r*",
-                    "referenceType": "collapsed",
                     "alt": "b*r*",
+                    "identifier": "b\\*r*",
+                    "label": "b*r*",
+                    "referenceType": "collapsed",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -400,9 +249,10 @@
                 },
                 {
                     "type": "ImageReference",
-                    "identifier": "b\\*r*",
-                    "referenceType": "shortcut",
                     "alt": "b*r*",
+                    "identifier": "b\\*r*",
+                    "label": "b*r*",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -458,6 +308,7 @@
         {
             "type": "Definition",
             "identifier": "b\\*r*",
+            "label": "b*r*",
             "title": null,
             "url": "http://google.com",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-not-closed.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-not-closed.text/output.json
@@ -5,30 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                1,
-                                4
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar][bar",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -36,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        0,
-                        6
-                    ],
-                    "raw": "[bar]["
-                },
-                {
-                    "type": "Str",
-                    "value": "bar",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 9
                         }
                     },
                     "range": [
-                        6,
+                        0,
                         9
                     ],
-                    "raw": "bar"
+                    "raw": "[bar][bar"
                 }
             ],
             "loc": {
@@ -85,30 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 3,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 3,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                12,
-                                15
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar][",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -146,30 +83,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "bar",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "bar",
-                            "loc": {
-                                "start": {
-                                    "line": 5,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 5,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                20,
-                                23
-                            ],
-                            "raw": "bar"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[bar]",
                     "loc": {
                         "start": {
                             "line": 5,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-with-angle-brackets.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-with-angle-brackets.text/output.json
@@ -6,8 +6,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -29,6 +27,9 @@
                             "raw": "foo"
                         }
                     ],
+                    "identifier": "foo",
+                    "label": "foo",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -65,6 +66,7 @@
         {
             "type": "Definition",
             "identifier": "foo",
+            "label": "foo",
             "title": null,
             "url": "./url with spaces",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-with-multiple-definitions.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/reference-link-with-multiple-definitions.text/output.json
@@ -6,8 +6,6 @@
             "children": [
                 {
                     "type": "LinkReference",
-                    "identifier": "foo",
-                    "referenceType": "shortcut",
                     "children": [
                         {
                             "type": "Str",
@@ -29,6 +27,9 @@
                             "raw": "foo"
                         }
                     ],
+                    "identifier": "foo",
+                    "label": "foo",
+                    "referenceType": "shortcut",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -65,6 +66,7 @@
         {
             "type": "Definition",
             "identifier": "foo",
+            "label": "foo",
             "title": null,
             "url": "first",
             "loc": {
@@ -86,6 +88,7 @@
         {
             "type": "Definition",
             "identifier": "foo",
+            "label": "foo",
             "title": null,
             "url": "second",
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/same-bullet.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/same-bullet.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -89,11 +89,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -173,11 +173,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.commonmark.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.commonmark.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,128 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 11
                         }
                     },
                     "range": [
-                        56,
+                        47,
                         58
                     ],
-                    "raw": "\\["
+                    "raw": "\\\\ \\` \\* \\["
                 }
             ],
             "loc": {
@@ -276,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are ",
+                    "value": "Underscores are _escaped_ unless they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -284,90 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        114,
-                        130
-                    ],
-                    "raw": "Underscores are "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        130,
-                        132
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        132,
-                        139
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        139,
-                        141
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": " unless they appear in_the_middle_of_a_word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 27
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 71
                         }
                     },
                     "range": [
-                        141,
+                        114,
                         185
                     ],
-                    "raw": " unless they appear in_the_middle_of_a_word."
+                    "raw": "Underscores are \\_escaped\\_ unless they appear in_the_middle_of_a_word."
                 }
             ],
             "loc": {
@@ -429,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -441,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -449,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        263,
-                                        264
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        264,
-                                        269
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "cat \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        269,
-                                        274
-                                    ],
-                                    "raw": "cat \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 20
-                                        }
-                                    },
-                                    "range": [
-                                        274,
-                                        279
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 20
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        279,
-                                        281
-                                    ],
-                                    "raw": " \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 27
                                         }
                                     },
                                     "range": [
-                                        281,
+                                        263,
                                         286
                                     ],
-                                    "raw": "&#x26"
+                                    "raw": "\\&copycat \\&amp; \\&#x26"
                                 }
                             ],
                             "loc": {
@@ -589,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -746,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                396,
-                                399
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -777,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        395,
-                        400
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        400,
-                        402
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        402,
+                        395,
                         407
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -885,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        463,
-                        465
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        465,
-                        482
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        482,
-                        484
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        484,
-                        503
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        503,
-                        505
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -992,10 +552,10 @@
                         }
                     },
                     "range": [
-                        505,
+                        463,
                         521
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1058,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1066,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        549,
-                        551
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        551,
+                        549,
                         569
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1155,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        588,
-                        590
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        590,
-                        607
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        607,
-                        609
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1224,10 +708,10 @@
                         }
                     },
                     "range": [
-                        609,
+                        588,
                         627
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1289,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                697,
-                                                706
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1376,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                713,
-                                                716
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                716,
-                                                718
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                718,
-                                                723
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1497,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                730,
-                                                733
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1580,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                740,
-                                                741
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                741,
-                                                743
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                743,
-                                                744
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1701,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                751,
-                                                752
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                752,
-                                                754
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                754,
-                                                756
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -1822,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                763,
-                                                766
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                766,
-                                                768
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                768,
-                                                769
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2060,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2072,22 +1272,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http\\://user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 59
-                                        }
-                                    },
-                                    "range": [
-                                        820,
-                                        875
-                                    ],
-                                    "raw": "http\\://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2125,7 +1310,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2133,22 +1318,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https\\://user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 60
-                                        }
-                                    },
-                                    "range": [
-                                        880,
-                                        936
-                                    ],
-                                    "raw": "https\\://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2206,7 +1376,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Double tildes should be ",
+                    "value": "Double tildes should be ~",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2214,37 +1384,38 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 24
+                            "column": 26
                         }
                     },
                     "range": [
                         938,
-                        962
-                    ],
-                    "raw": "Double tildes should be "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        962,
                         964
                     ],
-                    "raw": "\\~"
+                    "raw": "Double tildes should be \\~"
                 },
                 {
-                    "type": "Str",
-                    "value": "~escaped",
+                    "type": "Delete",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "escaped~",
+                            "loc": {
+                                "start": {
+                                    "line": 51,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 51,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                965,
+                                974
+                            ],
+                            "raw": "escaped\\~"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2252,79 +1423,22 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 34
+                            "column": 37
                         }
                     },
                     "range": [
                         964,
-                        972
+                        975
                     ],
-                    "raw": "~escaped"
+                    "raw": "~escaped\\~~"
                 },
                 {
                     "type": "Str",
-                    "value": "~",
+                    "value": ".\nAnd here: foo~~.",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        972,
-                        974
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.\nAnd here: foo",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 36
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        974,
-                        990
-                    ],
-                    "raw": "~.\nAnd here: foo"
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        990,
-                        992
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 15
+                            "column": 37
                         },
                         "end": {
                             "line": 52,
@@ -2332,10 +1446,10 @@
                         }
                     },
                     "range": [
-                        992,
+                        975,
                         994
                     ],
-                    "raw": "~."
+                    "raw": ".\nAnd here: foo\\~~."
                 }
             ],
             "loc": {
@@ -2429,18 +1543,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1035,
-                                1041
+                                1033,
+                                1043
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2468,18 +1582,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1044,
-                                1052
+                                1043,
+                                1054
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2527,25 +1641,25 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1079,
-                                1085
+                                1077,
+                                1087
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "tho",
+                                    "value": "tho|ugh",
                                     "loc": {
                                         "start": {
                                             "line": 58,
@@ -2553,69 +1667,31 @@
                                         },
                                         "end": {
                                             "line": 58,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        1088,
-                                        1091
-                                    ],
-                                    "raw": "tho"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 58,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1091,
-                                        1093
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "ugh",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 58,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        1093,
+                                        1088,
                                         1096
                                     ],
-                                    "raw": "ugh"
+                                    "raw": "tho\\|ugh"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1088,
-                                1096
+                                1087,
+                                1098
                             ],
-                            "raw": "tho\\|ugh"
+                            "raw": " tho\\|ugh |"
                         }
                     ],
                     "loc": {
@@ -2695,125 +1771,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "| here   | they   |\n",
+                    "value": "| here   | they   |\n| ---- | ----- |\n| should | though |",
                     "loc": {
                         "start": {
                             "line": 62,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1111,
-                        1131
-                    ],
-                    "raw": "| here   | they   |\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1131,
-                        1133
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ---- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1133,
-                        1139
-                    ],
-                    "raw": " ---- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        1139,
-                        1141
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ----- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        1141,
-                        1148
-                    ],
-                    "raw": " ----- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 19
-                        }
-                    },
-                    "range": [
-                        1148,
-                        1150
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": "\n| should | though |",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 19
                         },
                         "end": {
                             "line": 64,
@@ -2821,10 +1783,10 @@
                         }
                     },
                     "range": [
-                        1150,
+                        1111,
                         1170
                     ],
-                    "raw": "\n| should | though |"
+                    "raw": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |"
                 }
             ],
             "loc": {
@@ -2887,87 +1849,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n---- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1183,
-                        1197
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1197,
-                        1199
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "--- ",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        1199,
-                        1203
-                    ],
-                    "raw": "--- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1203,
-                        1205
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 8
                         },
                         "end": {
                             "line": 70,
@@ -2975,10 +1861,10 @@
                         }
                     },
                     "range": [
-                        1205,
+                        1183,
                         1228
                     ],
-                    "raw": " ------\nshould | though"
+                    "raw": "here   | they\n\\---- \\| ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3099,11 +1985,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3111,7 +1997,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3119,71 +2005,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        1290,
-                                        1291
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "<div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        1291,
-                                        1296
-                                    ],
-                                    "raw": "<div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        1296,
-                                        1297
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "</div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 17
                                         }
                                     },
                                     "range": [
-                                        1297,
+                                        1290,
                                         1303
                                     ],
-                                    "raw": "</div>"
+                                    "raw": "\\<div>\\</div>"
                                 }
                             ],
                             "loc": {
@@ -3221,7 +2050,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3229,7 +2058,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\<http\\:google.com>",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.commonmark.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.commonmark.text/output.json
@@ -1272,7 +1272,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 48,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 48,
+                                            "column": 59
+                                        }
+                                    },
+                                    "range": [
+                                        820,
+                                        875
+                                    ],
+                                    "raw": "http\\://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1318,7 +1333,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 49,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 49,
+                                            "column": 60
+                                        }
+                                    },
+                                    "range": [
+                                        880,
+                                        936
+                                    ],
+                                    "raw": "https\\://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.nogfm.commonmark.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.nogfm.commonmark.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,128 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 11
                         }
                     },
                     "range": [
-                        56,
+                        47,
                         58
                     ],
-                    "raw": "\\["
+                    "raw": "\\\\ \\` \\* \\["
                 }
             ],
             "loc": {
@@ -276,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are ",
+                    "value": "Underscores are _escaped_ unless they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -284,90 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        114,
-                        130
-                    ],
-                    "raw": "Underscores are "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        130,
-                        132
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        132,
-                        139
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        139,
-                        141
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": " unless they appear in_the_middle_of_a_word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 27
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 71
                         }
                     },
                     "range": [
-                        141,
+                        114,
                         185
                     ],
-                    "raw": " unless they appear in_the_middle_of_a_word."
+                    "raw": "Underscores are \\_escaped\\_ unless they appear in_the_middle_of_a_word."
                 }
             ],
             "loc": {
@@ -429,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -441,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -449,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        263,
-                                        264
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        264,
-                                        269
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "cat \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        269,
-                                        274
-                                    ],
-                                    "raw": "cat \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 20
-                                        }
-                                    },
-                                    "range": [
-                                        274,
-                                        279
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 20
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        279,
-                                        281
-                                    ],
-                                    "raw": " \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 27
                                         }
                                     },
                                     "range": [
-                                        281,
+                                        263,
                                         286
                                     ],
-                                    "raw": "&#x26"
+                                    "raw": "\\&copycat \\&amp; \\&#x26"
                                 }
                             ],
                             "loc": {
@@ -589,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -746,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                396,
-                                399
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -777,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        395,
-                        400
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        400,
-                        402
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        402,
+                        395,
                         407
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -885,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        463,
-                        465
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        465,
-                        482
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        482,
-                        484
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        484,
-                        503
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        503,
-                        505
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -992,10 +552,10 @@
                         }
                     },
                     "range": [
-                        505,
+                        463,
                         521
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1058,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1066,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        549,
-                        551
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        551,
+                        549,
                         569
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1155,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        588,
-                        590
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        590,
-                        607
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        607,
-                        609
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1224,10 +708,10 @@
                         }
                     },
                     "range": [
-                        609,
+                        588,
                         627
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1289,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                697,
-                                                706
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1376,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                713,
-                                                716
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                716,
-                                                718
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                718,
-                                                723
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1497,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                730,
-                                                733
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1580,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                740,
-                                                741
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                741,
-                                                743
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                743,
-                                                744
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1701,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                751,
-                                                752
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                752,
-                                                754
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                754,
-                                                756
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -1822,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                763,
-                                                766
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                766,
-                                                768
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                768,
-                                                769
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2060,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2147,7 +1347,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2417,18 +1617,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1038,
-                                1044
+                                1036,
+                                1046
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2456,18 +1656,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1047,
-                                1055
+                                1046,
+                                1057
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2515,18 +1715,18 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1082,
-                                1088
+                                1080,
+                                1090
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
@@ -2554,18 +1754,18 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 14
+                                    "column": 15
                                 }
                             },
                             "range": [
-                                1091,
-                                1094
+                                1090,
+                                1095
                             ],
-                            "raw": "nei"
+                            "raw": " nei|"
                         },
                         {
                             "type": "TableCell",
@@ -2597,14 +1797,14 @@
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
                                 1095,
-                                1099
+                                1101
                             ],
-                            "raw": "ther"
+                            "raw": "ther |"
                         }
                     ],
                     "loc": {
@@ -2715,18 +1915,18 @@
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1116,
-                                1122
+                                1114,
+                                1124
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2754,18 +1954,18 @@
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 17
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                1125,
-                                1131
+                                1124,
+                                1133
                             ],
-                            "raw": "they  "
+                            "raw": " they   |"
                         }
                     ],
                     "loc": {
@@ -2813,18 +2013,18 @@
                             "loc": {
                                 "start": {
                                     "line": 64,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 64,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1156,
-                                1162
+                                1154,
+                                1164
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
@@ -2852,18 +2052,18 @@
                             "loc": {
                                 "start": {
                                     "line": 64,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 64,
-                                    "column": 17
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                1165,
-                                1171
+                                1164,
+                                1173
                             ],
-                            "raw": "though"
+                            "raw": " though |"
                         }
                     ],
                     "loc": {
@@ -2943,49 +2143,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n----- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1186,
-                        1200
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1200,
-                        1202
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "---- | ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
                         },
                         "end": {
                             "line": 70,
@@ -2993,10 +2155,10 @@
                         }
                     },
                     "range": [
-                        1202,
+                        1186,
                         1231
                     ],
-                    "raw": "---- | ------\nshould | though"
+                    "raw": "here   | they\n\\----- | ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3117,11 +2279,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3129,7 +2291,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3137,71 +2299,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        1293,
-                                        1294
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "<div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        1294,
-                                        1299
-                                    ],
-                                    "raw": "<div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        1299,
-                                        1300
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "</div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 17
                                         }
                                     },
                                     "range": [
-                                        1300,
+                                        1293,
                                         1306
                                     ],
-                                    "raw": "</div>"
+                                    "raw": "\\<div>\\</div>"
                                 }
                             ],
                             "loc": {
@@ -3239,7 +2344,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3247,7 +2352,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\<http:google.com>",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.nogfm.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.nogfm.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,128 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 11
                         }
                     },
                     "range": [
-                        56,
+                        47,
                         58
                     ],
-                    "raw": "\\["
+                    "raw": "\\\\ \\` \\* \\["
                 }
             ],
             "loc": {
@@ -276,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are ",
+                    "value": "Underscores are _escaped_ unless they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -284,90 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        114,
-                        130
-                    ],
-                    "raw": "Underscores are "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        130,
-                        132
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        132,
-                        139
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        139,
-                        141
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": " unless they appear in_the_middle_of_a_word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 27
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 71
                         }
                     },
                     "range": [
-                        141,
+                        114,
                         185
                     ],
-                    "raw": " unless they appear in_the_middle_of_a_word."
+                    "raw": "Underscores are \\_escaped\\_ unless they appear in_the_middle_of_a_word."
                 }
             ],
             "loc": {
@@ -429,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -441,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "&",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -449,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        263,
-                                        268
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "copycat ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        268,
-                                        276
-                                    ],
-                                    "raw": "copycat "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        276,
-                                        281
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "amp; ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        281,
-                                        286
-                                    ],
-                                    "raw": "amp; "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        286,
-                                        291
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "#x26",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 36
                                         }
                                     },
                                     "range": [
-                                        291,
+                                        263,
                                         295
                                     ],
-                                    "raw": "#x26"
+                                    "raw": "&amp;copycat &amp;amp; &amp;#x26"
                                 }
                             ],
                             "loc": {
@@ -589,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -746,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                405,
-                                408
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -777,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        404,
-                        409
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        409,
-                        411
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        411,
+                        404,
                         416
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -885,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        472,
-                        474
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        474,
-                        491
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        491,
-                        493
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        493,
-                        512
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        512,
-                        514
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -992,10 +552,10 @@
                         }
                     },
                     "range": [
-                        514,
+                        472,
                         530
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1058,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1066,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        558,
-                        560
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        560,
+                        558,
                         578
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1155,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        597,
-                        599
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        599,
-                        616
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        616,
-                        618
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1224,10 +708,10 @@
                         }
                     },
                     "range": [
-                        618,
+                        597,
                         636
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1289,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                706,
-                                                715
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1376,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                722,
-                                                725
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                725,
-                                                727
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                727,
-                                                732
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1497,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                739,
-                                                742
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1580,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                749,
-                                                750
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                750,
-                                                752
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                752,
-                                                753
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1701,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                760,
-                                                761
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                761,
-                                                763
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                763,
-                                                765
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -1822,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                772,
-                                                775
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                775,
-                                                777
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                777,
-                                                778
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2060,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2147,7 +1347,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2417,18 +1617,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1047,
-                                1053
+                                1045,
+                                1055
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2456,18 +1656,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1056,
-                                1064
+                                1055,
+                                1066
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2515,18 +1715,18 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1091,
-                                1097
+                                1089,
+                                1099
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
@@ -2554,18 +1754,18 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 14
+                                    "column": 15
                                 }
                             },
                             "range": [
-                                1100,
-                                1103
+                                1099,
+                                1104
                             ],
-                            "raw": "nei"
+                            "raw": " nei|"
                         },
                         {
                             "type": "TableCell",
@@ -2597,14 +1797,14 @@
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
                                 1104,
-                                1108
+                                1110
                             ],
-                            "raw": "ther"
+                            "raw": "ther |"
                         }
                     ],
                     "loc": {
@@ -2715,18 +1915,18 @@
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1125,
-                                1131
+                                1123,
+                                1133
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2754,18 +1954,18 @@
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 17
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                1134,
-                                1140
+                                1133,
+                                1142
                             ],
-                            "raw": "they  "
+                            "raw": " they   |"
                         }
                     ],
                     "loc": {
@@ -2813,18 +2013,18 @@
                             "loc": {
                                 "start": {
                                     "line": 64,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 64,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1165,
-                                1171
+                                1163,
+                                1173
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
@@ -2852,18 +2052,18 @@
                             "loc": {
                                 "start": {
                                     "line": 64,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 64,
-                                    "column": 17
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                1174,
-                                1180
+                                1173,
+                                1182
                             ],
-                            "raw": "though"
+                            "raw": " though |"
                         }
                     ],
                     "loc": {
@@ -2943,49 +2143,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n----- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1195,
-                        1209
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1209,
-                        1211
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "---- | ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
                         },
                         "end": {
                             "line": 70,
@@ -2993,10 +2155,10 @@
                         }
                     },
                     "range": [
-                        1211,
+                        1195,
                         1240
                     ],
-                    "raw": "---- | ------\nshould | though"
+                    "raw": "here   | they\n\\----- | ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3117,11 +2279,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3129,7 +2291,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3137,71 +2299,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1302,
-                                        1306
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1306,
-                                        1310
-                                    ],
-                                    "raw": "div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "<",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1310,
-                                        1314
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "/div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 21
                                         }
                                     },
                                     "range": [
-                                        1314,
+                                        1302,
                                         1319
                                     ],
-                                    "raw": "/div>"
+                                    "raw": "&lt;div>&lt;/div>"
                                 }
                             ],
                             "loc": {
@@ -3239,7 +2344,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3247,7 +2352,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,
@@ -3255,33 +2360,14 @@
                                         },
                                         "end": {
                                             "line": 77,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1324,
-                                        1328
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "http:google.com>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 77,
                                             "column": 24
                                         }
                                     },
                                     "range": [
-                                        1328,
+                                        1324,
                                         1344
                                     ],
-                                    "raw": "http:google.com>"
+                                    "raw": "&lt;http:google.com>"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.noposition.pedantic.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.noposition.pedantic.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [ _",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,166 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        56,
-                        58
-                    ],
-                    "raw": "\\["
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        58,
-                        59
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 14
                         }
                     },
                     "range": [
-                        59,
+                        47,
                         61
                     ],
-                    "raw": "\\_"
+                    "raw": "\\\\ \\` \\* \\[ \\_"
                 }
             ],
             "loc": {
@@ -314,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are always ",
+                    "value": "Underscores are always _escaped_, even when they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -322,280 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 23
-                        }
-                    },
-                    "range": [
-                        117,
-                        140
-                    ],
-                    "raw": "Underscores are always "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 23
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        140,
-                        142
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        142,
-                        149
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 34
-                        }
-                    },
-                    "range": [
-                        149,
-                        151
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": ", even when they appear in",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 60
-                        }
-                    },
-                    "range": [
-                        151,
-                        177
-                    ],
-                    "raw": ", even when they appear in"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 60
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 62
-                        }
-                    },
-                    "range": [
-                        177,
-                        179
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "the",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 62
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 65
-                        }
-                    },
-                    "range": [
-                        179,
-                        182
-                    ],
-                    "raw": "the"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 65
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 67
-                        }
-                    },
-                    "range": [
-                        182,
-                        184
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "middle",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 67
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 73
-                        }
-                    },
-                    "range": [
-                        184,
-                        190
-                    ],
-                    "raw": "middle"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 73
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 75
-                        }
-                    },
-                    "range": [
-                        190,
-                        192
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "of",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 75
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 77
-                        }
-                    },
-                    "range": [
-                        192,
-                        194
-                    ],
-                    "raw": "of"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 77
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 79
-                        }
-                    },
-                    "range": [
-                        194,
-                        196
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "a",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 79
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 80
-                        }
-                    },
-                    "range": [
-                        196,
-                        197
-                    ],
-                    "raw": "a"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 80
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 82
-                        }
-                    },
-                    "range": [
-                        197,
-                        199
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 82
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 87
                         }
                     },
                     "range": [
-                        199,
+                        117,
                         204
                     ],
-                    "raw": "word."
+                    "raw": "Underscores are always \\_escaped\\_, even when they appear in\\_the\\_middle\\_of\\_a\\_word."
                 }
             ],
             "loc": {
@@ -657,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -669,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "&",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -677,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        282,
-                                        287
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "copycat ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        287,
-                                        295
-                                    ],
-                                    "raw": "copycat "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        295,
-                                        300
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "amp; ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        300,
-                                        305
-                                    ],
-                                    "raw": "amp; "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        305,
-                                        310
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "#x26",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 36
                                         }
                                     },
                                     "range": [
-                                        310,
+                                        282,
                                         314
                                     ],
-                                    "raw": "#x26"
+                                    "raw": "&amp;copycat &amp;amp; &amp;#x26"
                                 }
                             ],
                             "loc": {
@@ -817,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -974,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                424,
-                                427
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -1005,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        423,
-                        428
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        428,
-                        430
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        430,
+                        423,
                         435
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -1113,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        491,
-                        493
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        493,
-                        510
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        510,
-                        512
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        512,
-                        531
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        531,
-                        533
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -1220,10 +552,10 @@
                         }
                     },
                     "range": [
-                        533,
+                        491,
                         549
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1286,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1294,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        577,
-                        579
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        579,
+                        577,
                         597
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1383,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        616,
-                        618
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        618,
-                        635
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        635,
-                        637
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1452,10 +708,10 @@
                         }
                     },
                     "range": [
-                        637,
+                        616,
                         655
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1517,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                725,
-                                                734
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1604,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                741,
-                                                744
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                744,
-                                                746
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                746,
-                                                751
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1725,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                758,
-                                                761
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1808,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                768,
-                                                769
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                769,
-                                                771
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                771,
-                                                772
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1929,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                779,
-                                                780
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                780,
-                                                782
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                782,
-                                                784
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -2050,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                791,
-                                                794
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                794,
-                                                796
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                796,
-                                                797
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2288,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2300,60 +1272,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        848,
-                                        852
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        852,
-                                        858
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 63
-                                        }
-                                    },
-                                    "range": [
-                                        858,
-                                        907
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2391,7 +1310,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2399,60 +1318,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        912,
-                                        917
-                                    ],
-                                    "raw": "https"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        917,
-                                        923
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 64
-                                        }
-                                    },
-                                    "range": [
-                                        923,
-                                        972
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2510,7 +1376,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Double tildes should be ",
+                    "value": "Double tildes should be ~",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2518,37 +1384,38 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 24
+                            "column": 26
                         }
                     },
                     "range": [
                         974,
-                        998
-                    ],
-                    "raw": "Double tildes should be "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        998,
                         1000
                     ],
-                    "raw": "\\~"
+                    "raw": "Double tildes should be \\~"
                 },
                 {
-                    "type": "Str",
-                    "value": "~escaped",
+                    "type": "Delete",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "escaped~",
+                            "loc": {
+                                "start": {
+                                    "line": 51,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 51,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                1001,
+                                1010
+                            ],
+                            "raw": "escaped\\~"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2556,79 +1423,22 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 34
+                            "column": 37
                         }
                     },
                     "range": [
                         1000,
-                        1008
+                        1011
                     ],
-                    "raw": "~escaped"
+                    "raw": "~escaped\\~~"
                 },
                 {
                     "type": "Str",
-                    "value": "~",
+                    "value": ".\nAnd here: foo~~.",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        1008,
-                        1010
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.\nAnd here: foo",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 36
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        1010,
-                        1026
-                    ],
-                    "raw": "~.\nAnd here: foo"
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        1026,
-                        1028
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 15
+                            "column": 37
                         },
                         "end": {
                             "line": 52,
@@ -2636,10 +1446,10 @@
                         }
                     },
                     "range": [
-                        1028,
+                        1011,
                         1030
                     ],
-                    "raw": "~."
+                    "raw": ".\nAnd here: foo\\~~."
                 }
             ],
             "loc": {
@@ -2733,18 +1543,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1071,
-                                1077
+                                1069,
+                                1079
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2772,18 +1582,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1080,
-                                1088
+                                1079,
+                                1090
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2831,25 +1641,25 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1115,
-                                1121
+                                1113,
+                                1123
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "tho",
+                                    "value": "tho|ugh",
                                     "loc": {
                                         "start": {
                                             "line": 58,
@@ -2857,69 +1667,31 @@
                                         },
                                         "end": {
                                             "line": 58,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        1124,
-                                        1127
-                                    ],
-                                    "raw": "tho"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 58,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1127,
-                                        1129
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "ugh",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 58,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        1129,
+                                        1124,
                                         1132
                                     ],
-                                    "raw": "ugh"
+                                    "raw": "tho\\|ugh"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1124,
-                                1132
+                                1123,
+                                1134
                             ],
-                            "raw": "tho\\|ugh"
+                            "raw": " tho\\|ugh |"
                         }
                     ],
                     "loc": {
@@ -2999,125 +1771,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "| here   | they   |\n",
+                    "value": "| here   | they   |\n| ---- | ----- |\n| should | though |",
                     "loc": {
                         "start": {
                             "line": 62,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1147,
-                        1167
-                    ],
-                    "raw": "| here   | they   |\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1167,
-                        1169
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ---- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1169,
-                        1175
-                    ],
-                    "raw": " ---- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        1175,
-                        1177
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ----- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        1177,
-                        1184
-                    ],
-                    "raw": " ----- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 19
-                        }
-                    },
-                    "range": [
-                        1184,
-                        1186
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": "\n| should | though |",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 19
                         },
                         "end": {
                             "line": 64,
@@ -3125,10 +1783,10 @@
                         }
                     },
                     "range": [
-                        1186,
+                        1147,
                         1206
                     ],
-                    "raw": "\n| should | though |"
+                    "raw": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |"
                 }
             ],
             "loc": {
@@ -3191,87 +1849,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n---- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1219,
-                        1233
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1233,
-                        1235
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "--- ",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        1235,
-                        1239
-                    ],
-                    "raw": "--- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1239,
-                        1241
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 8
                         },
                         "end": {
                             "line": 70,
@@ -3279,10 +1861,10 @@
                         }
                     },
                     "range": [
-                        1241,
+                        1219,
                         1264
                     ],
-                    "raw": " ------\nshould | though"
+                    "raw": "here   | they\n\\---- \\| ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3403,11 +1985,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3415,7 +1997,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3423,71 +2005,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1326,
-                                        1330
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1330,
-                                        1334
-                                    ],
-                                    "raw": "div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "<",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1334,
-                                        1338
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "/div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 21
                                         }
                                     },
                                     "range": [
-                                        1338,
+                                        1326,
                                         1343
                                     ],
-                                    "raw": "/div>"
+                                    "raw": "&lt;div>&lt;/div>"
                                 }
                             ],
                             "loc": {
@@ -3525,7 +2050,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3533,7 +2058,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,
@@ -3541,71 +2066,14 @@
                                         },
                                         "end": {
                                             "line": 77,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1348,
-                                        1352
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1352,
-                                        1356
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 18
-                                        }
-                                    },
-                                    "range": [
-                                        1356,
-                                        1362
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "google.com>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 18
-                                        },
-                                        "end": {
-                                            "line": 77,
                                             "column": 29
                                         }
                                     },
                                     "range": [
-                                        1362,
+                                        1348,
                                         1373
                                     ],
-                                    "raw": "google.com>"
+                                    "raw": "&lt;http&#x3A;google.com>"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.noposition.pedantic.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.noposition.pedantic.text/output.json
@@ -1272,7 +1272,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 48,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 48,
+                                            "column": 63
+                                        }
+                                    },
+                                    "range": [
+                                        848,
+                                        907
+                                    ],
+                                    "raw": "http&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1318,7 +1333,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 49,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 49,
+                                            "column": 64
+                                        }
+                                    },
+                                    "range": [
+                                        912,
+                                        972
+                                    ],
+                                    "raw": "https&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.pedantic.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.pedantic.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [ _",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,166 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        56,
-                        58
-                    ],
-                    "raw": "\\["
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 11
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 12
-                        }
-                    },
-                    "range": [
-                        58,
-                        59
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 12
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 14
                         }
                     },
                     "range": [
-                        59,
+                        47,
                         61
                     ],
-                    "raw": "\\_"
+                    "raw": "\\\\ \\` \\* \\[ \\_"
                 }
             ],
             "loc": {
@@ -314,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are always ",
+                    "value": "Underscores are always _escaped_, even when they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -322,280 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 23
-                        }
-                    },
-                    "range": [
-                        117,
-                        140
-                    ],
-                    "raw": "Underscores are always "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 23
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        140,
-                        142
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        142,
-                        149
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 34
-                        }
-                    },
-                    "range": [
-                        149,
-                        151
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": ", even when they appear in",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 60
-                        }
-                    },
-                    "range": [
-                        151,
-                        177
-                    ],
-                    "raw": ", even when they appear in"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 60
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 62
-                        }
-                    },
-                    "range": [
-                        177,
-                        179
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "the",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 62
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 65
-                        }
-                    },
-                    "range": [
-                        179,
-                        182
-                    ],
-                    "raw": "the"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 65
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 67
-                        }
-                    },
-                    "range": [
-                        182,
-                        184
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "middle",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 67
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 73
-                        }
-                    },
-                    "range": [
-                        184,
-                        190
-                    ],
-                    "raw": "middle"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 73
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 75
-                        }
-                    },
-                    "range": [
-                        190,
-                        192
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "of",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 75
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 77
-                        }
-                    },
-                    "range": [
-                        192,
-                        194
-                    ],
-                    "raw": "of"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 77
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 79
-                        }
-                    },
-                    "range": [
-                        194,
-                        196
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "a",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 79
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 80
-                        }
-                    },
-                    "range": [
-                        196,
-                        197
-                    ],
-                    "raw": "a"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 80
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 82
-                        }
-                    },
-                    "range": [
-                        197,
-                        199
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 82
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 87
                         }
                     },
                     "range": [
-                        199,
+                        117,
                         204
                     ],
-                    "raw": "word."
+                    "raw": "Underscores are always \\_escaped\\_, even when they appear in\\_the\\_middle\\_of\\_a\\_word."
                 }
             ],
             "loc": {
@@ -657,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -669,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "&",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -677,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        282,
-                                        287
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "copycat ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        287,
-                                        295
-                                    ],
-                                    "raw": "copycat "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        295,
-                                        300
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "amp; ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        300,
-                                        305
-                                    ],
-                                    "raw": "amp; "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        305,
-                                        310
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "#x26",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 36
                                         }
                                     },
                                     "range": [
-                                        310,
+                                        282,
                                         314
                                     ],
-                                    "raw": "#x26"
+                                    "raw": "&amp;copycat &amp;amp; &amp;#x26"
                                 }
                             ],
                             "loc": {
@@ -817,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -974,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                424,
-                                427
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -1005,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        423,
-                        428
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        428,
-                        430
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        430,
+                        423,
                         435
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -1113,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        491,
-                        493
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        493,
-                        510
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        510,
-                        512
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        512,
-                        531
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        531,
-                        533
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -1220,10 +552,10 @@
                         }
                     },
                     "range": [
-                        533,
+                        491,
                         549
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1286,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1294,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        577,
-                        579
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        579,
+                        577,
                         597
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1383,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        616,
-                        618
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        618,
-                        635
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        635,
-                        637
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1452,10 +708,10 @@
                         }
                     },
                     "range": [
-                        637,
+                        616,
                         655
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1517,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                725,
-                                                734
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1604,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                741,
-                                                744
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                744,
-                                                746
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                746,
-                                                751
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1725,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                758,
-                                                761
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1808,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                768,
-                                                769
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                769,
-                                                771
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                771,
-                                                772
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1929,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                779,
-                                                780
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                780,
-                                                782
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                782,
-                                                784
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -2050,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                791,
-                                                794
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                794,
-                                                796
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                796,
-                                                797
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2288,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2300,60 +1272,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        848,
-                                        852
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        852,
-                                        858
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 63
-                                        }
-                                    },
-                                    "range": [
-                                        858,
-                                        907
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2391,7 +1310,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2399,60 +1318,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        912,
-                                        917
-                                    ],
-                                    "raw": "https"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        917,
-                                        923
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 64
-                                        }
-                                    },
-                                    "range": [
-                                        923,
-                                        972
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2510,7 +1376,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Double tildes should be ",
+                    "value": "Double tildes should be ~",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2518,37 +1384,38 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 24
+                            "column": 26
                         }
                     },
                     "range": [
                         974,
-                        998
-                    ],
-                    "raw": "Double tildes should be "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        998,
                         1000
                     ],
-                    "raw": "\\~"
+                    "raw": "Double tildes should be \\~"
                 },
                 {
-                    "type": "Str",
-                    "value": "~escaped",
+                    "type": "Delete",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "escaped~",
+                            "loc": {
+                                "start": {
+                                    "line": 51,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 51,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                1001,
+                                1010
+                            ],
+                            "raw": "escaped\\~"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2556,79 +1423,22 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 34
+                            "column": 37
                         }
                     },
                     "range": [
                         1000,
-                        1008
+                        1011
                     ],
-                    "raw": "~escaped"
+                    "raw": "~escaped\\~~"
                 },
                 {
                     "type": "Str",
-                    "value": "~",
+                    "value": ".\nAnd here: foo~~.",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        1008,
-                        1010
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.\nAnd here: foo",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 36
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        1010,
-                        1026
-                    ],
-                    "raw": "~.\nAnd here: foo"
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        1026,
-                        1028
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 15
+                            "column": 37
                         },
                         "end": {
                             "line": 52,
@@ -2636,10 +1446,10 @@
                         }
                     },
                     "range": [
-                        1028,
+                        1011,
                         1030
                     ],
-                    "raw": "~."
+                    "raw": ".\nAnd here: foo\\~~."
                 }
             ],
             "loc": {
@@ -2733,18 +1543,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1071,
-                                1077
+                                1069,
+                                1079
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2772,18 +1582,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1080,
-                                1088
+                                1079,
+                                1090
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2831,25 +1641,25 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1115,
-                                1121
+                                1113,
+                                1123
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "tho",
+                                    "value": "tho|ugh",
                                     "loc": {
                                         "start": {
                                             "line": 58,
@@ -2857,69 +1667,31 @@
                                         },
                                         "end": {
                                             "line": 58,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        1124,
-                                        1127
-                                    ],
-                                    "raw": "tho"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 58,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1127,
-                                        1129
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "ugh",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 58,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        1129,
+                                        1124,
                                         1132
                                     ],
-                                    "raw": "ugh"
+                                    "raw": "tho\\|ugh"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1124,
-                                1132
+                                1123,
+                                1134
                             ],
-                            "raw": "tho\\|ugh"
+                            "raw": " tho\\|ugh |"
                         }
                     ],
                     "loc": {
@@ -2999,125 +1771,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "| here   | they   |\n",
+                    "value": "| here   | they   |\n| ---- | ----- |\n| should | though |",
                     "loc": {
                         "start": {
                             "line": 62,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1147,
-                        1167
-                    ],
-                    "raw": "| here   | they   |\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1167,
-                        1169
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ---- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1169,
-                        1175
-                    ],
-                    "raw": " ---- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        1175,
-                        1177
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ----- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        1177,
-                        1184
-                    ],
-                    "raw": " ----- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 19
-                        }
-                    },
-                    "range": [
-                        1184,
-                        1186
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": "\n| should | though |",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 19
                         },
                         "end": {
                             "line": 64,
@@ -3125,10 +1783,10 @@
                         }
                     },
                     "range": [
-                        1186,
+                        1147,
                         1206
                     ],
-                    "raw": "\n| should | though |"
+                    "raw": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |"
                 }
             ],
             "loc": {
@@ -3191,87 +1849,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n---- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1219,
-                        1233
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1233,
-                        1235
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "--- ",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        1235,
-                        1239
-                    ],
-                    "raw": "--- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1239,
-                        1241
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 8
                         },
                         "end": {
                             "line": 70,
@@ -3279,10 +1861,10 @@
                         }
                     },
                     "range": [
-                        1241,
+                        1219,
                         1264
                     ],
-                    "raw": " ------\nshould | though"
+                    "raw": "here   | they\n\\---- \\| ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3403,11 +1985,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3415,7 +1997,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3423,71 +2005,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1326,
-                                        1330
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1330,
-                                        1334
-                                    ],
-                                    "raw": "div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "<",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1334,
-                                        1338
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "/div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 21
                                         }
                                     },
                                     "range": [
-                                        1338,
+                                        1326,
                                         1343
                                     ],
-                                    "raw": "/div>"
+                                    "raw": "&lt;div>&lt;/div>"
                                 }
                             ],
                             "loc": {
@@ -3525,7 +2050,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3533,7 +2058,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,
@@ -3541,71 +2066,14 @@
                                         },
                                         "end": {
                                             "line": 77,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1348,
-                                        1352
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1352,
-                                        1356
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 18
-                                        }
-                                    },
-                                    "range": [
-                                        1356,
-                                        1362
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "google.com>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 18
-                                        },
-                                        "end": {
-                                            "line": 77,
                                             "column": 29
                                         }
                                     },
                                     "range": [
-                                        1362,
+                                        1348,
                                         1373
                                     ],
-                                    "raw": "google.com>"
+                                    "raw": "&lt;http&#x3A;google.com>"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.pedantic.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.pedantic.text/output.json
@@ -1272,7 +1272,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 48,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 48,
+                                            "column": 63
+                                        }
+                                    },
+                                    "range": [
+                                        848,
+                                        907
+                                    ],
+                                    "raw": "http&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1318,7 +1333,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 49,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 49,
+                                            "column": 64
+                                        }
+                                    },
+                                    "range": [
+                                        912,
+                                        972
+                                    ],
+                                    "raw": "https&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.text/output.json
@@ -1272,7 +1272,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 48,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 48,
+                                            "column": 63
+                                        }
+                                    },
+                                    "range": [
+                                        829,
+                                        888
+                                    ],
+                                    "raw": "http&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1318,7 +1333,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 49,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 49,
+                                            "column": 64
+                                        }
+                                    },
+                                    "range": [
+                                        893,
+                                        953
+                                    ],
+                                    "raw": "https&#x3A;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.output.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,128 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 11
                         }
                     },
                     "range": [
-                        56,
+                        47,
                         58
                     ],
-                    "raw": "\\["
+                    "raw": "\\\\ \\` \\* \\["
                 }
             ],
             "loc": {
@@ -276,7 +162,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are ",
+                    "value": "Underscores are _escaped_ unless they appear in_the_middle_of_a_word.",
                     "loc": {
                         "start": {
                             "line": 9,
@@ -284,90 +170,14 @@
                         },
                         "end": {
                             "line": 9,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        114,
-                        130
-                    ],
-                    "raw": "Underscores are "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        130,
-                        132
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        132,
-                        139
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        139,
-                        141
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": " unless they appear in_the_middle_of_a_word.",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 27
-                        },
-                        "end": {
-                            "line": 9,
                             "column": 71
                         }
                     },
                     "range": [
-                        141,
+                        114,
                         185
                     ],
-                    "raw": " unless they appear in_the_middle_of_a_word."
+                    "raw": "Underscores are \\_escaped\\_ unless they appear in_the_middle_of_a_word."
                 }
             ],
             "loc": {
@@ -429,11 +239,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -441,7 +251,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "&",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -449,109 +259,14 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        263,
-                                        268
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "copycat ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        268,
-                                        276
-                                    ],
-                                    "raw": "copycat "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        276,
-                                        281
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "amp; ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        281,
-                                        286
-                                    ],
-                                    "raw": "amp; "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 13,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        286,
-                                        291
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "#x26",
-                                    "loc": {
-                                        "start": {
-                                            "line": 13,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 13,
                                             "column": 36
                                         }
                                     },
                                     "range": [
-                                        291,
+                                        263,
                                         295
                                     ],
-                                    "raw": "#x26"
+                                    "raw": "&amp;copycat &amp;amp; &amp;#x26"
                                 }
                             ],
                             "loc": {
@@ -589,7 +304,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -746,30 +461,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 18,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 18,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                405,
-                                408
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 18,
@@ -777,52 +470,14 @@
                         },
                         "end": {
                             "line": 18,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        404,
-                        409
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 18,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        409,
-                        411
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 18,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 18,
                             "column": 12
                         }
                     },
                     "range": [
-                        411,
+                        404,
                         416
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -885,106 +540,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 22,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 22,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        472,
-                        474
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 22,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        474,
-                        491
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 23,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        491,
-                        493
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 23,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        493,
-                        512
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        512,
-                        514
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 4
                         },
                         "end": {
                             "line": 24,
@@ -992,10 +552,10 @@
                         }
                     },
                     "range": [
-                        514,
+                        472,
                         530
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1058,7 +618,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 28,
@@ -1066,33 +626,14 @@
                         },
                         "end": {
                             "line": 28,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        558,
-                        560
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 28,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 28,
                             "column": 20
                         }
                     },
                     "range": [
-                        560,
+                        558,
                         578
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1155,68 +696,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        597,
-                        599
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        599,
-                        616
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 33,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        616,
-                        618
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 33,
-                            "column": 4
                         },
                         "end": {
                             "line": 33,
@@ -1224,10 +708,10 @@
                         }
                     },
                     "range": [
-                        618,
+                        597,
                         636
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1289,41 +773,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 37,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 37,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                706,
-                                                715
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 37,
@@ -1376,75 +838,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                722,
-                                                725
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                725,
-                                                727
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 38,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 38,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                727,
-                                                732
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 38,
@@ -1497,37 +899,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                739,
-                                                742
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1580,75 +960,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                749,
-                                                750
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                750,
-                                                752
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                752,
-                                                753
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1701,75 +1021,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                760,
-                                                761
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                761,
-                                                763
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                763,
-                                                765
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -1822,75 +1082,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                772,
-                                                775
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                775,
-                                                777
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                777,
-                                                778
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -2060,11 +1260,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2072,60 +1272,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        829,
-                                        833
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        833,
-                                        839
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 48,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 48,
-                                            "column": 63
-                                        }
-                                    },
-                                    "range": [
-                                        839,
-                                        888
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2163,7 +1310,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2171,60 +1318,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        893,
-                                        898
-                                    ],
-                                    "raw": "https"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        898,
-                                        904
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 49,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 49,
-                                            "column": 64
-                                        }
-                                    },
-                                    "range": [
-                                        904,
-                                        953
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2282,7 +1376,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Double tildes should be ",
+                    "value": "Double tildes should be ~",
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2290,37 +1384,38 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 24
+                            "column": 26
                         }
                     },
                     "range": [
                         955,
-                        979
-                    ],
-                    "raw": "Double tildes should be "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        979,
                         981
                     ],
-                    "raw": "\\~"
+                    "raw": "Double tildes should be \\~"
                 },
                 {
-                    "type": "Str",
-                    "value": "~escaped",
+                    "type": "Delete",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "escaped~",
+                            "loc": {
+                                "start": {
+                                    "line": 51,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 51,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                982,
+                                991
+                            ],
+                            "raw": "escaped\\~"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 51,
@@ -2328,79 +1423,22 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 34
+                            "column": 37
                         }
                     },
                     "range": [
                         981,
-                        989
+                        992
                     ],
-                    "raw": "~escaped"
+                    "raw": "~escaped\\~~"
                 },
                 {
                     "type": "Str",
-                    "value": "~",
+                    "value": ".\nAnd here: foo~~.",
                     "loc": {
                         "start": {
                             "line": 51,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        989,
-                        991
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.\nAnd here: foo",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 36
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 13
-                        }
-                    },
-                    "range": [
-                        991,
-                        1007
-                    ],
-                    "raw": "~.\nAnd here: foo"
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 13
-                        },
-                        "end": {
-                            "line": 52,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        1007,
-                        1009
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.",
-                    "loc": {
-                        "start": {
-                            "line": 52,
-                            "column": 15
+                            "column": 37
                         },
                         "end": {
                             "line": 52,
@@ -2408,10 +1446,10 @@
                         }
                     },
                     "range": [
-                        1009,
+                        992,
                         1011
                     ],
-                    "raw": "~."
+                    "raw": ".\nAnd here: foo\\~~."
                 }
             ],
             "loc": {
@@ -2505,18 +1543,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1052,
-                                1058
+                                1050,
+                                1060
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2544,18 +1582,18 @@
                             "loc": {
                                 "start": {
                                     "line": 56,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 56,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1061,
-                                1069
+                                1060,
+                                1071
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2603,25 +1641,25 @@
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1096,
-                                1102
+                                1094,
+                                1104
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "tho",
+                                    "value": "tho|ugh",
                                     "loc": {
                                         "start": {
                                             "line": 58,
@@ -2629,69 +1667,31 @@
                                         },
                                         "end": {
                                             "line": 58,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        1105,
-                                        1108
-                                    ],
-                                    "raw": "tho"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 58,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1108,
-                                        1110
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "ugh",
-                                    "loc": {
-                                        "start": {
-                                            "line": 58,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 58,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        1110,
+                                        1105,
                                         1113
                                     ],
-                                    "raw": "ugh"
+                                    "raw": "tho\\|ugh"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 58,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 58,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1105,
-                                1113
+                                1104,
+                                1115
                             ],
-                            "raw": "tho\\|ugh"
+                            "raw": " tho\\|ugh |"
                         }
                     ],
                     "loc": {
@@ -2771,125 +1771,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "| here   | they   |\n",
+                    "value": "| here   | they   |\n| ---- | ----- |\n| should | though |",
                     "loc": {
                         "start": {
                             "line": 62,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1128,
-                        1148
-                    ],
-                    "raw": "| here   | they   |\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1148,
-                        1150
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ---- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1150,
-                        1156
-                    ],
-                    "raw": " ---- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        1156,
-                        1158
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ----- ",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        1158,
-                        1165
-                    ],
-                    "raw": " ----- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 63,
-                            "column": 19
-                        }
-                    },
-                    "range": [
-                        1165,
-                        1167
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": "\n| should | though |",
-                    "loc": {
-                        "start": {
-                            "line": 63,
-                            "column": 19
                         },
                         "end": {
                             "line": 64,
@@ -2897,10 +1783,10 @@
                         }
                     },
                     "range": [
-                        1167,
+                        1128,
                         1187
                     ],
-                    "raw": "\n| should | though |"
+                    "raw": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |"
                 }
             ],
             "loc": {
@@ -2963,87 +1849,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n---- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 68,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1200,
-                        1214
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1214,
-                        1216
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "--- ",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        1216,
-                        1220
-                    ],
-                    "raw": "--- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 69,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1220,
-                        1222
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 69,
-                            "column": 8
                         },
                         "end": {
                             "line": 70,
@@ -3051,10 +1861,10 @@
                         }
                     },
                     "range": [
-                        1222,
+                        1200,
                         1245
                     ],
-                    "raw": " ------\nshould | though"
+                    "raw": "here   | they\n\\---- \\| ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3175,11 +1985,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3187,7 +1997,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 76,
@@ -3195,71 +2005,14 @@
                                         },
                                         "end": {
                                             "line": 76,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1307,
-                                        1311
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1311,
-                                        1315
-                                    ],
-                                    "raw": "div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "<",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 76,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1315,
-                                        1319
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "/div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 76,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 76,
                                             "column": 21
                                         }
                                     },
                                     "range": [
-                                        1319,
+                                        1307,
                                         1324
                                     ],
-                                    "raw": "/div>"
+                                    "raw": "&lt;div>&lt;/div>"
                                 }
                             ],
                             "loc": {
@@ -3297,7 +2050,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3305,7 +2058,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 77,
@@ -3313,71 +2066,14 @@
                                         },
                                         "end": {
                                             "line": 77,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1329,
-                                        1333
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1333,
-                                        1337
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 77,
-                                            "column": 18
-                                        }
-                                    },
-                                    "range": [
-                                        1337,
-                                        1343
-                                    ],
-                                    "raw": "&#x3A;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "google.com>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 77,
-                                            "column": 18
-                                        },
-                                        "end": {
-                                            "line": 77,
                                             "column": 29
                                         }
                                     },
                                     "range": [
-                                        1343,
+                                        1329,
                                         1354
                                     ],
-                                    "raw": "google.com>"
+                                    "raw": "&lt;http&#x3A;google.com>"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.text/output.json
@@ -1391,7 +1391,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 50,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 50,
+                                            "column": 59
+                                        }
+                                    },
+                                    "range": [
+                                        881,
+                                        936
+                                    ],
+                                    "raw": "http\\://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1437,7 +1452,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 51,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 51,
+                                            "column": 60
+                                        }
+                                    },
+                                    "range": [
+                                        941,
+                                        997
+                                    ],
+                                    "raw": "https\\://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1483,7 +1513,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 52,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 52,
+                                            "column": 64
+                                        }
+                                    },
+                                    "range": [
+                                        1002,
+                                        1062
+                                    ],
+                                    "raw": "http&colon;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -1529,7 +1574,22 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment",
+                                    "loc": {
+                                        "start": {
+                                            "line": 53,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 53,
+                                            "column": 65
+                                        }
+                                    },
+                                    "range": [
+                                        1067,
+                                        1128
+                                    ],
+                                    "raw": "https&colon;//user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/stringify-escape.text/output.json
@@ -45,7 +45,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "\\",
+                    "value": "\\ ` * [",
                     "loc": {
                         "start": {
                             "line": 3,
@@ -53,128 +53,14 @@
                         },
                         "end": {
                             "line": 3,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        47,
-                        49
-                    ],
-                    "raw": "\\\\"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 3
-                        }
-                    },
-                    "range": [
-                        49,
-                        50
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "`",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 3
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        50,
-                        52
-                    ],
-                    "raw": "\\`"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        52,
-                        53
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "*",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        53,
-                        55
-                    ],
-                    "raw": "\\*"
-                },
-                {
-                    "type": "Str",
-                    "value": " ",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 3,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        55,
-                        56
-                    ],
-                    "raw": " "
-                },
-                {
-                    "type": "Str",
-                    "value": "[",
-                    "loc": {
-                        "start": {
-                            "line": 3,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 3,
                             "column": 11
                         }
                     },
                     "range": [
-                        56,
+                        47,
                         58
                     ],
-                    "raw": "\\["
+                    "raw": "\\\\ \\` \\* \\["
                 }
             ],
             "loc": {
@@ -276,87 +162,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Underscores are ",
+                    "value": "Underscores are _escaped_ unless they appear in_the_middle_of_a_word.\nor ",
                     "loc": {
                         "start": {
                             "line": 9,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 16
-                        }
-                    },
-                    "range": [
-                        114,
-                        130
-                    ],
-                    "raw": "Underscores are "
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 16
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        130,
-                        132
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": "escaped",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 18
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 25
-                        }
-                    },
-                    "range": [
-                        132,
-                        139
-                    ],
-                    "raw": "escaped"
-                },
-                {
-                    "type": "Str",
-                    "value": "_",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 25
-                        },
-                        "end": {
-                            "line": 9,
-                            "column": 27
-                        }
-                    },
-                    "range": [
-                        139,
-                        141
-                    ],
-                    "raw": "\\_"
-                },
-                {
-                    "type": "Str",
-                    "value": " unless they appear in_the_middle_of_a_word.\nor ",
-                    "loc": {
-                        "start": {
-                            "line": 9,
-                            "column": 27
                         },
                         "end": {
                             "line": 10,
@@ -364,10 +174,10 @@
                         }
                     },
                     "range": [
-                        141,
+                        114,
                         189
                     ],
-                    "raw": " unless they appear in_the_middle_of_a_word.\nor "
+                    "raw": "Underscores are \\_escaped\\_ unless they appear in_the_middle_of_a_word.\nor "
                 },
                 {
                     "type": "Strong",
@@ -487,11 +297,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -499,7 +309,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 14,
@@ -507,109 +317,14 @@
                                         },
                                         "end": {
                                             "line": 14,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        287,
-                                        288
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "©",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 14,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        288,
-                                        293
-                                    ],
-                                    "raw": "&copy"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "cat \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 14,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        293,
-                                        298
-                                    ],
-                                    "raw": "cat \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 14,
-                                            "column": 20
-                                        }
-                                    },
-                                    "range": [
-                                        298,
-                                        303
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " \\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 20
-                                        },
-                                        "end": {
-                                            "line": 14,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        303,
-                                        305
-                                    ],
-                                    "raw": " \\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 14,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 14,
                                             "column": 27
                                         }
                                     },
                                     "range": [
-                                        305,
+                                        287,
                                         310
                                     ],
-                                    "raw": "&#x26"
+                                    "raw": "\\&copycat \\&amp; \\&#x26"
                                 }
                             ],
                             "loc": {
@@ -647,7 +362,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -655,7 +370,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "&",
+                                    "value": "&copycat &amp; &#x26",
                                     "loc": {
                                         "start": {
                                             "line": 15,
@@ -663,109 +378,14 @@
                                         },
                                         "end": {
                                             "line": 15,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        315,
-                                        320
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "copycat ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 15,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 15,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        320,
-                                        328
-                                    ],
-                                    "raw": "copycat "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 15,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 15,
-                                            "column": 22
-                                        }
-                                    },
-                                    "range": [
-                                        328,
-                                        333
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "amp; ",
-                                    "loc": {
-                                        "start": {
-                                            "line": 15,
-                                            "column": 22
-                                        },
-                                        "end": {
-                                            "line": 15,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        333,
-                                        338
-                                    ],
-                                    "raw": "amp; "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "&",
-                                    "loc": {
-                                        "start": {
-                                            "line": 15,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 15,
-                                            "column": 32
-                                        }
-                                    },
-                                    "range": [
-                                        338,
-                                        343
-                                    ],
-                                    "raw": "&amp;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "#x26",
-                                    "loc": {
-                                        "start": {
-                                            "line": 15,
-                                            "column": 32
-                                        },
-                                        "end": {
-                                            "line": 15,
                                             "column": 36
                                         }
                                     },
                                     "range": [
-                                        343,
+                                        315,
                                         347
                                     ],
-                                    "raw": "#x26"
+                                    "raw": "&amp;copycat &amp;amp; &amp;#x26"
                                 }
                             ],
                             "loc": {
@@ -803,7 +423,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -960,30 +580,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "ref",
-                    "referenceType": "shortcut",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "ref",
-                            "loc": {
-                                "start": {
-                                    "line": 20,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 20,
-                                    "column": 4
-                                }
-                            },
-                            "range": [
-                                457,
-                                460
-                            ],
-                            "raw": "ref"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[ref](text)",
                     "loc": {
                         "start": {
                             "line": 20,
@@ -991,52 +589,14 @@
                         },
                         "end": {
                             "line": 20,
-                            "column": 5
-                        }
-                    },
-                    "range": [
-                        456,
-                        461
-                    ],
-                    "raw": "[ref]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 20,
-                            "column": 5
-                        },
-                        "end": {
-                            "line": 20,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        461,
-                        463
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "text)",
-                    "loc": {
-                        "start": {
-                            "line": 20,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 20,
                             "column": 12
                         }
                     },
                     "range": [
-                        463,
+                        456,
                         468
                     ],
-                    "raw": "text)"
+                    "raw": "[ref]\\(text)"
                 }
             ],
             "loc": {
@@ -1099,106 +659,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "-",
+                    "value": "- not a list item\n- not a list item\n+ not a list item",
                     "loc": {
                         "start": {
                             "line": 24,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 24,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        524,
-                        526
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n",
-                    "loc": {
-                        "start": {
-                            "line": 24,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 25,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        526,
-                        543
-                    ],
-                    "raw": " not a list item\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 25,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 25,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        543,
-                        545
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 25,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 26,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        545,
-                        564
-                    ],
-                    "raw": " not a list item\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "+",
-                    "loc": {
-                        "start": {
-                            "line": 26,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 26,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        564,
-                        566
-                    ],
-                    "raw": "\\+"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a list item",
-                    "loc": {
-                        "start": {
-                            "line": 26,
-                            "column": 4
                         },
                         "end": {
                             "line": 26,
@@ -1206,10 +671,10 @@
                         }
                     },
                     "range": [
-                        566,
+                        524,
                         582
                     ],
-                    "raw": " not a list item"
+                    "raw": "\\- not a list item\n\\- not a list item\n  \\+ not a list item"
                 }
             ],
             "loc": {
@@ -1272,7 +737,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": ">",
+                    "value": "> not a block quote",
                     "loc": {
                         "start": {
                             "line": 30,
@@ -1280,33 +745,14 @@
                         },
                         "end": {
                             "line": 30,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        610,
-                        612
-                    ],
-                    "raw": "\\>"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a block quote",
-                    "loc": {
-                        "start": {
-                            "line": 30,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 30,
                             "column": 20
                         }
                     },
                     "range": [
-                        612,
+                        610,
                         630
                     ],
-                    "raw": " not a block quote"
+                    "raw": "\\> not a block quote"
                 }
             ],
             "loc": {
@@ -1369,68 +815,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "#",
+                    "value": "# not a heading\n## not a subheading",
                     "loc": {
                         "start": {
                             "line": 34,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 34,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        649,
-                        651
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": " not a heading\n  ",
-                    "loc": {
-                        "start": {
-                            "line": 34,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 35,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        651,
-                        668
-                    ],
-                    "raw": " not a heading\n  "
-                },
-                {
-                    "type": "Str",
-                    "value": "#",
-                    "loc": {
-                        "start": {
-                            "line": 35,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 35,
-                            "column": 4
-                        }
-                    },
-                    "range": [
-                        668,
-                        670
-                    ],
-                    "raw": "\\#"
-                },
-                {
-                    "type": "Str",
-                    "value": "# not a subheading",
-                    "loc": {
-                        "start": {
-                            "line": 35,
-                            "column": 4
                         },
                         "end": {
                             "line": 35,
@@ -1438,10 +827,10 @@
                         }
                     },
                     "range": [
-                        670,
+                        649,
                         688
                     ],
-                    "raw": "# not a subheading"
+                    "raw": "\\# not a heading\n  \\## not a subheading"
                 }
             ],
             "loc": {
@@ -1503,41 +892,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two*three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 39,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 39,
-                                                    "column": 14
-                                                }
-                                            },
-                                            "range": [
-                                                758,
-                                                767
-                                            ],
-                                            "raw": "two*three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 39,
@@ -1590,75 +957,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "two\\*three",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "two",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                774,
-                                                777
-                                            ],
-                                            "raw": "two"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "*",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                777,
-                                                779
-                                            ],
-                                            "raw": "\\*"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "three",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 40,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 40,
-                                                    "column": 15
-                                                }
-                                            },
-                                            "range": [
-                                                779,
-                                                784
-                                            ],
-                                            "raw": "three"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[two*three]",
                                     "loc": {
                                         "start": {
                                             "line": 40,
@@ -1711,37 +1018,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 41,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 41,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                791,
-                                                794
-                                            ],
-                                            "raw": "a\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 41,
@@ -1794,75 +1079,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                801,
-                                                802
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                802,
-                                                804
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 42,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 42,
-                                                    "column": 9
-                                                }
-                                            },
-                                            "range": [
-                                                804,
-                                                805
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 42,
@@ -1915,75 +1140,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a\\\\\\a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 43,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 43,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                812,
-                                                813
-                                            ],
-                                            "raw": "a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 43,
-                                                    "column": 6
-                                                },
-                                                "end": {
-                                                    "line": 43,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                813,
-                                                815
-                                            ],
-                                            "raw": "\\\\"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "\\a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 43,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 43,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                815,
-                                                817
-                                            ],
-                                            "raw": "\\a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a\\\\a]",
                                     "loc": {
                                         "start": {
                                             "line": 43,
@@ -2036,75 +1201,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "a_a\\_a",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "a_a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 44,
-                                                    "column": 5
-                                                },
-                                                "end": {
-                                                    "line": 44,
-                                                    "column": 8
-                                                }
-                                            },
-                                            "range": [
-                                                824,
-                                                827
-                                            ],
-                                            "raw": "a_a"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "_",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 44,
-                                                    "column": 8
-                                                },
-                                                "end": {
-                                                    "line": 44,
-                                                    "column": 10
-                                                }
-                                            },
-                                            "range": [
-                                                827,
-                                                829
-                                            ],
-                                            "raw": "\\_"
-                                        },
-                                        {
-                                            "type": "Str",
-                                            "value": "a",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 44,
-                                                    "column": 10
-                                                },
-                                                "end": {
-                                                    "line": 44,
-                                                    "column": 11
-                                                }
-                                            },
-                                            "range": [
-                                                829,
-                                                830
-                                            ],
-                                            "raw": "a"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[a_a_a]",
                                     "loc": {
                                         "start": {
                                             "line": 44,
@@ -2274,11 +1379,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2286,22 +1391,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http\\://user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 50,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 50,
-                                            "column": 59
-                                        }
-                                    },
-                                    "range": [
-                                        881,
-                                        936
-                                    ],
-                                    "raw": "http\\://user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2339,7 +1429,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2347,22 +1437,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https\\://user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 51,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 51,
-                                            "column": 60
-                                        }
-                                    },
-                                    "range": [
-                                        941,
-                                        997
-                                    ],
-                                    "raw": "https\\://user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2400,7 +1475,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2408,60 +1483,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 52,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 52,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1002,
-                                        1006
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 52,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 52,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        1006,
-                                        1013
-                                    ],
-                                    "raw": "&colon;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 52,
-                                            "column": 15
-                                        },
-                                        "end": {
-                                            "line": 52,
-                                            "column": 64
-                                        }
-                                    },
-                                    "range": [
-                                        1013,
-                                        1062
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "http://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2499,7 +1521,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -2507,60 +1529,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "https",
-                                    "loc": {
-                                        "start": {
-                                            "line": 53,
-                                            "column": 4
-                                        },
-                                        "end": {
-                                            "line": 53,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        1067,
-                                        1072
-                                    ],
-                                    "raw": "https"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 53,
-                                            "column": 9
-                                        },
-                                        "end": {
-                                            "line": 53,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1072,
-                                        1079
-                                    ],
-                                    "raw": "&colon;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "//user:password@host:port/path?key=value#fragment",
-                                    "loc": {
-                                        "start": {
-                                            "line": 53,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 53,
-                                            "column": 65
-                                        }
-                                    },
-                                    "range": [
-                                        1079,
-                                        1128
-                                    ],
-                                    "raw": "//user:password@host:port/path?key=value#fragment"
+                                    "value": "https://user:password@host:port/path?key=value#fragment"
                                 }
                             ],
                             "loc": {
@@ -2618,7 +1587,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "Double tildes should be ",
+                    "value": "Double tildes should be ~",
                     "loc": {
                         "start": {
                             "line": 55,
@@ -2626,37 +1595,38 @@
                         },
                         "end": {
                             "line": 55,
-                            "column": 24
+                            "column": 26
                         }
                     },
                     "range": [
                         1130,
-                        1154
-                    ],
-                    "raw": "Double tildes should be "
-                },
-                {
-                    "type": "Str",
-                    "value": "~",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 24
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        1154,
                         1156
                     ],
-                    "raw": "\\~"
+                    "raw": "Double tildes should be \\~"
                 },
                 {
-                    "type": "Str",
-                    "value": "~escaped",
+                    "type": "Delete",
+                    "children": [
+                        {
+                            "type": "Str",
+                            "value": "escaped~",
+                            "loc": {
+                                "start": {
+                                    "line": 55,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 55,
+                                    "column": 36
+                                }
+                            },
+                            "range": [
+                                1157,
+                                1166
+                            ],
+                            "raw": "escaped\\~"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 55,
@@ -2664,41 +1634,22 @@
                         },
                         "end": {
                             "line": 55,
-                            "column": 34
+                            "column": 37
                         }
                     },
                     "range": [
                         1156,
-                        1164
+                        1167
                     ],
-                    "raw": "~escaped"
+                    "raw": "~escaped\\~~"
                 },
                 {
                     "type": "Str",
-                    "value": "~",
+                    "value": ".\nAnd here: foo~~.",
                     "loc": {
                         "start": {
                             "line": 55,
-                            "column": 34
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 36
-                        }
-                    },
-                    "range": [
-                        1164,
-                        1166
-                    ],
-                    "raw": "\\~"
-                },
-                {
-                    "type": "Str",
-                    "value": "~.\nAnd here: foo~~.",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 36
+                            "column": 37
                         },
                         "end": {
                             "line": 56,
@@ -2706,10 +1657,10 @@
                         }
                     },
                     "range": [
-                        1166,
+                        1167,
                         1185
                     ],
-                    "raw": "~.\nAnd here: foo~~."
+                    "raw": ".\nAnd here: foo~~."
                 }
             ],
             "loc": {
@@ -2803,18 +1754,18 @@
                             "loc": {
                                 "start": {
                                     "line": 60,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 60,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1226,
-                                1232
+                                1224,
+                                1234
                             ],
-                            "raw": "here  "
+                            "raw": "| here   |"
                         },
                         {
                             "type": "TableCell",
@@ -2842,18 +1793,18 @@
                             "loc": {
                                 "start": {
                                     "line": 60,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 60,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1235,
-                                1243
+                                1234,
+                                1245
                             ],
-                            "raw": "they    "
+                            "raw": " they     |"
                         }
                     ],
                     "loc": {
@@ -2901,25 +1852,25 @@
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1270,
-                                1276
+                                1268,
+                                1278
                             ],
-                            "raw": "should"
+                            "raw": "| should |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "tho",
+                                    "value": "tho|ugh",
                                     "loc": {
                                         "start": {
                                             "line": 62,
@@ -2927,69 +1878,31 @@
                                         },
                                         "end": {
                                             "line": 62,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        1279,
-                                        1282
-                                    ],
-                                    "raw": "tho"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 62,
-                                            "column": 14
-                                        },
-                                        "end": {
-                                            "line": 62,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1282,
-                                        1284
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "ugh",
-                                    "loc": {
-                                        "start": {
-                                            "line": 62,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 62,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        1284,
+                                        1279,
                                         1287
                                     ],
-                                    "raw": "ugh"
+                                    "raw": "tho\\|ugh"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 62,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 62,
-                                    "column": 19
+                                    "column": 21
                                 }
                             },
                             "range": [
-                                1279,
-                                1287
+                                1278,
+                                1289
                             ],
-                            "raw": "tho\\|ugh"
+                            "raw": " tho\\|ugh |"
                         }
                     ],
                     "loc": {
@@ -3069,125 +1982,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "| here   | they   |\n",
+                    "value": "| here   | they   |\n| ---- | ----- |\n| should | though |",
                     "loc": {
                         "start": {
                             "line": 66,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1302,
-                        1322
-                    ],
-                    "raw": "| here   | they   |\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1322,
-                        1324
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ---- ",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1324,
-                        1330
-                    ],
-                    "raw": " ---- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 10
-                        }
-                    },
-                    "range": [
-                        1330,
-                        1332
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ----- ",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 10
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 17
-                        }
-                    },
-                    "range": [
-                        1332,
-                        1339
-                    ],
-                    "raw": " ----- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 17
-                        },
-                        "end": {
-                            "line": 67,
-                            "column": 19
-                        }
-                    },
-                    "range": [
-                        1339,
-                        1341
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": "\n| should | though |",
-                    "loc": {
-                        "start": {
-                            "line": 67,
-                            "column": 19
                         },
                         "end": {
                             "line": 68,
@@ -3195,10 +1994,10 @@
                         }
                     },
                     "range": [
-                        1341,
+                        1302,
                         1361
                     ],
-                    "raw": "\n| should | though |"
+                    "raw": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |"
                 }
             ],
             "loc": {
@@ -3261,87 +2060,11 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "here   | they\n",
+                    "value": "here   | they\n---- | ------\nshould | though",
                     "loc": {
                         "start": {
                             "line": 72,
                             "column": 0
-                        },
-                        "end": {
-                            "line": 73,
-                            "column": 0
-                        }
-                    },
-                    "range": [
-                        1374,
-                        1388
-                    ],
-                    "raw": "here   | they\n"
-                },
-                {
-                    "type": "Str",
-                    "value": "-",
-                    "loc": {
-                        "start": {
-                            "line": 73,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 73,
-                            "column": 2
-                        }
-                    },
-                    "range": [
-                        1388,
-                        1390
-                    ],
-                    "raw": "\\-"
-                },
-                {
-                    "type": "Str",
-                    "value": "--- ",
-                    "loc": {
-                        "start": {
-                            "line": 73,
-                            "column": 2
-                        },
-                        "end": {
-                            "line": 73,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        1390,
-                        1394
-                    ],
-                    "raw": "--- "
-                },
-                {
-                    "type": "Str",
-                    "value": "|",
-                    "loc": {
-                        "start": {
-                            "line": 73,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 73,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        1394,
-                        1396
-                    ],
-                    "raw": "\\|"
-                },
-                {
-                    "type": "Str",
-                    "value": " ------\nshould | though",
-                    "loc": {
-                        "start": {
-                            "line": 73,
-                            "column": 8
                         },
                         "end": {
                             "line": 74,
@@ -3349,10 +2072,10 @@
                         }
                     },
                     "range": [
-                        1396,
+                        1374,
                         1419
                     ],
-                    "raw": " ------\nshould | though"
+                    "raw": "here   | they\n\\---- \\| ------\nshould | though"
                 }
             ],
             "loc": {
@@ -3473,11 +2196,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3485,7 +2208,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 80,
@@ -3493,71 +2216,14 @@
                                         },
                                         "end": {
                                             "line": 80,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        1481,
-                                        1482
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "<div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 80,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 80,
-                                            "column": 10
-                                        }
-                                    },
-                                    "range": [
-                                        1482,
-                                        1487
-                                    ],
-                                    "raw": "<div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 80,
-                                            "column": 10
-                                        },
-                                        "end": {
-                                            "line": 80,
-                                            "column": 11
-                                        }
-                                    },
-                                    "range": [
-                                        1487,
-                                        1488
-                                    ],
-                                    "raw": "\\"
-                                },
-                                {
-                                    "type": "Html",
-                                    "value": "</div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 80,
-                                            "column": 11
-                                        },
-                                        "end": {
-                                            "line": 80,
                                             "column": 17
                                         }
                                     },
                                     "range": [
-                                        1488,
+                                        1481,
                                         1494
                                     ],
-                                    "raw": "</div>"
+                                    "raw": "\\<div>\\</div>"
                                 }
                             ],
                             "loc": {
@@ -3595,7 +2261,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3603,7 +2269,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "\\<http\\:google.com>",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 81,
@@ -3656,7 +2322,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3664,7 +2330,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<div></div>",
                                     "loc": {
                                         "start": {
                                             "line": 82,
@@ -3672,71 +2338,14 @@
                                         },
                                         "end": {
                                             "line": 82,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1523,
-                                        1527
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 82,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 82,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1527,
-                                        1531
-                                    ],
-                                    "raw": "div>"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "<",
-                                    "loc": {
-                                        "start": {
-                                            "line": 82,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 82,
-                                            "column": 16
-                                        }
-                                    },
-                                    "range": [
-                                        1531,
-                                        1535
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "/div>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 82,
-                                            "column": 16
-                                        },
-                                        "end": {
-                                            "line": 82,
                                             "column": 21
                                         }
                                     },
                                     "range": [
-                                        1535,
+                                        1523,
                                         1540
                                     ],
-                                    "raw": "/div>"
+                                    "raw": "&lt;div>&lt;/div>"
                                 }
                             ],
                             "loc": {
@@ -3774,7 +2383,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -3782,7 +2391,7 @@
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "<",
+                                    "value": "<http:google.com>",
                                     "loc": {
                                         "start": {
                                             "line": 83,
@@ -3790,71 +2399,14 @@
                                         },
                                         "end": {
                                             "line": 83,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1545,
-                                        1549
-                                    ],
-                                    "raw": "&lt;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "http",
-                                    "loc": {
-                                        "start": {
-                                            "line": 83,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 83,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        1549,
-                                        1553
-                                    ],
-                                    "raw": "http"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": ":",
-                                    "loc": {
-                                        "start": {
-                                            "line": 83,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 83,
-                                            "column": 19
-                                        }
-                                    },
-                                    "range": [
-                                        1553,
-                                        1560
-                                    ],
-                                    "raw": "&colon;"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "google.com>",
-                                    "loc": {
-                                        "start": {
-                                            "line": 83,
-                                            "column": 19
-                                        },
-                                        "end": {
-                                            "line": 83,
                                             "column": 30
                                         }
                                     },
                                     "range": [
-                                        1560,
+                                        1545,
                                         1571
                                     ],
-                                    "raw": "google.com>"
+                                    "raw": "&lt;http&colon;google.com>"
                                 }
                             ],
                             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/strong-and-em-together-one.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/strong-and-em-together-one.text/output.json
@@ -5,10 +5,10 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Strong",
+                    "type": "Emphasis",
                     "children": [
                         {
-                            "type": "Emphasis",
+                            "type": "Strong",
                             "children": [
                                 {
                                     "type": "Str",
@@ -33,18 +33,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 1
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 26
+                                    "column": 27
                                 }
                             },
                             "range": [
-                                2,
-                                26
+                                1,
+                                27
                             ],
-                            "raw": "*This is strong and em.*"
+                            "raw": "**This is strong and em.**"
                         }
                     ],
                     "loc": {
@@ -103,10 +103,10 @@
                     "raw": "So is "
                 },
                 {
-                    "type": "Strong",
+                    "type": "Emphasis",
                     "children": [
                         {
-                            "type": "Emphasis",
+                            "type": "Strong",
                             "children": [
                                 {
                                     "type": "Str",
@@ -131,18 +131,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 8
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 14
+                                    "column": 15
                                 }
                             },
                             "range": [
-                                38,
-                                44
+                                37,
+                                45
                             ],
-                            "raw": "*this*"
+                            "raw": "**this**"
                         }
                     ],
                     "loc": {
@@ -201,10 +201,10 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Strong",
+                    "type": "Emphasis",
                     "children": [
                         {
-                            "type": "Emphasis",
+                            "type": "Strong",
                             "children": [
                                 {
                                     "type": "Str",
@@ -229,18 +229,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 2
+                                    "column": 1
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 26
+                                    "column": 27
                                 }
                             },
                             "range": [
-                                56,
-                                80
+                                55,
+                                81
                             ],
-                            "raw": "_This is strong and em._"
+                            "raw": "__This is strong and em.__"
                         }
                     ],
                     "loc": {
@@ -299,10 +299,10 @@
                     "raw": "So is "
                 },
                 {
-                    "type": "Strong",
+                    "type": "Emphasis",
                     "children": [
                         {
-                            "type": "Emphasis",
+                            "type": "Strong",
                             "children": [
                                 {
                                     "type": "Str",
@@ -327,18 +327,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 8
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 14
+                                    "column": 15
                                 }
                             },
                             "range": [
-                                92,
-                                98
+                                91,
+                                99
                             ],
-                            "raw": "_this_"
+                            "raw": "__this__"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/strong-initial-white-space.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/strong-initial-white-space.text/output.json
@@ -5,28 +5,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Strong",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": " bar ",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                2,
-                                7
-                            ],
-                            "raw": " bar "
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "** bar **.",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -34,33 +14,14 @@
                         },
                         "end": {
                             "line": 1,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        0,
-                        9
-                    ],
-                    "raw": "** bar **"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 1,
                             "column": 10
                         }
                     },
                     "range": [
-                        9,
+                        0,
                         10
                     ],
-                    "raw": "."
+                    "raw": "** bar **."
                 }
             ],
             "loc": {
@@ -83,28 +44,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Strong",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": " bar ",
-                            "loc": {
-                                "start": {
-                                    "line": 4,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 4,
-                                    "column": 7
-                                }
-                            },
-                            "range": [
-                                15,
-                                20
-                            ],
-                            "raw": " bar "
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "__ bar __.",
                     "loc": {
                         "start": {
                             "line": 4,
@@ -112,33 +53,14 @@
                         },
                         "end": {
                             "line": 4,
-                            "column": 9
-                        }
-                    },
-                    "range": [
-                        13,
-                        22
-                    ],
-                    "raw": "__ bar __"
-                },
-                {
-                    "type": "Str",
-                    "value": ".",
-                    "loc": {
-                        "start": {
-                            "line": 4,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 4,
                             "column": 10
                         }
                     },
                     "range": [
-                        22,
+                        13,
                         23
                     ],
-                    "raw": "."
+                    "raw": "__ bar __."
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-empty-initial-cell.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-empty-initial-cell.text/output.json
@@ -18,18 +18,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 3
                                 }
                             },
                             "range": [
-                                2,
-                                2
+                                0,
+                                3
                             ],
-                            "raw": ""
+                            "raw": "| |"
                         },
                         {
                             "type": "TableCell",
@@ -57,18 +57,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 4
+                                    "column": 3
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 5
+                                    "column": 6
                                 }
                             },
                             "range": [
-                                4,
-                                5
+                                3,
+                                6
                             ],
-                            "raw": "a"
+                            "raw": " a|"
                         },
                         {
                             "type": "TableCell",
@@ -100,14 +100,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 7
+                                    "column": 8
                                 }
                             },
                             "range": [
                                 6,
-                                7
+                                8
                             ],
-                            "raw": "c"
+                            "raw": "c|"
                         }
                     ],
                     "loc": {
@@ -155,18 +155,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 3
                                 }
                             },
                             "range": [
-                                27,
-                                28
+                                26,
+                                29
                             ],
-                            "raw": "a"
+                            "raw": "|a|"
                         },
                         {
                             "type": "TableCell",
@@ -198,14 +198,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 4
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 29,
-                                30
+                                31
                             ],
-                            "raw": "b"
+                            "raw": "b|"
                         },
                         {
                             "type": "TableCell",
@@ -237,14 +237,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 6
+                                    "column": 7
                                 }
                             },
                             "range": [
                                 31,
-                                32
+                                33
                             ],
-                            "raw": "c"
+                            "raw": "c|"
                         }
                     ],
                     "loc": {
@@ -292,18 +292,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 3
                                 }
                             },
                             "range": [
-                                35,
-                                36
+                                34,
+                                37
                             ],
-                            "raw": "a"
+                            "raw": "|a|"
                         },
                         {
                             "type": "TableCell",
@@ -335,14 +335,14 @@
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 4
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 37,
-                                38
+                                39
                             ],
-                            "raw": "b"
+                            "raw": "b|"
                         },
                         {
                             "type": "TableCell",
@@ -374,14 +374,14 @@
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 6
+                                    "column": 7
                                 }
                             },
                             "range": [
                                 39,
-                                40
+                                41
                             ],
-                            "raw": "c"
+                            "raw": "c|"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-escaped-pipes.nooutput.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-escaped-pipes.nooutput.text/output.json
@@ -38,18 +38,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                2,
-                                7
+                                0,
+                                9
                             ],
-                            "raw": "First"
+                            "raw": "| First |"
                         },
                         {
                             "type": "TableCell",
@@ -77,18 +77,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 10
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                10,
-                                16
+                                9,
+                                18
                             ],
-                            "raw": "Second"
+                            "raw": " Second |"
                         },
                         {
                             "type": "TableCell",
@@ -116,18 +116,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 24
+                                    "column": 26
                                 }
                             },
                             "range": [
-                                19,
-                                24
+                                18,
+                                26
                             ],
-                            "raw": "third"
+                            "raw": " third |"
                         }
                     ],
                     "loc": {
@@ -175,18 +175,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                56,
-                                61
+                                54,
+                                63
                             ],
-                            "raw": "first"
+                            "raw": "| first |"
                         },
                         {
                             "type": "TableCell",
@@ -214,18 +214,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 10
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                64,
-                                70
+                                63,
+                                72
                             ],
-                            "raw": "second"
+                            "raw": " second |"
                         },
                         {
                             "type": "TableCell",
@@ -253,18 +253,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 24
+                                    "column": 26
                                 }
                             },
                             "range": [
-                                73,
-                                78
+                                72,
+                                80
                             ],
-                            "raw": "third"
+                            "raw": " third |"
                         }
                     ],
                     "loc": {
@@ -312,25 +312,25 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                83,
-                                88
+                                81,
+                                90
                             ],
-                            "raw": "first"
+                            "raw": "| first |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "second ",
+                                    "value": "second | second",
                                     "loc": {
                                         "start": {
                                             "line": 4,
@@ -338,76 +338,38 @@
                                         },
                                         "end": {
                                             "line": 4,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        91,
-                                        98
-                                    ],
-                                    "raw": "second "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 4,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 4,
-                                            "column": 19
-                                        }
-                                    },
-                                    "range": [
-                                        98,
-                                        100
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " second",
-                                    "loc": {
-                                        "start": {
-                                            "line": 4,
-                                            "column": 19
-                                        },
-                                        "end": {
-                                            "line": 4,
                                             "column": 26
                                         }
                                     },
                                     "range": [
-                                        100,
+                                        91,
                                         107
                                     ],
-                                    "raw": " second"
+                                    "raw": "second \\| second"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 10
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 26
+                                    "column": 28
                                 }
                             },
                             "range": [
-                                91,
-                                107
+                                90,
+                                109
                             ],
-                            "raw": "second \\| second"
+                            "raw": " second \\| second |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "third ",
+                                    "value": "third |",
                                     "loc": {
                                         "start": {
                                             "line": 4,
@@ -415,39 +377,20 @@
                                         },
                                         "end": {
                                             "line": 4,
-                                            "column": 35
-                                        }
-                                    },
-                                    "range": [
-                                        110,
-                                        116
-                                    ],
-                                    "raw": "third "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 4,
-                                            "column": 35
-                                        },
-                                        "end": {
-                                            "line": 4,
                                             "column": 37
                                         }
                                     },
                                     "range": [
-                                        116,
+                                        110,
                                         118
                                     ],
-                                    "raw": "\\|"
+                                    "raw": "third \\|"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 29
+                                    "column": 28
                                 },
                                 "end": {
                                     "line": 4,
@@ -455,10 +398,10 @@
                                 }
                             },
                             "range": [
-                                110,
+                                109,
                                 118
                             ],
-                            "raw": "third \\|"
+                            "raw": " third \\|"
                         }
                     ],
                     "loc": {
@@ -506,25 +449,25 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                121,
-                                126
+                                119,
+                                128
                             ],
-                            "raw": "first"
+                            "raw": "| first |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "second ",
+                                    "value": "second \\",
                                     "loc": {
                                         "start": {
                                             "line": 5,
@@ -532,57 +475,38 @@
                                         },
                                         "end": {
                                             "line": 5,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        129,
-                                        136
-                                    ],
-                                    "raw": "second "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 5,
                                             "column": 19
                                         }
                                     },
                                     "range": [
-                                        136,
+                                        129,
                                         138
                                     ],
-                                    "raw": "\\\\"
+                                    "raw": "second \\\\"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 10
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 19
+                                    "column": 20
                                 }
                             },
                             "range": [
-                                129,
-                                138
+                                128,
+                                139
                             ],
-                            "raw": "second \\\\"
+                            "raw": " second \\\\|"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "third ",
+                                    "value": "third \\",
                                     "loc": {
                                         "start": {
                                             "line": 5,
@@ -590,50 +514,31 @@
                                         },
                                         "end": {
                                             "line": 5,
-                                            "column": 27
-                                        }
-                                    },
-                                    "range": [
-                                        140,
-                                        146
-                                    ],
-                                    "raw": "third "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 5,
-                                            "column": 27
-                                        },
-                                        "end": {
-                                            "line": 5,
                                             "column": 29
                                         }
                                     },
                                     "range": [
-                                        146,
+                                        140,
                                         148
                                     ],
-                                    "raw": "\\\\"
+                                    "raw": "third \\\\"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 21
+                                    "column": 20
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 29
+                                    "column": 30
                                 }
                             },
                             "range": [
-                                140,
-                                148
+                                139,
+                                149
                             ],
-                            "raw": "third \\\\"
+                            "raw": " third \\\\|"
                         }
                     ],
                     "loc": {
@@ -681,25 +586,25 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
-                                152,
-                                157
+                                150,
+                                159
                             ],
-                            "raw": "first"
+                            "raw": "| first |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "second ",
+                                    "value": "second \\| second",
                                     "loc": {
                                         "start": {
                                             "line": 6,
@@ -707,95 +612,38 @@
                                         },
                                         "end": {
                                             "line": 6,
-                                            "column": 17
-                                        }
-                                    },
-                                    "range": [
-                                        160,
-                                        167
-                                    ],
-                                    "raw": "second "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 17
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 19
-                                        }
-                                    },
-                                    "range": [
-                                        167,
-                                        169
-                                    ],
-                                    "raw": "\\\\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 19
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 21
-                                        }
-                                    },
-                                    "range": [
-                                        169,
-                                        171
-                                    ],
-                                    "raw": "\\|"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " second",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 21
-                                        },
-                                        "end": {
-                                            "line": 6,
                                             "column": 28
                                         }
                                     },
                                     "range": [
-                                        171,
+                                        160,
                                         178
                                     ],
-                                    "raw": " second"
+                                    "raw": "second \\\\\\| second"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 10
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 28
+                                    "column": 30
                                 }
                             },
                             "range": [
-                                160,
-                                178
+                                159,
+                                180
                             ],
-                            "raw": "second \\\\\\| second"
+                            "raw": " second \\\\\\| second |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
                                     "type": "Str",
-                                    "value": "third ",
+                                    "value": "third \\|",
                                     "loc": {
                                         "start": {
                                             "line": 6,
@@ -803,58 +651,20 @@
                                         },
                                         "end": {
                                             "line": 6,
-                                            "column": 37
-                                        }
-                                    },
-                                    "range": [
-                                        181,
-                                        187
-                                    ],
-                                    "raw": "third "
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "\\",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 37
-                                        },
-                                        "end": {
-                                            "line": 6,
-                                            "column": 39
-                                        }
-                                    },
-                                    "range": [
-                                        187,
-                                        189
-                                    ],
-                                    "raw": "\\\\"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "|",
-                                    "loc": {
-                                        "start": {
-                                            "line": 6,
-                                            "column": 39
-                                        },
-                                        "end": {
-                                            "line": 6,
                                             "column": 41
                                         }
                                     },
                                     "range": [
-                                        189,
+                                        181,
                                         191
                                     ],
-                                    "raw": "\\|"
+                                    "raw": "third \\\\\\|"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 31
+                                    "column": 30
                                 },
                                 "end": {
                                     "line": 6,
@@ -862,10 +672,10 @@
                                 }
                             },
                             "range": [
-                                181,
+                                180,
                                 191
                             ],
-                            "raw": "third \\\\\\|"
+                            "raw": " third \\\\\\|"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-invalid-alignment.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-invalid-alignment.text/output.json
@@ -288,18 +288,18 @@
                             "loc": {
                                 "start": {
                                     "line": 21,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 21,
-                                    "column": 3
+                                    "column": 5
                                 }
                             },
                             "range": [
-                                208,
-                                209
+                                206,
+                                211
                             ],
-                            "raw": "a"
+                            "raw": "| a |"
                         }
                     ],
                     "loc": {
@@ -347,18 +347,18 @@
                             "loc": {
                                 "start": {
                                     "line": 23,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 23,
-                                    "column": 3
+                                    "column": 5
                                 }
                             },
                             "range": [
-                                220,
-                                221
+                                218,
+                                223
                             ],
-                            "raw": "d"
+                            "raw": "| d |"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-loose.output.loose-table.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-loose.output.loose-table.text/output.json
@@ -41,14 +41,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 0,
-                                8
+                                10
                             ],
-                            "raw": "Header 1"
+                            "raw": "Header 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -76,7 +76,7 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 1,
@@ -84,10 +84,10 @@
                                 }
                             },
                             "range": [
-                                11,
+                                10,
                                 19
                             ],
-                            "raw": "Header 2"
+                            "raw": " Header 2"
                         }
                     ],
                     "loc": {
@@ -139,14 +139,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 40,
-                                48
+                                50
                             ],
-                            "raw": "Cell 1  "
+                            "raw": "Cell 1   |"
                         },
                         {
                             "type": "TableCell",
@@ -174,7 +174,7 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 3,
@@ -182,10 +182,10 @@
                                 }
                             },
                             "range": [
-                                51,
+                                50,
                                 59
                             ],
-                            "raw": "Cell 2  "
+                            "raw": " Cell 2  "
                         }
                     ],
                     "loc": {
@@ -237,14 +237,14 @@
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 60,
-                                68
+                                70
                             ],
-                            "raw": "Cell 3  "
+                            "raw": "Cell 3   |"
                         },
                         {
                             "type": "TableCell",
@@ -272,7 +272,7 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 4,
@@ -280,10 +280,10 @@
                                 }
                             },
                             "range": [
-                                71,
+                                70,
                                 79
                             ],
-                            "raw": "Cell 4  "
+                            "raw": " Cell 4  "
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-loose.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-loose.output.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                2,
-                                10
+                                0,
+                                12
                             ],
-                            "raw": "Header 1"
+                            "raw": "| Header 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -76,18 +76,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                13,
-                                21
+                                12,
+                                23
                             ],
-                            "raw": "Header 2"
+                            "raw": " Header 2 |"
                         }
                     ],
                     "loc": {
@@ -135,18 +135,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                50,
-                                58
+                                48,
+                                60
                             ],
-                            "raw": "Cell 1  "
+                            "raw": "| Cell 1   |"
                         },
                         {
                             "type": "TableCell",
@@ -174,18 +174,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                61,
-                                69
+                                60,
+                                71
                             ],
-                            "raw": "Cell 2  "
+                            "raw": " Cell 2   |"
                         }
                     ],
                     "loc": {
@@ -233,18 +233,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                74,
-                                82
+                                72,
+                                84
                             ],
-                            "raw": "Cell 3  "
+                            "raw": "| Cell 3   |"
                         },
                         {
                             "type": "TableCell",
@@ -272,18 +272,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                85,
-                                93
+                                84,
+                                95
                             ],
-                            "raw": "Cell 4  "
+                            "raw": " Cell 4   |"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-no-body.md/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-no-body.md/output.json
@@ -78,18 +78,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 6
+                                    "column": 8
                                 }
                             },
                             "range": [
-                                9,
-                                13
+                                7,
+                                15
                             ],
-                            "raw": "Name"
+                            "raw": "| Name |"
                         },
                         {
                             "type": "TableCell",
@@ -117,18 +117,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 9
+                                    "column": 8
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 15
+                                    "column": 17
                                 }
                             },
                             "range": [
-                                16,
-                                22
+                                15,
+                                24
                             ],
-                            "raw": "GitHub"
+                            "raw": " GitHub |"
                         },
                         {
                             "type": "TableCell",
@@ -156,18 +156,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 18
+                                    "column": 17
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 25
+                                    "column": 27
                                 }
                             },
                             "range": [
-                                25,
-                                32
+                                24,
+                                34
                             ],
-                            "raw": "Twitter"
+                            "raw": " Twitter |"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-no-body.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-no-body.text/output.json
@@ -78,18 +78,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 6
+                                    "column": 8
                                 }
                             },
                             "range": [
-                                9,
-                                13
+                                7,
+                                15
                             ],
-                            "raw": "Name"
+                            "raw": "| Name |"
                         },
                         {
                             "type": "TableCell",
@@ -117,18 +117,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 9
+                                    "column": 8
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 15
+                                    "column": 17
                                 }
                             },
                             "range": [
-                                16,
-                                22
+                                15,
+                                24
                             ],
-                            "raw": "GitHub"
+                            "raw": " GitHub |"
                         },
                         {
                             "type": "TableCell",
@@ -156,18 +156,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 18
+                                    "column": 17
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 25
+                                    "column": 27
                                 }
                             },
                             "range": [
-                                25,
-                                32
+                                24,
+                                34
                             ],
-                            "raw": "Twitter"
+                            "raw": " Twitter |"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-no-end-of-line.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-no-end-of-line.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 4
+                                    "column": 5
                                 }
                             },
                             "range": [
-                                1,
-                                4
+                                0,
+                                5
                             ],
-                            "raw": "foo"
+                            "raw": "|foo|"
                         },
                         {
                             "type": "TableCell",
@@ -80,14 +80,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 8
+                                    "column": 9
                                 }
                             },
                             "range": [
                                 5,
-                                8
+                                9
                             ],
-                            "raw": "bar"
+                            "raw": "bar|"
                         }
                     ],
                     "loc": {
@@ -135,18 +135,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 3
                                 }
                             },
                             "range": [
-                                17,
-                                18
+                                16,
+                                19
                             ],
-                            "raw": "1"
+                            "raw": "|1|"
                         },
                         {
                             "type": "TableCell",
@@ -178,14 +178,14 @@
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 4
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 19,
-                                20
+                                21
                             ],
-                            "raw": "2"
+                            "raw": "2|"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-pipes-in-code.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-pipes-in-code.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                2,
-                                5
+                                0,
+                                7
                             ],
-                            "raw": "abc"
+                            "raw": "| abc |"
                         },
                         {
                             "type": "TableCell",
@@ -76,18 +76,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 10
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 15
+                                    "column": 17
                                 }
                             },
                             "range": [
-                                10,
-                                15
+                                7,
+                                17
                             ],
-                            "raw": "head2"
+                            "raw": "   head2 |"
                         }
                     ],
                     "loc": {
@@ -135,25 +135,25 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                38,
-                                41
+                                36,
+                                43
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "|||",
+                                    "type": "Str",
+                                    "value": "`",
                                     "loc": {
                                         "start": {
                                             "line": 3,
@@ -161,31 +161,89 @@
                                         },
                                         "end": {
                                             "line": 3,
-                                            "column": 15
+                                            "column": 11
                                         }
                                     },
                                     "range": [
                                         46,
-                                        51
+                                        47
                                     ],
-                                    "raw": "`|||`"
+                                    "raw": "`"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 10
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 15
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                46,
-                                51
+                                43,
+                                48
                             ],
-                            "raw": "`|||`"
+                            "raw": "   `|"
+                        },
+                        {
+                            "type": "TableCell",
+                            "children": [],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 14
+                                }
+                            },
+                            "range": [
+                                48,
+                                50
+                            ],
+                            "raw": "||"
+                        },
+                        {
+                            "type": "TableCell",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "`",
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 14
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 15
+                                        }
+                                    },
+                                    "range": [
+                                        50,
+                                        51
+                                    ],
+                                    "raw": "`"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 17
+                                }
+                            },
+                            "range": [
+                                50,
+                                53
+                            ],
+                            "raw": "` |"
                         }
                     ],
                     "loc": {
@@ -233,18 +291,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                56,
-                                59
+                                54,
+                                61
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
@@ -272,7 +330,7 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 14
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 4,
@@ -280,10 +338,10 @@
                                 }
                             },
                             "range": [
-                                68,
+                                61,
                                 71
                             ],
-                            "raw": "` |"
+                            "raw": "       ` |"
                         }
                     ],
                     "loc": {
@@ -331,25 +389,25 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                74,
-                                77
+                                72,
+                                79
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "|",
+                                    "type": "Str",
+                                    "value": "`",
                                     "loc": {
                                         "start": {
                                             "line": 5,
@@ -357,31 +415,70 @@
                                         },
                                         "end": {
                                             "line": 5,
-                                            "column": 15
+                                            "column": 13
                                         }
                                     },
                                     "range": [
                                         84,
-                                        87
+                                        85
                                     ],
-                                    "raw": "`|`"
+                                    "raw": "`"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 12
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 15
+                                    "column": 14
                                 }
                             },
                             "range": [
-                                84,
-                                87
+                                79,
+                                86
                             ],
-                            "raw": "`|`"
+                            "raw": "     `|"
+                        },
+                        {
+                            "type": "TableCell",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "`",
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 14
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 15
+                                        }
+                                    },
+                                    "range": [
+                                        86,
+                                        87
+                                    ],
+                                    "raw": "`"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 17
+                                }
+                            },
+                            "range": [
+                                86,
+                                89
+                            ],
+                            "raw": "` |"
                         }
                     ],
                     "loc": {
@@ -429,18 +526,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                92,
-                                95
+                                90,
+                                97
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
@@ -468,18 +565,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 8
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 15
+                                    "column": 17
                                 }
                             },
                             "range": [
-                                98,
-                                105
+                                97,
+                                107
                             ],
-                            "raw": "`` f ``"
+                            "raw": " `` f `` |"
                         }
                     ],
                     "loc": {
@@ -527,25 +624,25 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                110,
-                                113
+                                108,
+                                115
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "",
+                                    "type": "Str",
+                                    "value": "````",
                                     "loc": {
                                         "start": {
                                             "line": 7,
@@ -566,7 +663,7 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 11
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 7,
@@ -574,10 +671,10 @@
                                 }
                             },
                             "range": [
-                                119,
+                                115,
                                 125
                             ],
-                            "raw": "```` |"
+                            "raw": "    ```` |"
                         }
                     ],
                     "loc": {
@@ -625,25 +722,25 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                128,
-                                131
+                                126,
+                                133
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "",
+                                    "type": "Str",
+                                    "value": "``f`",
                                     "loc": {
                                         "start": {
                                             "line": 8,
@@ -651,39 +748,20 @@
                                         },
                                         "end": {
                                             "line": 8,
-                                            "column": 13
-                                        }
-                                    },
-                                    "range": [
-                                        137,
-                                        139
-                                    ],
-                                    "raw": "``"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "f`",
-                                    "loc": {
-                                        "start": {
-                                            "line": 8,
-                                            "column": 13
-                                        },
-                                        "end": {
-                                            "line": 8,
                                             "column": 15
                                         }
                                     },
                                     "range": [
-                                        139,
+                                        137,
                                         141
                                     ],
-                                    "raw": "f`"
+                                    "raw": "``f`"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 11
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 8,
@@ -691,10 +769,10 @@
                                 }
                             },
                             "range": [
-                                137,
+                                133,
                                 143
                             ],
-                            "raw": "``f` |"
+                            "raw": "    ``f` |"
                         }
                     ],
                     "loc": {
@@ -766,18 +844,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                147,
-                                150
+                                145,
+                                152
                             ],
-                            "raw": "abc"
+                            "raw": "| abc |"
                         },
                         {
                             "type": "TableCell",
@@ -805,7 +883,7 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 10
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 10,
@@ -813,10 +891,10 @@
                                 }
                             },
                             "range": [
-                                155,
+                                152,
                                 160
                             ],
-                            "raw": "head2"
+                            "raw": "   head2"
                         }
                     ],
                     "loc": {
@@ -864,18 +942,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                179,
-                                182
+                                177,
+                                184
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
@@ -903,7 +981,7 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 14
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 12,
@@ -911,10 +989,10 @@
                                 }
                             },
                             "range": [
-                                191,
+                                184,
                                 192
                             ],
-                            "raw": "`"
+                            "raw": "       `"
                         }
                     ],
                     "loc": {
@@ -962,25 +1040,25 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                195,
-                                198
+                                193,
+                                200
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "|",
+                                    "type": "Str",
+                                    "value": "`",
                                     "loc": {
                                         "start": {
                                             "line": 13,
@@ -988,20 +1066,59 @@
                                         },
                                         "end": {
                                             "line": 13,
-                                            "column": 15
+                                            "column": 13
                                         }
                                     },
                                     "range": [
                                         205,
-                                        208
+                                        206
                                     ],
-                                    "raw": "`|`"
+                                    "raw": "`"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 12
+                                    "column": 7
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 14
+                                }
+                            },
+                            "range": [
+                                200,
+                                207
+                            ],
+                            "raw": "     `|"
+                        },
+                        {
+                            "type": "TableCell",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "`",
+                                    "loc": {
+                                        "start": {
+                                            "line": 13,
+                                            "column": 14
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 15
+                                        }
+                                    },
+                                    "range": [
+                                        207,
+                                        208
+                                    ],
+                                    "raw": "`"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 14
                                 },
                                 "end": {
                                     "line": 13,
@@ -1009,10 +1126,10 @@
                                 }
                             },
                             "range": [
-                                205,
+                                207,
                                 208
                             ],
-                            "raw": "`|`"
+                            "raw": "`"
                         }
                     ],
                     "loc": {
@@ -1060,18 +1177,18 @@
                             "loc": {
                                 "start": {
                                     "line": 14,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 14,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                211,
-                                214
+                                209,
+                                216
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
@@ -1099,7 +1216,7 @@
                             "loc": {
                                 "start": {
                                     "line": 14,
-                                    "column": 8
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 14,
@@ -1107,10 +1224,10 @@
                                 }
                             },
                             "range": [
-                                217,
+                                216,
                                 224
                             ],
-                            "raw": "`` f ``"
+                            "raw": " `` f ``"
                         }
                     ],
                     "loc": {
@@ -1158,25 +1275,25 @@
                             "loc": {
                                 "start": {
                                     "line": 15,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 15,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                227,
-                                230
+                                225,
+                                232
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "",
+                                    "type": "Str",
+                                    "value": "````",
                                     "loc": {
                                         "start": {
                                             "line": 15,
@@ -1197,7 +1314,7 @@
                             "loc": {
                                 "start": {
                                     "line": 15,
-                                    "column": 11
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 15,
@@ -1205,10 +1322,10 @@
                                 }
                             },
                             "range": [
-                                236,
+                                232,
                                 240
                             ],
-                            "raw": "````"
+                            "raw": "    ````"
                         }
                     ],
                     "loc": {
@@ -1256,25 +1373,25 @@
                             "loc": {
                                 "start": {
                                     "line": 16,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 16,
-                                    "column": 5
+                                    "column": 7
                                 }
                             },
                             "range": [
-                                243,
-                                246
+                                241,
+                                248
                             ],
-                            "raw": "x  "
+                            "raw": "| x   |"
                         },
                         {
                             "type": "TableCell",
                             "children": [
                                 {
-                                    "type": "Code",
-                                    "value": "",
+                                    "type": "Str",
+                                    "value": "``f`",
                                     "loc": {
                                         "start": {
                                             "line": 16,
@@ -1282,39 +1399,20 @@
                                         },
                                         "end": {
                                             "line": 16,
-                                            "column": 12
-                                        }
-                                    },
-                                    "range": [
-                                        251,
-                                        253
-                                    ],
-                                    "raw": "``"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "f`",
-                                    "loc": {
-                                        "start": {
-                                            "line": 16,
-                                            "column": 12
-                                        },
-                                        "end": {
-                                            "line": 16,
                                             "column": 14
                                         }
                                     },
                                     "range": [
-                                        253,
+                                        251,
                                         255
                                     ],
-                                    "raw": "f`"
+                                    "raw": "``f`"
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 16,
-                                    "column": 10
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 16,
@@ -1322,10 +1420,10 @@
                                 }
                             },
                             "range": [
-                                251,
+                                248,
                                 255
                             ],
-                            "raw": "``f`"
+                            "raw": "   ``f`"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-spaced.output.nospaced-table.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-spaced.output.nospaced-table.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 9
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                1,
-                                9
+                                0,
+                                10
                             ],
-                            "raw": "Header 1"
+                            "raw": "|Header 1|"
                         },
                         {
                             "type": "TableCell",
@@ -80,14 +80,14 @@
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 19
                                 }
                             },
                             "range": [
                                 10,
-                                18
+                                19
                             ],
-                            "raw": "Header 2"
+                            "raw": "Header 2|"
                         }
                     ],
                     "loc": {
@@ -135,18 +135,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                41,
-                                48
+                                40,
+                                50
                             ],
-                            "raw": "Cell 1 "
+                            "raw": "|Cell 1  |"
                         },
                         {
                             "type": "TableCell",
@@ -174,18 +174,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 12
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 18
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                52,
-                                58
+                                50,
+                                59
                             ],
-                            "raw": "Cell 2"
+                            "raw": "  Cell 2|"
                         }
                     ],
                     "loc": {
@@ -233,18 +233,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 1
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
-                                61,
-                                68
+                                60,
+                                70
                             ],
-                            "raw": "Cell 3 "
+                            "raw": "|Cell 3  |"
                         },
                         {
                             "type": "TableCell",
@@ -272,18 +272,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 12
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 18
+                                    "column": 19
                                 }
                             },
                             "range": [
-                                72,
-                                78
+                                70,
+                                79
                             ],
-                            "raw": "Cell 4"
+                            "raw": "  Cell 4|"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table-spaced.output.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table-spaced.output.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                2,
-                                10
+                                0,
+                                12
                             ],
-                            "raw": "Header 1"
+                            "raw": "| Header 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -76,18 +76,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                13,
-                                21
+                                12,
+                                23
                             ],
-                            "raw": "Header 2"
+                            "raw": " Header 2 |"
                         }
                     ],
                     "loc": {
@@ -135,18 +135,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                50,
-                                58
+                                48,
+                                60
                             ],
-                            "raw": "Cell 1  "
+                            "raw": "| Cell 1   |"
                         },
                         {
                             "type": "TableCell",
@@ -174,18 +174,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 15
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                63,
-                                69
+                                60,
+                                71
                             ],
-                            "raw": "Cell 2"
+                            "raw": "   Cell 2 |"
                         }
                     ],
                     "loc": {
@@ -233,18 +233,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                74,
-                                82
+                                72,
+                                84
                             ],
-                            "raw": "Cell 3  "
+                            "raw": "| Cell 3   |"
                         },
                         {
                             "type": "TableCell",
@@ -272,18 +272,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 15
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                87,
-                                93
+                                84,
+                                95
                             ],
-                            "raw": "Cell 4"
+                            "raw": "   Cell 4 |"
                         }
                     ],
                     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/table.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/table.text/output.json
@@ -37,18 +37,18 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 1,
-                                    "column": 11
+                                    "column": 13
                                 }
                             },
                             "range": [
-                                2,
-                                11
+                                0,
+                                13
                             ],
-                            "raw": "Heading 1"
+                            "raw": "| Heading 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -115,7 +115,7 @@
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 14
+                                    "column": 13
                                 },
                                 "end": {
                                     "line": 1,
@@ -123,10 +123,10 @@
                                 }
                             },
                             "range": [
-                                14,
+                                13,
                                 27
                             ],
-                            "raw": "**H**eading 2"
+                            "raw": " **H**eading 2"
                         }
                     ],
                     "loc": {
@@ -174,18 +174,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 11
+                                    "column": 13
                                 }
                             },
                             "range": [
-                                54,
-                                63
+                                52,
+                                65
                             ],
-                            "raw": "Cell 1   "
+                            "raw": "| Cell 1    |"
                         },
                         {
                             "type": "TableCell",
@@ -213,7 +213,7 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 14
+                                    "column": 13
                                 },
                                 "end": {
                                     "line": 3,
@@ -221,10 +221,10 @@
                                 }
                             },
                             "range": [
-                                66,
+                                65,
                                 72
                             ],
-                            "raw": "Cell 2"
+                            "raw": " Cell 2"
                         }
                     ],
                     "loc": {
@@ -272,18 +272,18 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 4,
-                                    "column": 11
+                                    "column": 13
                                 }
                             },
                             "range": [
-                                75,
-                                84
+                                73,
+                                86
                             ],
-                            "raw": "Cell 3   "
+                            "raw": "| Cell 3    |"
                         },
                         {
                             "type": "TableCell",
@@ -311,7 +311,7 @@
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 14
+                                    "column": 13
                                 },
                                 "end": {
                                     "line": 4,
@@ -319,10 +319,10 @@
                                 }
                             },
                             "range": [
-                                87,
+                                86,
                                 93
                             ],
-                            "raw": "Cell 4"
+                            "raw": " Cell 4"
                         }
                     ],
                     "loc": {
@@ -396,18 +396,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                97,
-                                105
+                                95,
+                                107
                             ],
-                            "raw": "Header 1"
+                            "raw": "| Header 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -435,18 +435,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                108,
-                                116
+                                107,
+                                118
                             ],
-                            "raw": "Header 2"
+                            "raw": " Header 2 |"
                         },
                         {
                             "type": "TableCell",
@@ -474,18 +474,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 24
+                                    "column": 23
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 32
+                                    "column": 34
                                 }
                             },
                             "range": [
-                                119,
-                                127
+                                118,
+                                129
                             ],
-                            "raw": "Header 3"
+                            "raw": " Header 3 |"
                         },
                         {
                             "type": "TableCell",
@@ -513,18 +513,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 35
+                                    "column": 34
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 43
+                                    "column": 45
                                 }
                             },
                             "range": [
-                                130,
-                                138
+                                129,
+                                140
                             ],
-                            "raw": "Header 4"
+                            "raw": " Header 4 |"
                         }
                     ],
                     "loc": {
@@ -572,18 +572,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                189,
-                                197
+                                187,
+                                199
                             ],
-                            "raw": "Cell 1  "
+                            "raw": "| Cell 1   |"
                         },
                         {
                             "type": "TableCell",
@@ -611,18 +611,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                200,
-                                208
+                                199,
+                                210
                             ],
-                            "raw": "Cell 2  "
+                            "raw": " Cell 2   |"
                         },
                         {
                             "type": "TableCell",
@@ -650,18 +650,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 24
+                                    "column": 23
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 32
+                                    "column": 34
                                 }
                             },
                             "range": [
-                                211,
-                                219
+                                210,
+                                221
                             ],
-                            "raw": "Cell 3  "
+                            "raw": " Cell 3   |"
                         },
                         {
                             "type": "TableCell",
@@ -689,18 +689,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 35
+                                    "column": 34
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 43
+                                    "column": 45
                                 }
                             },
                             "range": [
-                                222,
-                                230
+                                221,
+                                232
                             ],
-                            "raw": "Cell 4  "
+                            "raw": " Cell 4   |"
                         }
                     ],
                     "loc": {
@@ -748,18 +748,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 10
+                                    "column": 12
                                 }
                             },
                             "range": [
-                                235,
-                                243
+                                233,
+                                245
                             ],
-                            "raw": "Cell 5  "
+                            "raw": "| Cell 5   |"
                         },
                         {
                             "type": "TableCell",
@@ -787,18 +787,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 13
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 21
+                                    "column": 23
                                 }
                             },
                             "range": [
-                                246,
-                                254
+                                245,
+                                256
                             ],
-                            "raw": "Cell 6  "
+                            "raw": " Cell 6   |"
                         },
                         {
                             "type": "TableCell",
@@ -826,18 +826,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 24
+                                    "column": 23
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 32
+                                    "column": 34
                                 }
                             },
                             "range": [
-                                257,
-                                265
+                                256,
+                                267
                             ],
-                            "raw": "Cell 7  "
+                            "raw": " Cell 7   |"
                         },
                         {
                             "type": "TableCell",
@@ -865,18 +865,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 35
+                                    "column": 34
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 43
+                                    "column": 45
                                 }
                             },
                             "range": [
-                                268,
-                                276
+                                267,
+                                278
                             ],
-                            "raw": "Cell 8  "
+                            "raw": " Cell 8   |"
                         }
                     ],
                     "loc": {
@@ -915,6 +915,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "Test code",
             "loc": {
                 "start": {
@@ -972,14 +973,14 @@
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 295,
-                                303
+                                305
                             ],
-                            "raw": "Header 1"
+                            "raw": "Header 1 |"
                         },
                         {
                             "type": "TableCell",
@@ -1007,7 +1008,7 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 13,
@@ -1015,10 +1016,10 @@
                                 }
                             },
                             "range": [
-                                306,
+                                305,
                                 314
                             ],
-                            "raw": "Header 2"
+                            "raw": " Header 2"
                         }
                     ],
                     "loc": {
@@ -1070,14 +1071,14 @@
                                 },
                                 "end": {
                                     "line": 15,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 335,
-                                343
+                                345
                             ],
-                            "raw": "Cell 1  "
+                            "raw": "Cell 1   |"
                         },
                         {
                             "type": "TableCell",
@@ -1105,7 +1106,7 @@
                             "loc": {
                                 "start": {
                                     "line": 15,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 15,
@@ -1113,10 +1114,10 @@
                                 }
                             },
                             "range": [
-                                346,
+                                345,
                                 352
                             ],
-                            "raw": "Cell 2"
+                            "raw": " Cell 2"
                         }
                     ],
                     "loc": {
@@ -1168,14 +1169,14 @@
                                 },
                                 "end": {
                                     "line": 16,
-                                    "column": 8
+                                    "column": 10
                                 }
                             },
                             "range": [
                                 353,
-                                361
+                                363
                             ],
-                            "raw": "Cell 3  "
+                            "raw": "Cell 3   |"
                         },
                         {
                             "type": "TableCell",
@@ -1203,7 +1204,7 @@
                             "loc": {
                                 "start": {
                                     "line": 16,
-                                    "column": 11
+                                    "column": 10
                                 },
                                 "end": {
                                     "line": 16,
@@ -1211,10 +1212,10 @@
                                 }
                             },
                             "range": [
-                                364,
+                                363,
                                 370
                             ],
-                            "raw": "Cell 4"
+                            "raw": " Cell 4"
                         }
                     ],
                     "loc": {
@@ -1292,14 +1293,14 @@
                                 },
                                 "end": {
                                     "line": 18,
-                                    "column": 8
+                                    "column": 9
                                 }
                             },
                             "range": [
                                 372,
-                                380
+                                381
                             ],
-                            "raw": "Header 1"
+                            "raw": "Header 1|"
                         },
                         {
                             "type": "TableCell",
@@ -1331,14 +1332,14 @@
                                 },
                                 "end": {
                                     "line": 18,
-                                    "column": 17
+                                    "column": 18
                                 }
                             },
                             "range": [
                                 381,
-                                389
+                                390
                             ],
-                            "raw": "Header 2"
+                            "raw": "Header 2|"
                         },
                         {
                             "type": "TableCell",
@@ -1370,14 +1371,14 @@
                                 },
                                 "end": {
                                     "line": 18,
-                                    "column": 26
+                                    "column": 27
                                 }
                             },
                             "range": [
                                 390,
-                                398
+                                399
                             ],
-                            "raw": "Header 3"
+                            "raw": "Header 3|"
                         },
                         {
                             "type": "TableCell",
@@ -1468,14 +1469,14 @@
                                 },
                                 "end": {
                                     "line": 20,
-                                    "column": 7
+                                    "column": 9
                                 }
                             },
                             "range": [
                                 444,
-                                451
+                                453
                             ],
-                            "raw": "Cell 1 "
+                            "raw": "Cell 1  |"
                         },
                         {
                             "type": "TableCell",
@@ -1507,14 +1508,14 @@
                                 },
                                 "end": {
                                     "line": 20,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
                                 453,
-                                460
+                                462
                             ],
-                            "raw": "Cell 2 "
+                            "raw": "Cell 2  |"
                         },
                         {
                             "type": "TableCell",
@@ -1546,14 +1547,14 @@
                                 },
                                 "end": {
                                     "line": 20,
-                                    "column": 25
+                                    "column": 27
                                 }
                             },
                             "range": [
                                 462,
-                                469
+                                471
                             ],
-                            "raw": "Cell 3 "
+                            "raw": "Cell 3  |"
                         },
                         {
                             "type": "TableCell",
@@ -1664,14 +1665,14 @@
                                 },
                                 "end": {
                                     "line": 21,
-                                    "column": 8
+                                    "column": 9
                                 }
                             },
                             "range": [
                                 478,
-                                486
+                                487
                             ],
-                            "raw": "*Cell 5*"
+                            "raw": "*Cell 5*|"
                         },
                         {
                             "type": "TableCell",
@@ -1703,14 +1704,14 @@
                                 },
                                 "end": {
                                     "line": 21,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
                                 487,
-                                494
+                                496
                             ],
-                            "raw": "Cell 6 "
+                            "raw": "Cell 6  |"
                         },
                         {
                             "type": "TableCell",
@@ -1742,14 +1743,14 @@
                                 },
                                 "end": {
                                     "line": 21,
-                                    "column": 25
+                                    "column": 27
                                 }
                             },
                             "range": [
                                 496,
-                                503
+                                505
                             ],
-                            "raw": "Cell 7 "
+                            "raw": "Cell 7  |"
                         },
                         {
                             "type": "TableCell",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/tabs.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/tabs.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": true,
+            "spread": true,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": true,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -58,19 +58,19 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 3,
-                            "column": 0
+                            "line": 2,
+                            "column": 19
                         }
                     },
                     "range": [
                         0,
-                        42
+                        41
                     ],
-                    "raw": "+\tthis is a list item\n\tindented with tabs\n"
+                    "raw": "+\tthis is a list item\n\tindented with tabs"
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -188,6 +188,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "this code block is indented by one tab",
             "loc": {
                 "start": {
@@ -247,6 +248,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "\tthis code block is indented by two tabs",
             "loc": {
                 "start": {
@@ -306,6 +308,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "+\tthis is an example list item\n\tindented with tabs\n\n+   this is an example list item\n    indented with spaces",
             "loc": {
                 "start": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/task-list-ordered.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/task-list-ordered.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -177,11 +177,11 @@
                             "type": "List",
                             "ordered": true,
                             "start": 1,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": true,
                                     "children": [
                                         {
@@ -276,7 +276,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -337,7 +337,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-asterisk.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-asterisk.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -177,11 +177,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": true,
                                     "children": [
                                         {
@@ -227,7 +227,7 @@
                                     "loc": {
                                         "start": {
                                             "line": 4,
-                                            "column": 2
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 4,
@@ -235,16 +235,16 @@
                                         }
                                     },
                                     "range": [
-                                        63,
+                                        65,
                                         76
                                     ],
-                                    "raw": "  * [x] Moon."
+                                    "raw": "* [x] Moon."
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 4,
@@ -252,10 +252,10 @@
                                 }
                             },
                             "range": [
-                                63,
+                                65,
                                 76
                             ],
-                            "raw": "  * [x] Moon."
+                            "raw": "* [x] Moon."
                         }
                     ],
                     "loc": {
@@ -276,7 +276,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -337,7 +337,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-dash.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-dash.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -177,11 +177,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": true,
                                     "children": [
                                         {
@@ -227,7 +227,7 @@
                                     "loc": {
                                         "start": {
                                             "line": 4,
-                                            "column": 2
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 4,
@@ -235,16 +235,16 @@
                                         }
                                     },
                                     "range": [
-                                        63,
+                                        65,
                                         76
                                     ],
-                                    "raw": "  - [x] Moon."
+                                    "raw": "- [x] Moon."
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 4,
@@ -252,10 +252,10 @@
                                 }
                             },
                             "range": [
-                                63,
+                                65,
                                 76
                             ],
-                            "raw": "  - [x] Moon."
+                            "raw": "- [x] Moon."
                         }
                     ],
                     "loc": {
@@ -276,7 +276,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -337,7 +337,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-plus.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/task-list-unordered-plus.text/output.json
@@ -5,11 +5,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -70,7 +70,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -131,7 +131,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -177,11 +177,11 @@
                             "type": "List",
                             "ordered": false,
                             "start": null,
-                            "loose": false,
+                            "spread": false,
                             "children": [
                                 {
                                     "type": "ListItem",
-                                    "loose": false,
+                                    "spread": false,
                                     "checked": true,
                                     "children": [
                                         {
@@ -227,7 +227,7 @@
                                     "loc": {
                                         "start": {
                                             "line": 4,
-                                            "column": 2
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 4,
@@ -235,16 +235,16 @@
                                         }
                                     },
                                     "range": [
-                                        63,
+                                        65,
                                         76
                                     ],
-                                    "raw": "  + [x] Moon."
+                                    "raw": "+ [x] Moon."
                                 }
                             ],
                             "loc": {
                                 "start": {
                                     "line": 4,
-                                    "column": 2
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 4,
@@ -252,10 +252,10 @@
                                 }
                             },
                             "range": [
-                                63,
+                                65,
                                 76
                             ],
-                            "raw": "  + [x] Moon."
+                            "raw": "+ [x] Moon."
                         }
                     ],
                     "loc": {
@@ -276,7 +276,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -337,7 +337,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/task-list.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/task-list.text/output.json
@@ -45,41 +45,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": " ",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 4,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 4,
-                                                    "column": 4
-                                                }
-                                            },
-                                            "range": [
-                                                28,
-                                                29
-                                            ],
-                                            "raw": " "
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[ ]",
                                     "loc": {
                                         "start": {
                                             "line": 4,
@@ -132,37 +110,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "\t",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 5,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 5,
-                                                    "column": 4
-                                                }
-                                            },
-                                            "range": [
-                                                34,
-                                                35
-                                            ],
-                                            "raw": "\t"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[\t]",
                                     "loc": {
                                         "start": {
                                             "line": 5,
@@ -234,41 +190,19 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "x",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "x",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 7,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 7,
-                                                    "column": 5
-                                                }
-                                            },
-                                            "range": [
-                                                42,
-                                                43
-                                            ],
-                                            "raw": "x"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[x]",
                                     "loc": {
                                         "start": {
                                             "line": 7,
@@ -321,37 +255,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "x",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "X",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 8,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 8,
-                                                    "column": 5
-                                                }
-                                            },
-                                            "range": [
-                                                49,
-                                                50
-                                            ],
-                                            "raw": "X"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[X]",
                                     "loc": {
                                         "start": {
                                             "line": 8,
@@ -463,13 +375,53 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": false,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[ ]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 13,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 13,
+                                            "column": 5
+                                        }
+                                    },
+                                    "range": [
+                                        82,
+                                        85
+                                    ],
+                                    "raw": "[ ]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 13,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 13,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                82,
+                                86
+                            ],
+                            "raw": "[ ] "
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 13,
@@ -488,9 +440,49 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": false,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[\t]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 14,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 14,
+                                            "column": 5
+                                        }
+                                    },
+                                    "range": [
+                                        89,
+                                        92
+                                    ],
+                                    "raw": "[\t]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 14,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 14,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                89,
+                                93
+                            ],
+                            "raw": "[\t] "
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 14,
@@ -528,13 +520,53 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": true,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[x]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 16,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 16,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        98,
+                                        101
+                                    ],
+                                    "raw": "[x]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 16,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 16,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                98,
+                                102
+                            ],
+                            "raw": "[x] "
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 16,
@@ -553,9 +585,49 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": true,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[X]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 17,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 17,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        106,
+                                        109
+                                    ],
+                                    "raw": "[X]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 17,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 17,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                106,
+                                110
+                            ],
+                            "raw": "[X] "
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 17,
@@ -633,13 +705,53 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": false,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[ ]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 22,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 22,
+                                            "column": 5
+                                        }
+                                    },
+                                    "range": [
+                                        123,
+                                        126
+                                    ],
+                                    "raw": "[ ]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 22,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 22,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                123,
+                                127
+                            ],
+                            "raw": "[ ]\t"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 22,
@@ -658,9 +770,49 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": false,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[\t]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 23,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 23,
+                                            "column": 5
+                                        }
+                                    },
+                                    "range": [
+                                        130,
+                                        133
+                                    ],
+                                    "raw": "[\t]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 23,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 23,
+                                    "column": 6
+                                }
+                            },
+                            "range": [
+                                130,
+                                134
+                            ],
+                            "raw": "[\t]\t"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 23,
@@ -698,13 +850,53 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": true,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[x]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        139,
+                                        142
+                                    ],
+                                    "raw": "[x]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 25,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                139,
+                                143
+                            ],
+                            "raw": "[x]\t"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 25,
@@ -723,9 +915,49 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
-                    "checked": true,
-                    "children": [],
+                    "spread": false,
+                    "checked": null,
+                    "children": [
+                        {
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "[X]",
+                                    "loc": {
+                                        "start": {
+                                            "line": 26,
+                                            "column": 3
+                                        },
+                                        "end": {
+                                            "line": 26,
+                                            "column": 6
+                                        }
+                                    },
+                                    "range": [
+                                        147,
+                                        150
+                                    ],
+                                    "raw": "[X]"
+                                }
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 26,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 26,
+                                    "column": 7
+                                }
+                            },
+                            "range": [
+                                147,
+                                151
+                            ],
+                            "raw": "[X]\t"
+                        }
+                    ],
                     "loc": {
                         "start": {
                             "line": 26,
@@ -803,41 +1035,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": " ",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 31,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 31,
-                                                    "column": 4
-                                                }
-                                            },
-                                            "range": [
-                                                213,
-                                                214
-                                            ],
-                                            "raw": " "
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[ ]Hello;",
                                     "loc": {
                                         "start": {
                                             "line": 31,
@@ -845,33 +1055,14 @@
                                         },
                                         "end": {
                                             "line": 31,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        212,
-                                        215
-                                    ],
-                                    "raw": "[ ]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "Hello;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 31,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 31,
                                             "column": 11
                                         }
                                     },
                                     "range": [
-                                        215,
+                                        212,
                                         221
                                     ],
-                                    "raw": "Hello;"
+                                    "raw": "[ ]Hello;"
                                 }
                             ],
                             "loc": {
@@ -909,37 +1100,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "\t",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 32,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 32,
-                                                    "column": 4
-                                                }
-                                            },
-                                            "range": [
-                                                225,
-                                                226
-                                            ],
-                                            "raw": "\t"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[\t]World;",
                                     "loc": {
                                         "start": {
                                             "line": 32,
@@ -947,33 +1116,14 @@
                                         },
                                         "end": {
                                             "line": 32,
-                                            "column": 5
-                                        }
-                                    },
-                                    "range": [
-                                        224,
-                                        227
-                                    ],
-                                    "raw": "[\t]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "World;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 32,
-                                            "column": 5
-                                        },
-                                        "end": {
-                                            "line": 32,
                                             "column": 11
                                         }
                                     },
                                     "range": [
-                                        227,
+                                        224,
                                         233
                                     ],
-                                    "raw": "World;"
+                                    "raw": "[\t]World;"
                                 }
                             ],
                             "loc": {
@@ -1030,41 +1180,19 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "x",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "x",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 34,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 34,
-                                                    "column": 5
-                                                }
-                                            },
-                                            "range": [
-                                                239,
-                                                240
-                                            ],
-                                            "raw": "x"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[x]Foo.",
                                     "loc": {
                                         "start": {
                                             "line": 34,
@@ -1072,33 +1200,14 @@
                                         },
                                         "end": {
                                             "line": 34,
-                                            "column": 6
-                                        }
-                                    },
-                                    "range": [
-                                        238,
-                                        241
-                                    ],
-                                    "raw": "[x]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "Foo.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 34,
-                                            "column": 6
-                                        },
-                                        "end": {
-                                            "line": 34,
                                             "column": 10
                                         }
                                     },
                                     "range": [
-                                        241,
+                                        238,
                                         245
                                     ],
-                                    "raw": "Foo."
+                                    "raw": "[x]Foo."
                                 }
                             ],
                             "loc": {
@@ -1136,37 +1245,15 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": "x",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "X",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 35,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 35,
-                                                    "column": 5
-                                                }
-                                            },
-                                            "range": [
-                                                250,
-                                                251
-                                            ],
-                                            "raw": "X"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[X]Bar",
                                     "loc": {
                                         "start": {
                                             "line": 35,
@@ -1174,33 +1261,14 @@
                                         },
                                         "end": {
                                             "line": 35,
-                                            "column": 6
-                                        }
-                                    },
-                                    "range": [
-                                        249,
-                                        252
-                                    ],
-                                    "raw": "[X]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": "Bar",
-                                    "loc": {
-                                        "start": {
-                                            "line": 35,
-                                            "column": 6
-                                        },
-                                        "end": {
-                                            "line": 35,
                                             "column": 9
                                         }
                                     },
                                     "range": [
-                                        252,
+                                        249,
                                         255
                                     ],
-                                    "raw": "Bar"
+                                    "raw": "[X]Bar"
                                 }
                             ],
                             "loc": {
@@ -1297,11 +1365,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -1362,7 +1430,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -1442,11 +1510,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -1507,7 +1575,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -1627,11 +1695,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -1692,7 +1760,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -1772,11 +1840,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -1837,7 +1905,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -1957,17 +2025,36 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "Hello;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "    Hello;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 58,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 58,
+                                            "column": 16
+                                        }
+                                    },
+                                    "range": [
+                                        534,
+                                        544
+                                    ],
+                                    "raw": "    Hello;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 58,
@@ -2003,13 +2090,32 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "World;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "    World;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 59,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 59,
+                                            "column": 16
+                                        }
+                                    },
+                                    "range": [
+                                        551,
+                                        561
+                                    ],
+                                    "raw": "    World;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 59,
@@ -2064,11 +2170,11 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -2129,7 +2235,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -2249,17 +2355,36 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "Hello;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "\tHello;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 67,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 67,
+                                            "column": 13
+                                        }
+                                    },
+                                    "range": [
+                                        655,
+                                        662
+                                    ],
+                                    "raw": "\tHello;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 67,
@@ -2295,13 +2420,32 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "World;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "\tWorld;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 68,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 68,
+                                            "column": 13
+                                        }
+                                    },
+                                    "range": [
+                                        669,
+                                        676
+                                    ],
+                                    "raw": "\tWorld;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 68,
@@ -2356,17 +2500,36 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "Foo.",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "\tFoo.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 70,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 70,
+                                            "column": 12
+                                        }
+                                    },
+                                    "range": [
+                                        685,
+                                        690
+                                    ],
+                                    "raw": "\tFoo."
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 70,
@@ -2402,13 +2565,32 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "Bar.",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "\tBar.",
+                                    "loc": {
+                                        "start": {
+                                            "line": 71,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 71,
+                                            "column": 12
+                                        }
+                                    },
+                                    "range": [
+                                        698,
+                                        703
+                                    ],
+                                    "raw": "\tBar."
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 71,
@@ -2503,17 +2685,36 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "    Hello;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "\t    Hello;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 76,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 76,
+                                            "column": 17
+                                        }
+                                    },
+                                    "range": [
+                                        756,
+                                        767
+                                    ],
+                                    "raw": "\t    Hello;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 76,
@@ -2568,17 +2769,36 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "World;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "    World;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 78,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 78,
+                                            "column": 17
+                                        }
+                                    },
+                                    "range": [
+                                        776,
+                                        786
+                                    ],
+                                    "raw": "    World;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 78,
@@ -2633,17 +2853,36 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
-                            "type": "CodeBlock",
-                            "lang": null,
-                            "value": "\tHello;",
+                            "type": "Paragraph",
+                            "children": [
+                                {
+                                    "type": "Str",
+                                    "value": "    \tHello;",
+                                    "loc": {
+                                        "start": {
+                                            "line": 80,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 80,
+                                            "column": 17
+                                        }
+                                    },
+                                    "range": [
+                                        794,
+                                        805
+                                    ],
+                                    "raw": "    \tHello;"
+                                }
+                            ],
                             "loc": {
                                 "start": {
                                     "line": 80,
@@ -2679,7 +2918,7 @@
                 },
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": false,
                     "children": [
                         {
@@ -2759,11 +2998,11 @@
             "type": "List",
             "ordered": true,
             "start": 2,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": true,
                     "children": [
                         {
@@ -2883,75 +3122,34 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "\n",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 88,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 89,
-                                                    "column": 0
-                                                }
-                                            },
-                                            "range": [
-                                                867,
-                                                868
-                                            ],
-                                            "raw": "\n"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[",
                                     "loc": {
                                         "start": {
                                             "line": 88,
                                             "column": 2
                                         },
                                         "end": {
-                                            "line": 89,
-                                            "column": 1
+                                            "line": 88,
+                                            "column": 3
                                         }
                                     },
                                     "range": [
                                         866,
-                                        869
+                                        867
                                     ],
-                                    "raw": "[\n]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " Hello;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 89,
-                                            "column": 1
-                                        },
-                                        "end": {
-                                            "line": 89,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        869,
-                                        876
-                                    ],
-                                    "raw": " Hello;"
+                                    "raw": "["
                                 }
                             ],
                             "loc": {
@@ -2960,15 +3158,15 @@
                                     "column": 2
                                 },
                                 "end": {
-                                    "line": 89,
-                                    "column": 8
+                                    "line": 88,
+                                    "column": 3
                                 }
                             },
                             "range": [
                                 866,
-                                876
+                                867
                             ],
-                            "raw": "[\n] Hello;"
+                            "raw": "["
                         }
                     ],
                     "loc": {
@@ -2977,15 +3175,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 89,
-                            "column": 8
+                            "line": 88,
+                            "column": 3
                         }
                     },
                     "range": [
                         864,
-                        876
+                        867
                     ],
-                    "raw": "* [\n] Hello;"
+                    "raw": "* ["
                 }
             ],
             "loc": {
@@ -2994,89 +3192,87 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 88,
+                    "column": 3
+                }
+            },
+            "range": [
+                864,
+                867
+            ],
+            "raw": "* ["
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "] Hello;",
+                    "loc": {
+                        "start": {
+                            "line": 89,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 89,
+                            "column": 8
+                        }
+                    },
+                    "range": [
+                        868,
+                        876
+                    ],
+                    "raw": "] Hello;"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 89,
+                    "column": 0
+                },
+                "end": {
                     "line": 89,
                     "column": 8
                 }
             },
             "range": [
-                864,
+                868,
                 876
             ],
-            "raw": "* [\n] Hello;"
+            "raw": "] Hello;"
         },
         {
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "\n",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 91,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 92,
-                                                    "column": 0
-                                                }
-                                            },
-                                            "range": [
-                                                882,
-                                                883
-                                            ],
-                                            "raw": "\n"
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[",
                                     "loc": {
                                         "start": {
                                             "line": 91,
                                             "column": 3
                                         },
                                         "end": {
-                                            "line": 92,
-                                            "column": 1
+                                            "line": 91,
+                                            "column": 4
                                         }
                                     },
                                     "range": [
                                         881,
-                                        884
+                                        882
                                     ],
-                                    "raw": "[\n]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " Hello;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 92,
-                                            "column": 1
-                                        },
-                                        "end": {
-                                            "line": 92,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        884,
-                                        891
-                                    ],
-                                    "raw": " Hello;"
+                                    "raw": "["
                                 }
                             ],
                             "loc": {
@@ -3085,15 +3281,15 @@
                                     "column": 3
                                 },
                                 "end": {
-                                    "line": 92,
-                                    "column": 8
+                                    "line": 91,
+                                    "column": 4
                                 }
                             },
                             "range": [
                                 881,
-                                891
+                                882
                             ],
-                            "raw": "[\n] Hello;"
+                            "raw": "["
                         }
                     ],
                     "loc": {
@@ -3102,15 +3298,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 92,
-                            "column": 8
+                            "line": 91,
+                            "column": 4
                         }
                     },
                     "range": [
                         878,
-                        891
+                        882
                     ],
-                    "raw": "1. [\n] Hello;"
+                    "raw": "1. ["
                 }
             ],
             "loc": {
@@ -3119,15 +3315,54 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 91,
+                    "column": 4
+                }
+            },
+            "range": [
+                878,
+                882
+            ],
+            "raw": "1. ["
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "] Hello;",
+                    "loc": {
+                        "start": {
+                            "line": 92,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 92,
+                            "column": 8
+                        }
+                    },
+                    "range": [
+                        883,
+                        891
+                    ],
+                    "raw": "] Hello;"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 92,
+                    "column": 0
+                },
+                "end": {
                     "line": 92,
                     "column": 8
                 }
             },
             "range": [
-                878,
+                883,
                 891
             ],
-            "raw": "1. [\n] Hello;"
+            "raw": "] Hello;"
         },
         {
             "type": "Header",
@@ -3173,41 +3408,19 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "  ",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 97,
-                                                    "column": 3
-                                                },
-                                                "end": {
-                                                    "line": 97,
-                                                    "column": 5
-                                                }
-                                            },
-                                            "range": [
-                                                959,
-                                                961
-                                            ],
-                                            "raw": "  "
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[  ] Hello;",
                                     "loc": {
                                         "start": {
                                             "line": 97,
@@ -3215,33 +3428,14 @@
                                         },
                                         "end": {
                                             "line": 97,
-                                            "column": 6
-                                        }
-                                    },
-                                    "range": [
-                                        958,
-                                        962
-                                    ],
-                                    "raw": "[  ]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " Hello;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 97,
-                                            "column": 6
-                                        },
-                                        "end": {
-                                            "line": 97,
                                             "column": 13
                                         }
                                     },
                                     "range": [
-                                        962,
+                                        958,
                                         969
                                     ],
-                                    "raw": " Hello;"
+                                    "raw": "[  ] Hello;"
                                 }
                             ],
                             "loc": {
@@ -3298,75 +3492,34 @@
             "type": "List",
             "ordered": true,
             "start": 1,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
                             "type": "Paragraph",
                             "children": [
                                 {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": " \n",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 99,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 100,
-                                                    "column": 1
-                                                }
-                                            },
-                                            "range": [
-                                                975,
-                                                978
-                                            ],
-                                            "raw": " \n "
-                                        }
-                                    ],
+                                    "type": "Str",
+                                    "value": "[",
                                     "loc": {
                                         "start": {
                                             "line": 99,
                                             "column": 3
                                         },
                                         "end": {
-                                            "line": 100,
-                                            "column": 2
+                                            "line": 99,
+                                            "column": 4
                                         }
                                     },
                                     "range": [
                                         974,
-                                        979
+                                        975
                                     ],
-                                    "raw": "[ \n ]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " World;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 100,
-                                            "column": 2
-                                        },
-                                        "end": {
-                                            "line": 100,
-                                            "column": 9
-                                        }
-                                    },
-                                    "range": [
-                                        979,
-                                        986
-                                    ],
-                                    "raw": " World;"
+                                    "raw": "["
                                 }
                             ],
                             "loc": {
@@ -3375,15 +3528,15 @@
                                     "column": 3
                                 },
                                 "end": {
-                                    "line": 100,
-                                    "column": 9
+                                    "line": 99,
+                                    "column": 5
                                 }
                             },
                             "range": [
                                 974,
-                                986
+                                976
                             ],
-                            "raw": "[ \n ] World;"
+                            "raw": "[ "
                         }
                     ],
                     "loc": {
@@ -3392,219 +3545,15 @@
                             "column": 0
                         },
                         "end": {
-                            "line": 100,
-                            "column": 9
+                            "line": 99,
+                            "column": 5
                         }
                     },
                     "range": [
                         971,
-                        986
+                        976
                     ],
-                    "raw": "1. [ \n ] World;"
-                },
-                {
-                    "type": "ListItem",
-                    "loose": false,
-                    "checked": null,
-                    "children": [
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": "\t\t",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 101,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 101,
-                                                    "column": 6
-                                                }
-                                            },
-                                            "range": [
-                                                991,
-                                                993
-                                            ],
-                                            "raw": "\t\t"
-                                        }
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 101,
-                                            "column": 3
-                                        },
-                                        "end": {
-                                            "line": 101,
-                                            "column": 7
-                                        }
-                                    },
-                                    "range": [
-                                        990,
-                                        994
-                                    ],
-                                    "raw": "[\t\t]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " Hello;",
-                                    "loc": {
-                                        "start": {
-                                            "line": 101,
-                                            "column": 7
-                                        },
-                                        "end": {
-                                            "line": 101,
-                                            "column": 14
-                                        }
-                                    },
-                                    "range": [
-                                        994,
-                                        1001
-                                    ],
-                                    "raw": " Hello;"
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 101,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 101,
-                                    "column": 14
-                                }
-                            },
-                            "range": [
-                                990,
-                                1001
-                            ],
-                            "raw": "[\t\t] Hello;"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 101,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 101,
-                            "column": 14
-                        }
-                    },
-                    "range": [
-                        987,
-                        1001
-                    ],
-                    "raw": "2. [\t\t] Hello;"
-                },
-                {
-                    "type": "ListItem",
-                    "loose": false,
-                    "checked": null,
-                    "children": [
-                        {
-                            "type": "Paragraph",
-                            "children": [
-                                {
-                                    "type": "LinkReference",
-                                    "identifier": " ",
-                                    "referenceType": "shortcut",
-                                    "children": [
-                                        {
-                                            "type": "Str",
-                                            "value": " \t ",
-                                            "loc": {
-                                                "start": {
-                                                    "line": 102,
-                                                    "column": 4
-                                                },
-                                                "end": {
-                                                    "line": 102,
-                                                    "column": 7
-                                                }
-                                            },
-                                            "range": [
-                                                1006,
-                                                1009
-                                            ],
-                                            "raw": " \t "
-                                        }
-                                    ],
-                                    "loc": {
-                                        "start": {
-                                            "line": 102,
-                                            "column": 3
-                                        },
-                                        "end": {
-                                            "line": 102,
-                                            "column": 8
-                                        }
-                                    },
-                                    "range": [
-                                        1005,
-                                        1010
-                                    ],
-                                    "raw": "[ \t ]"
-                                },
-                                {
-                                    "type": "Str",
-                                    "value": " World.",
-                                    "loc": {
-                                        "start": {
-                                            "line": 102,
-                                            "column": 8
-                                        },
-                                        "end": {
-                                            "line": 102,
-                                            "column": 15
-                                        }
-                                    },
-                                    "range": [
-                                        1010,
-                                        1017
-                                    ],
-                                    "raw": " World."
-                                }
-                            ],
-                            "loc": {
-                                "start": {
-                                    "line": 102,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 102,
-                                    "column": 15
-                                }
-                            },
-                            "range": [
-                                1005,
-                                1017
-                            ],
-                            "raw": "[ \t ] World."
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 102,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 102,
-                            "column": 15
-                        }
-                    },
-                    "range": [
-                        1002,
-                        1017
-                    ],
-                    "raw": "3. [ \t ] World."
+                    "raw": "1. [ "
                 }
             ],
             "loc": {
@@ -3613,15 +3562,54 @@
                     "column": 0
                 },
                 "end": {
+                    "line": 99,
+                    "column": 5
+                }
+            },
+            "range": [
+                971,
+                976
+            ],
+            "raw": "1. [ "
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "] World;\n2. [\t\t] Hello;\n3. [ \t ] World.",
+                    "loc": {
+                        "start": {
+                            "line": 100,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 102,
+                            "column": 15
+                        }
+                    },
+                    "range": [
+                        978,
+                        1017
+                    ],
+                    "raw": "] World;\n2. [\t\t] Hello;\n3. [ \t ] World."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 100,
+                    "column": 1
+                },
+                "end": {
                     "line": 102,
                     "column": 15
                 }
             },
             "range": [
-                971,
+                978,
                 1017
             ],
-            "raw": "1. [ \n ] World;\n2. [\t\t] Hello;\n3. [ \t ] World."
+            "raw": "] World;\n2. [\t\t] Hello;\n3. [ \t ] World."
         }
     ],
     "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/tidyness.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/tidyness.text/output.json
@@ -47,11 +47,11 @@
                     "type": "List",
                     "ordered": false,
                     "start": null,
-                    "loose": false,
+                    "spread": false,
                     "children": [
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -112,7 +112,7 @@
                         },
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {
@@ -173,7 +173,7 @@
                         },
                         {
                             "type": "ListItem",
-                            "loose": false,
+                            "spread": false,
                             "checked": null,
                             "children": [
                                 {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/title-attributes.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/title-attributes.text/output.json
@@ -82,18 +82,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                11,
-                                25
+                                9,
+                                27
                             ],
-                            "raw": "Implementation"
+                            "raw": "| Implementation |"
                         },
                         {
                             "type": "TableCell",
@@ -121,18 +121,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                28,
-                                38
+                                27,
+                                40
                             ],
-                            "raw": "Characters"
+                            "raw": " Characters |"
                         },
                         {
                             "type": "TableCell",
@@ -160,18 +160,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                41,
-                                47
+                                40,
+                                49
                             ],
-                            "raw": "Nested"
+                            "raw": " Nested |"
                         },
                         {
                             "type": "TableCell",
@@ -199,18 +199,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                50,
-                                60
+                                49,
+                                62
                             ],
-                            "raw": "Mismatched"
+                            "raw": " Mismatched |"
                         },
                         {
                             "type": "TableCell",
@@ -238,18 +238,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                63,
-                                70
+                                62,
+                                72
                             ],
-                            "raw": "Escaped"
+                            "raw": " Escaped |"
                         },
                         {
                             "type": "TableCell",
@@ -277,18 +277,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                73,
-                                87
+                                72,
+                                89
                             ],
-                            "raw": "Named Entities"
+                            "raw": " Named Entities |"
                         },
                         {
                             "type": "TableCell",
@@ -316,18 +316,18 @@
                             "loc": {
                                 "start": {
                                     "line": 3,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 3,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                90,
-                                107
+                                89,
+                                109
                             ],
-                            "raw": "Numbered Entities"
+                            "raw": " Numbered Entities |"
                         }
                     ],
                     "loc": {
@@ -375,18 +375,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                213,
-                                227
+                                211,
+                                229
                             ],
-                            "raw": "Markdown.pl   "
+                            "raw": "| Markdown.pl    |"
                         },
                         {
                             "type": "TableCell",
@@ -414,18 +414,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                230,
-                                240
+                                229,
+                                242
                             ],
-                            "raw": "`\"`       "
+                            "raw": " `\"`        |"
                         },
                         {
                             "type": "TableCell",
@@ -453,18 +453,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                243,
-                                249
+                                242,
+                                251
                             ],
-                            "raw": "Yes   "
+                            "raw": " Yes    |"
                         },
                         {
                             "type": "TableCell",
@@ -492,18 +492,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                252,
-                                262
+                                251,
+                                264
                             ],
-                            "raw": "Yes       "
+                            "raw": " Yes        |"
                         },
                         {
                             "type": "TableCell",
@@ -531,18 +531,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                265,
-                                272
+                                264,
+                                274
                             ],
-                            "raw": "No     "
+                            "raw": " No      |"
                         },
                         {
                             "type": "TableCell",
@@ -570,18 +570,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                275,
-                                289
+                                274,
+                                291
                             ],
-                            "raw": "Yes           "
+                            "raw": " Yes            |"
                         },
                         {
                             "type": "TableCell",
@@ -609,18 +609,18 @@
                             "loc": {
                                 "start": {
                                     "line": 5,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 5,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                292,
-                                309
+                                291,
+                                311
                             ],
-                            "raw": "Yes              "
+                            "raw": " Yes               |"
                         }
                     ],
                     "loc": {
@@ -668,18 +668,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                314,
-                                328
+                                312,
+                                330
                             ],
-                            "raw": "GitHub        "
+                            "raw": "| GitHub         |"
                         },
                         {
                             "type": "TableCell",
@@ -707,18 +707,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                331,
-                                341
+                                330,
+                                343
                             ],
-                            "raw": "`\"`       "
+                            "raw": " `\"`        |"
                         },
                         {
                             "type": "TableCell",
@@ -746,18 +746,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                344,
-                                350
+                                343,
+                                352
                             ],
-                            "raw": "Yes   "
+                            "raw": " Yes    |"
                         },
                         {
                             "type": "TableCell",
@@ -785,18 +785,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                353,
-                                363
+                                352,
+                                365
                             ],
-                            "raw": "Yes       "
+                            "raw": " Yes        |"
                         },
                         {
                             "type": "TableCell",
@@ -824,18 +824,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                366,
-                                373
+                                365,
+                                375
                             ],
-                            "raw": "No     "
+                            "raw": " No      |"
                         },
                         {
                             "type": "TableCell",
@@ -863,18 +863,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                376,
-                                390
+                                375,
+                                392
                             ],
-                            "raw": "No            "
+                            "raw": " No             |"
                         },
                         {
                             "type": "TableCell",
@@ -902,18 +902,18 @@
                             "loc": {
                                 "start": {
                                     "line": 6,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 6,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                393,
-                                410
+                                392,
+                                412
                             ],
-                            "raw": "No               "
+                            "raw": " No                |"
                         }
                     ],
                     "loc": {
@@ -961,18 +961,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                415,
-                                429
+                                413,
+                                431
                             ],
-                            "raw": "CommonMark    "
+                            "raw": "| CommonMark     |"
                         },
                         {
                             "type": "TableCell",
@@ -1000,18 +1000,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                432,
-                                442
+                                431,
+                                444
                             ],
-                            "raw": "`\"`       "
+                            "raw": " `\"`        |"
                         },
                         {
                             "type": "TableCell",
@@ -1039,18 +1039,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                445,
-                                451
+                                444,
+                                453
                             ],
-                            "raw": "No    "
+                            "raw": " No     |"
                         },
                         {
                             "type": "TableCell",
@@ -1078,18 +1078,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                454,
-                                464
+                                453,
+                                466
                             ],
-                            "raw": "No        "
+                            "raw": " No         |"
                         },
                         {
                             "type": "TableCell",
@@ -1117,18 +1117,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                467,
-                                474
+                                466,
+                                476
                             ],
-                            "raw": "Yes    "
+                            "raw": " Yes     |"
                         },
                         {
                             "type": "TableCell",
@@ -1156,18 +1156,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                477,
-                                491
+                                476,
+                                493
                             ],
-                            "raw": "Yes           "
+                            "raw": " Yes            |"
                         },
                         {
                             "type": "TableCell",
@@ -1195,18 +1195,18 @@
                             "loc": {
                                 "start": {
                                     "line": 7,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 7,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                494,
-                                511
+                                493,
+                                513
                             ],
-                            "raw": "Yes              "
+                            "raw": " Yes               |"
                         }
                     ],
                     "loc": {
@@ -1254,18 +1254,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                516,
-                                530
+                                514,
+                                532
                             ],
-                            "raw": "Markdown.pl   "
+                            "raw": "| Markdown.pl    |"
                         },
                         {
                             "type": "TableCell",
@@ -1293,18 +1293,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                533,
-                                543
+                                532,
+                                545
                             ],
-                            "raw": "`'`       "
+                            "raw": " `'`        |"
                         },
                         {
                             "type": "TableCell",
@@ -1332,18 +1332,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                546,
-                                552
+                                545,
+                                554
                             ],
-                            "raw": "Yes   "
+                            "raw": " Yes    |"
                         },
                         {
                             "type": "TableCell",
@@ -1371,18 +1371,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                555,
-                                565
+                                554,
+                                567
                             ],
-                            "raw": "Yes       "
+                            "raw": " Yes        |"
                         },
                         {
                             "type": "TableCell",
@@ -1410,18 +1410,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                568,
-                                575
+                                567,
+                                577
                             ],
-                            "raw": "No     "
+                            "raw": " No      |"
                         },
                         {
                             "type": "TableCell",
@@ -1449,18 +1449,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                578,
-                                592
+                                577,
+                                594
                             ],
-                            "raw": "Yes           "
+                            "raw": " Yes            |"
                         },
                         {
                             "type": "TableCell",
@@ -1488,18 +1488,18 @@
                             "loc": {
                                 "start": {
                                     "line": 8,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 8,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                595,
-                                612
+                                594,
+                                614
                             ],
-                            "raw": "Yes              "
+                            "raw": " Yes               |"
                         }
                     ],
                     "loc": {
@@ -1547,18 +1547,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                617,
-                                631
+                                615,
+                                633
                             ],
-                            "raw": "GitHub        "
+                            "raw": "| GitHub         |"
                         },
                         {
                             "type": "TableCell",
@@ -1586,18 +1586,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                634,
-                                644
+                                633,
+                                646
                             ],
-                            "raw": "`'`       "
+                            "raw": " `'`        |"
                         },
                         {
                             "type": "TableCell",
@@ -1625,18 +1625,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                647,
-                                653
+                                646,
+                                655
                             ],
-                            "raw": "Yes   "
+                            "raw": " Yes    |"
                         },
                         {
                             "type": "TableCell",
@@ -1664,18 +1664,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                656,
-                                666
+                                655,
+                                668
                             ],
-                            "raw": "Yes       "
+                            "raw": " Yes        |"
                         },
                         {
                             "type": "TableCell",
@@ -1703,18 +1703,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                669,
-                                676
+                                668,
+                                678
                             ],
-                            "raw": "No     "
+                            "raw": " No      |"
                         },
                         {
                             "type": "TableCell",
@@ -1742,18 +1742,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                679,
-                                693
+                                678,
+                                695
                             ],
-                            "raw": "No            "
+                            "raw": " No             |"
                         },
                         {
                             "type": "TableCell",
@@ -1781,18 +1781,18 @@
                             "loc": {
                                 "start": {
                                     "line": 9,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 9,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                696,
-                                713
+                                695,
+                                715
                             ],
-                            "raw": "No               "
+                            "raw": " No                |"
                         }
                     ],
                     "loc": {
@@ -1840,18 +1840,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                718,
-                                732
+                                716,
+                                734
                             ],
-                            "raw": "CommonMark    "
+                            "raw": "| CommonMark     |"
                         },
                         {
                             "type": "TableCell",
@@ -1879,18 +1879,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                735,
-                                745
+                                734,
+                                747
                             ],
-                            "raw": "`'`       "
+                            "raw": " `'`        |"
                         },
                         {
                             "type": "TableCell",
@@ -1918,18 +1918,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                748,
-                                754
+                                747,
+                                756
                             ],
-                            "raw": "No    "
+                            "raw": " No     |"
                         },
                         {
                             "type": "TableCell",
@@ -1957,18 +1957,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                757,
-                                767
+                                756,
+                                769
                             ],
-                            "raw": "No        "
+                            "raw": " No         |"
                         },
                         {
                             "type": "TableCell",
@@ -1996,18 +1996,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                770,
-                                777
+                                769,
+                                779
                             ],
-                            "raw": "Yes    "
+                            "raw": " Yes     |"
                         },
                         {
                             "type": "TableCell",
@@ -2035,18 +2035,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                780,
-                                794
+                                779,
+                                796
                             ],
-                            "raw": "Yes           "
+                            "raw": " Yes            |"
                         },
                         {
                             "type": "TableCell",
@@ -2074,18 +2074,18 @@
                             "loc": {
                                 "start": {
                                     "line": 10,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 10,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                797,
-                                814
+                                796,
+                                816
                             ],
-                            "raw": "Yes              "
+                            "raw": " Yes               |"
                         }
                     ],
                     "loc": {
@@ -2133,18 +2133,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                819,
-                                833
+                                817,
+                                835
                             ],
-                            "raw": "Markdown.pl   "
+                            "raw": "| Markdown.pl    |"
                         },
                         {
                             "type": "TableCell",
@@ -2172,18 +2172,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                836,
-                                846
+                                835,
+                                848
                             ],
-                            "raw": "`()`      "
+                            "raw": " `()`       |"
                         },
                         {
                             "type": "TableCell",
@@ -2211,18 +2211,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                849,
-                                855
+                                848,
+                                857
                             ],
-                            "raw": "-     "
+                            "raw": " -      |"
                         },
                         {
                             "type": "TableCell",
@@ -2250,18 +2250,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                858,
-                                868
+                                857,
+                                870
                             ],
-                            "raw": "-         "
+                            "raw": " -          |"
                         },
                         {
                             "type": "TableCell",
@@ -2289,18 +2289,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                871,
-                                878
+                                870,
+                                880
                             ],
-                            "raw": "-      "
+                            "raw": " -       |"
                         },
                         {
                             "type": "TableCell",
@@ -2328,18 +2328,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                881,
-                                895
+                                880,
+                                897
                             ],
-                            "raw": "-             "
+                            "raw": " -              |"
                         },
                         {
                             "type": "TableCell",
@@ -2367,18 +2367,18 @@
                             "loc": {
                                 "start": {
                                     "line": 11,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 11,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                898,
-                                915
+                                897,
+                                917
                             ],
-                            "raw": "-                "
+                            "raw": " -                 |"
                         }
                     ],
                     "loc": {
@@ -2426,18 +2426,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                920,
-                                934
+                                918,
+                                936
                             ],
-                            "raw": "GitHub        "
+                            "raw": "| GitHub         |"
                         },
                         {
                             "type": "TableCell",
@@ -2465,18 +2465,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                937,
-                                947
+                                936,
+                                949
                             ],
-                            "raw": "`()`      "
+                            "raw": " `()`       |"
                         },
                         {
                             "type": "TableCell",
@@ -2504,18 +2504,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                950,
-                                956
+                                949,
+                                958
                             ],
-                            "raw": "-     "
+                            "raw": " -      |"
                         },
                         {
                             "type": "TableCell",
@@ -2543,18 +2543,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                959,
-                                969
+                                958,
+                                971
                             ],
-                            "raw": "-         "
+                            "raw": " -          |"
                         },
                         {
                             "type": "TableCell",
@@ -2582,18 +2582,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                972,
-                                979
+                                971,
+                                981
                             ],
-                            "raw": "-      "
+                            "raw": " -       |"
                         },
                         {
                             "type": "TableCell",
@@ -2621,18 +2621,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                982,
-                                996
+                                981,
+                                998
                             ],
-                            "raw": "-             "
+                            "raw": " -              |"
                         },
                         {
                             "type": "TableCell",
@@ -2660,18 +2660,18 @@
                             "loc": {
                                 "start": {
                                     "line": 12,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 12,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                999,
-                                1016
+                                998,
+                                1018
                             ],
-                            "raw": "-                "
+                            "raw": " -                 |"
                         }
                     ],
                     "loc": {
@@ -2719,18 +2719,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 2
+                                    "column": 0
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 16
+                                    "column": 18
                                 }
                             },
                             "range": [
-                                1021,
-                                1035
+                                1019,
+                                1037
                             ],
-                            "raw": "CommonMark    "
+                            "raw": "| CommonMark     |"
                         },
                         {
                             "type": "TableCell",
@@ -2758,18 +2758,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 19
+                                    "column": 18
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 29
+                                    "column": 31
                                 }
                             },
                             "range": [
-                                1038,
-                                1048
+                                1037,
+                                1050
                             ],
-                            "raw": "`()`      "
+                            "raw": " `()`       |"
                         },
                         {
                             "type": "TableCell",
@@ -2797,18 +2797,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 32
+                                    "column": 31
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 38
+                                    "column": 40
                                 }
                             },
                             "range": [
-                                1051,
-                                1057
+                                1050,
+                                1059
                             ],
-                            "raw": "No    "
+                            "raw": " No     |"
                         },
                         {
                             "type": "TableCell",
@@ -2836,18 +2836,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 41
+                                    "column": 40
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 51
+                                    "column": 53
                                 }
                             },
                             "range": [
-                                1060,
-                                1070
+                                1059,
+                                1072
                             ],
-                            "raw": "Yes       "
+                            "raw": " Yes        |"
                         },
                         {
                             "type": "TableCell",
@@ -2875,18 +2875,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 54
+                                    "column": 53
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 61
+                                    "column": 63
                                 }
                             },
                             "range": [
-                                1073,
-                                1080
+                                1072,
+                                1082
                             ],
-                            "raw": "Yes    "
+                            "raw": " Yes     |"
                         },
                         {
                             "type": "TableCell",
@@ -2914,18 +2914,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 64
+                                    "column": 63
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 78
+                                    "column": 80
                                 }
                             },
                             "range": [
-                                1083,
-                                1097
+                                1082,
+                                1099
                             ],
-                            "raw": "Yes           "
+                            "raw": " Yes            |"
                         },
                         {
                             "type": "TableCell",
@@ -2953,18 +2953,18 @@
                             "loc": {
                                 "start": {
                                     "line": 13,
-                                    "column": 81
+                                    "column": 80
                                 },
                                 "end": {
                                     "line": 13,
-                                    "column": 98
+                                    "column": 100
                                 }
                             },
                             "range": [
-                                1100,
-                                1117
+                                1099,
+                                1119
                             ],
-                            "raw": "Yes              "
+                            "raw": " Yes               |"
                         }
                     ],
                     "loc": {
@@ -3105,30 +3105,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "and \"matching delimiters\"",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 19,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 19,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1174,
-                                1179
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html \"and \"matching delimiters\"\")",
                     "loc": {
                         "start": {
                             "line": 19,
@@ -3166,30 +3144,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "and \"mismatched delimiters",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 21,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 21,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1225,
-                                1230
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html \"and \"mismatched delimiters\")",
                     "loc": {
                         "start": {
                             "line": 21,
@@ -3228,7 +3184,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "and \\\"escapes\\\"",
+                    "title": "and \"escapes\"",
                     "url": "./world.html",
                     "children": [
                         {
@@ -3511,30 +3467,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "and 'matching delimiters'",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 33,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 33,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1485,
-                                1490
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html 'and 'matching delimiters'')",
                     "loc": {
                         "start": {
                             "line": 33,
@@ -3572,30 +3506,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Link",
-                    "title": "and 'mismatched delimiters",
-                    "url": "./world.html",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "Hello",
-                            "loc": {
-                                "start": {
-                                    "line": 35,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 35,
-                                    "column": 6
-                                }
-                            },
-                            "range": [
-                                1536,
-                                1541
-                            ],
-                            "raw": "Hello"
-                        }
-                    ],
+                    "type": "Str",
+                    "value": "[Hello](./world.html 'and 'mismatched delimiters')",
                     "loc": {
                         "start": {
                             "line": 35,
@@ -3634,7 +3546,7 @@
             "children": [
                 {
                     "type": "Link",
-                    "title": "and \\'escapes\\'",
+                    "title": "and 'escapes'",
                     "url": "./world.html",
                     "children": [
                         {
@@ -3856,9 +3768,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and text",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -3887,33 +3799,14 @@
                         },
                         "end": {
                             "line": 45,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        1759,
-                        1766
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (and text))",
-                    "loc": {
-                        "start": {
-                            "line": 45,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 45,
                             "column": 32
                         }
                     },
                     "range": [
-                        1766,
+                        1759,
                         1791
                     ],
-                    "raw": "(./world.html (and text))"
+                    "raw": "[Hello](./world.html (and text))"
                 }
             ],
             "loc": {
@@ -3936,9 +3829,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and (matching delimiters",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -3967,22 +3860,22 @@
                         },
                         "end": {
                             "line": 47,
-                            "column": 7
+                            "column": 48
                         }
                     },
                     "range": [
                         1793,
-                        1800
+                        1841
                     ],
-                    "raw": "[Hello]"
+                    "raw": "[Hello](./world.html (and (matching delimiters))"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.html (and (matching delimiters)))",
+                    "value": ")",
                     "loc": {
                         "start": {
                             "line": 47,
-                            "column": 7
+                            "column": 48
                         },
                         "end": {
                             "line": 47,
@@ -3990,10 +3883,10 @@
                         }
                     },
                     "range": [
-                        1800,
+                        1841,
                         1842
                     ],
-                    "raw": "(./world.html (and (matching delimiters)))"
+                    "raw": ")"
                 }
             ],
             "loc": {
@@ -4016,9 +3909,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and (mismatched delimiters",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -4047,33 +3940,14 @@
                         },
                         "end": {
                             "line": 49,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        1844,
-                        1851
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (and (mismatched delimiters))",
-                    "loc": {
-                        "start": {
-                            "line": 49,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 49,
                             "column": 50
                         }
                     },
                     "range": [
-                        1851,
+                        1844,
                         1894
                     ],
-                    "raw": "(./world.html (and (mismatched delimiters))"
+                    "raw": "[Hello](./world.html (and (mismatched delimiters))"
                 }
             ],
             "loc": {
@@ -4096,9 +3970,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and (escapes)",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -4127,109 +4001,14 @@
                         },
                         "end": {
                             "line": 51,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        1896,
-                        1903
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (and ",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        1903,
-                        1922
-                    ],
-                    "raw": "(./world.html (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 28
-                        }
-                    },
-                    "range": [
-                        1922,
-                        1924
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "escapes",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 28
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 35
-                        }
-                    },
-                    "range": [
-                        1924,
-                        1931
-                    ],
-                    "raw": "escapes"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 35
-                        },
-                        "end": {
-                            "line": 51,
-                            "column": 37
-                        }
-                    },
-                    "range": [
-                        1931,
-                        1933
-                    ],
-                    "raw": "\\)"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 51,
-                            "column": 37
-                        },
-                        "end": {
-                            "line": 51,
                             "column": 39
                         }
                     },
                     "range": [
-                        1933,
+                        1896,
                         1935
                     ],
-                    "raw": "))"
+                    "raw": "[Hello](./world.html (and \\(escapes\\)))"
                 }
             ],
             "loc": {
@@ -4252,9 +4031,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and (named entities)",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -4283,109 +4062,14 @@
                         },
                         "end": {
                             "line": 53,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        1937,
-                        1944
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (and ",
-                    "loc": {
-                        "start": {
-                            "line": 53,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 53,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        1944,
-                        1963
-                    ],
-                    "raw": "(./world.html (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 53,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 53,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        1963,
-                        1969
-                    ],
-                    "raw": "&lpar;"
-                },
-                {
-                    "type": "Str",
-                    "value": "named entities",
-                    "loc": {
-                        "start": {
-                            "line": 53,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 53,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        1969,
-                        1983
-                    ],
-                    "raw": "named entities"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 53,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 53,
-                            "column": 52
-                        }
-                    },
-                    "range": [
-                        1983,
-                        1989
-                    ],
-                    "raw": "&rpar;"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 53,
-                            "column": 52
-                        },
-                        "end": {
-                            "line": 53,
                             "column": 54
                         }
                     },
                     "range": [
-                        1989,
+                        1937,
                         1991
                     ],
-                    "raw": "))"
+                    "raw": "[Hello](./world.html (and &lpar;named entities&rpar;))"
                 }
             ],
             "loc": {
@@ -4408,9 +4092,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "LinkReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Link",
+                    "title": "and (numbered entities)",
+                    "url": "./world.html",
                     "children": [
                         {
                             "type": "Str",
@@ -4439,109 +4123,14 @@
                         },
                         "end": {
                             "line": 55,
-                            "column": 7
-                        }
-                    },
-                    "range": [
-                        1993,
-                        2000
-                    ],
-                    "raw": "[Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.html (and ",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        2000,
-                        2019
-                    ],
-                    "raw": "(./world.html (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        2019,
-                        2025
-                    ],
-                    "raw": "&#x28;"
-                },
-                {
-                    "type": "Str",
-                    "value": "numbered entities",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 49
-                        }
-                    },
-                    "range": [
-                        2025,
-                        2042
-                    ],
-                    "raw": "numbered entities"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 49
-                        },
-                        "end": {
-                            "line": 55,
-                            "column": 55
-                        }
-                    },
-                    "range": [
-                        2042,
-                        2048
-                    ],
-                    "raw": "&#x29;"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 55,
-                            "column": 55
-                        },
-                        "end": {
-                            "line": 55,
                             "column": 57
                         }
                     },
                     "range": [
-                        2048,
+                        1993,
                         2050
                     ],
-                    "raw": "))"
+                    "raw": "[Hello](./world.html (and &#x28;numbered entities&#x29;))"
                 }
             ],
             "loc": {
@@ -4685,10 +4274,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "and \"matching delimiters\"",
-                    "url": "./world.png",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.png \"and \"matching delimiters\"\")",
                     "loc": {
                         "start": {
                             "line": 63,
@@ -4726,10 +4313,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "and \"mismatched delimiters",
-                    "url": "./world.png",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.png \"and \"mismatched delimiters\")",
                     "loc": {
                         "start": {
                             "line": 65,
@@ -4768,7 +4353,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "and \\\"escapes\\\"",
+                    "title": "and \"escapes\"",
                     "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
@@ -4971,10 +4556,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "and 'matching delimiters'",
-                    "url": "./world.png",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.png 'and 'matching delimiters'')",
                     "loc": {
                         "start": {
                             "line": 77,
@@ -5012,10 +4595,8 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "Image",
-                    "title": "and 'mismatched delimiters",
-                    "url": "./world.png",
-                    "alt": "Hello",
+                    "type": "Str",
+                    "value": "![Hello](./world.png 'and 'mismatched delimiters')",
                     "loc": {
                         "start": {
                             "line": 79,
@@ -5054,7 +4635,7 @@
             "children": [
                 {
                     "type": "Image",
-                    "title": "and \\'escapes\\'",
+                    "title": "and 'escapes'",
                     "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
@@ -5216,9 +4797,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and text",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5227,33 +4808,14 @@
                         },
                         "end": {
                             "line": 89,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        2700,
-                        2708
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.png (and text))",
-                    "loc": {
-                        "start": {
-                            "line": 89,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 89,
                             "column": 32
                         }
                     },
                     "range": [
-                        2708,
+                        2700,
                         2732
                     ],
-                    "raw": "(./world.png (and text))"
+                    "raw": "![Hello](./world.png (and text))"
                 }
             ],
             "loc": {
@@ -5276,9 +4838,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and (matching delimiters",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5287,22 +4849,22 @@
                         },
                         "end": {
                             "line": 91,
-                            "column": 8
+                            "column": 48
                         }
                     },
                     "range": [
                         2734,
-                        2742
+                        2782
                     ],
-                    "raw": "![Hello]"
+                    "raw": "![Hello](./world.png (and (matching delimiters))"
                 },
                 {
                     "type": "Str",
-                    "value": "(./world.png (and (matching delimiters)))",
+                    "value": ")",
                     "loc": {
                         "start": {
                             "line": 91,
-                            "column": 8
+                            "column": 48
                         },
                         "end": {
                             "line": 91,
@@ -5310,10 +4872,10 @@
                         }
                     },
                     "range": [
-                        2742,
+                        2782,
                         2783
                     ],
-                    "raw": "(./world.png (and (matching delimiters)))"
+                    "raw": ")"
                 }
             ],
             "loc": {
@@ -5336,9 +4898,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and (mismatched delimiters",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5347,33 +4909,14 @@
                         },
                         "end": {
                             "line": 93,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        2785,
-                        2793
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.png (and (mismatched delimiters))",
-                    "loc": {
-                        "start": {
-                            "line": 93,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 93,
                             "column": 50
                         }
                     },
                     "range": [
-                        2793,
+                        2785,
                         2835
                     ],
-                    "raw": "(./world.png (and (mismatched delimiters))"
+                    "raw": "![Hello](./world.png (and (mismatched delimiters))"
                 }
             ],
             "loc": {
@@ -5396,9 +4939,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and (escapes)",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5407,109 +4950,14 @@
                         },
                         "end": {
                             "line": 95,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        2837,
-                        2845
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.png (and ",
-                    "loc": {
-                        "start": {
-                            "line": 95,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 95,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        2845,
-                        2863
-                    ],
-                    "raw": "(./world.png (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 95,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 95,
-                            "column": 28
-                        }
-                    },
-                    "range": [
-                        2863,
-                        2865
-                    ],
-                    "raw": "\\("
-                },
-                {
-                    "type": "Str",
-                    "value": "escapes",
-                    "loc": {
-                        "start": {
-                            "line": 95,
-                            "column": 28
-                        },
-                        "end": {
-                            "line": 95,
-                            "column": 35
-                        }
-                    },
-                    "range": [
-                        2865,
-                        2872
-                    ],
-                    "raw": "escapes"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 95,
-                            "column": 35
-                        },
-                        "end": {
-                            "line": 95,
-                            "column": 37
-                        }
-                    },
-                    "range": [
-                        2872,
-                        2874
-                    ],
-                    "raw": "\\)"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 95,
-                            "column": 37
-                        },
-                        "end": {
-                            "line": 95,
                             "column": 39
                         }
                     },
                     "range": [
-                        2874,
+                        2837,
                         2876
                     ],
-                    "raw": "))"
+                    "raw": "![Hello](./world.png (and \\(escapes\\)))"
                 }
             ],
             "loc": {
@@ -5532,9 +4980,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and (named entities)",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5543,109 +4991,14 @@
                         },
                         "end": {
                             "line": 97,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        2878,
-                        2886
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.png (and ",
-                    "loc": {
-                        "start": {
-                            "line": 97,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 97,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        2886,
-                        2904
-                    ],
-                    "raw": "(./world.png (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 97,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 97,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        2904,
-                        2910
-                    ],
-                    "raw": "&lpar;"
-                },
-                {
-                    "type": "Str",
-                    "value": "named entities",
-                    "loc": {
-                        "start": {
-                            "line": 97,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 97,
-                            "column": 46
-                        }
-                    },
-                    "range": [
-                        2910,
-                        2924
-                    ],
-                    "raw": "named entities"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 97,
-                            "column": 46
-                        },
-                        "end": {
-                            "line": 97,
-                            "column": 52
-                        }
-                    },
-                    "range": [
-                        2924,
-                        2930
-                    ],
-                    "raw": "&rpar;"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 97,
-                            "column": 52
-                        },
-                        "end": {
-                            "line": 97,
                             "column": 54
                         }
                     },
                     "range": [
-                        2930,
+                        2878,
                         2932
                     ],
-                    "raw": "))"
+                    "raw": "![Hello](./world.png (and &lpar;named entities&rpar;))"
                 }
             ],
             "loc": {
@@ -5668,9 +5021,9 @@
             "type": "Paragraph",
             "children": [
                 {
-                    "type": "ImageReference",
-                    "identifier": "hello",
-                    "referenceType": "shortcut",
+                    "type": "Image",
+                    "title": "and (numbered entities)",
+                    "url": "./world.png",
                     "alt": "Hello",
                     "loc": {
                         "start": {
@@ -5679,109 +5032,14 @@
                         },
                         "end": {
                             "line": 99,
-                            "column": 8
-                        }
-                    },
-                    "range": [
-                        2934,
-                        2942
-                    ],
-                    "raw": "![Hello]"
-                },
-                {
-                    "type": "Str",
-                    "value": "(./world.png (and ",
-                    "loc": {
-                        "start": {
-                            "line": 99,
-                            "column": 8
-                        },
-                        "end": {
-                            "line": 99,
-                            "column": 26
-                        }
-                    },
-                    "range": [
-                        2942,
-                        2960
-                    ],
-                    "raw": "(./world.png (and "
-                },
-                {
-                    "type": "Str",
-                    "value": "(",
-                    "loc": {
-                        "start": {
-                            "line": 99,
-                            "column": 26
-                        },
-                        "end": {
-                            "line": 99,
-                            "column": 32
-                        }
-                    },
-                    "range": [
-                        2960,
-                        2966
-                    ],
-                    "raw": "&#x28;"
-                },
-                {
-                    "type": "Str",
-                    "value": "numbered entities",
-                    "loc": {
-                        "start": {
-                            "line": 99,
-                            "column": 32
-                        },
-                        "end": {
-                            "line": 99,
-                            "column": 49
-                        }
-                    },
-                    "range": [
-                        2966,
-                        2983
-                    ],
-                    "raw": "numbered entities"
-                },
-                {
-                    "type": "Str",
-                    "value": ")",
-                    "loc": {
-                        "start": {
-                            "line": 99,
-                            "column": 49
-                        },
-                        "end": {
-                            "line": 99,
-                            "column": 55
-                        }
-                    },
-                    "range": [
-                        2983,
-                        2989
-                    ],
-                    "raw": "&#x29;"
-                },
-                {
-                    "type": "Str",
-                    "value": "))",
-                    "loc": {
-                        "start": {
-                            "line": 99,
-                            "column": 55
-                        },
-                        "end": {
-                            "line": 99,
                             "column": 57
                         }
                     },
                     "range": [
-                        2989,
+                        2934,
                         2991
                     ],
-                    "raw": "))"
+                    "raw": "![Hello](./world.png (and &#x28;numbered entities&#x29;))"
                 }
             ],
             "loc": {

--- a/packages/@textlint/markdown-to-ast/test/fixtures/toplevel-paragraphs.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/toplevel-paragraphs.text/output.json
@@ -6,7 +6,7 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "hello world\n    how are you\n    how are you",
+                    "value": "hello world\nhow are you\nhow are you",
                     "loc": {
                         "start": {
                             "line": 1,
@@ -82,6 +82,7 @@
         {
             "type": "CodeBlock",
             "lang": null,
+            "meta": null,
             "value": "how are you",
             "loc": {
                 "start": {
@@ -236,54 +237,15 @@
             "raw": "# how are you"
         },
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "Str",
-                    "value": "hello world",
-                    "loc": {
-                        "start": {
-                            "line": 16,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 16,
-                            "column": 11
-                        }
-                    },
-                    "range": [
-                        124,
-                        135
-                    ],
-                    "raw": "hello world"
-                }
-            ],
-            "loc": {
-                "start": {
-                    "line": 16,
-                    "column": 0
-                },
-                "end": {
-                    "line": 16,
-                    "column": 11
-                }
-            },
-            "range": [
-                124,
-                135
-            ],
-            "raw": "hello world"
-        },
-        {
             "type": "Header",
             "depth": 1,
             "children": [
                 {
                     "type": "Str",
-                    "value": "how are you",
+                    "value": "hello world\nhow are you",
                     "loc": {
                         "start": {
-                            "line": 17,
+                            "line": 16,
                             "column": 0
                         },
                         "end": {
@@ -292,15 +254,15 @@
                         }
                     },
                     "range": [
-                        136,
+                        124,
                         147
                     ],
-                    "raw": "how are you"
+                    "raw": "hello world\nhow are you"
                 }
             ],
             "loc": {
                 "start": {
-                    "line": 17,
+                    "line": 16,
                     "column": 0
                 },
                 "end": {
@@ -309,10 +271,10 @@
                 }
             },
             "range": [
-                136,
+                124,
                 159
             ],
-            "raw": "how are you\n==========="
+            "raw": "hello world\nhow are you\n==========="
         },
         {
             "type": "Paragraph",
@@ -455,11 +417,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -694,89 +656,27 @@
             "children": [
                 {
                     "type": "Str",
-                    "value": "hello ",
+                    "value": "hello [world][how]\n[how]: /are/you",
                     "loc": {
                         "start": {
                             "line": 32,
                             "column": 0
                         },
                         "end": {
-                            "line": 32,
-                            "column": 6
+                            "line": 33,
+                            "column": 15
                         }
                     },
                     "range": [
                         289,
-                        295
+                        323
                     ],
-                    "raw": "hello "
-                },
-                {
-                    "type": "LinkReference",
-                    "identifier": "how",
-                    "referenceType": "full",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "world",
-                            "loc": {
-                                "start": {
-                                    "line": 32,
-                                    "column": 7
-                                },
-                                "end": {
-                                    "line": 32,
-                                    "column": 12
-                                }
-                            },
-                            "range": [
-                                296,
-                                301
-                            ],
-                            "raw": "world"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 32,
-                            "column": 6
-                        },
-                        "end": {
-                            "line": 32,
-                            "column": 18
-                        }
-                    },
-                    "range": [
-                        295,
-                        307
-                    ],
-                    "raw": "[world][how]"
+                    "raw": "hello [world][how]\n[how]: /are/you"
                 }
             ],
             "loc": {
                 "start": {
                     "line": 32,
-                    "column": 0
-                },
-                "end": {
-                    "line": 32,
-                    "column": 18
-                }
-            },
-            "range": [
-                289,
-                307
-            ],
-            "raw": "hello [world][how]"
-        },
-        {
-            "type": "Definition",
-            "identifier": "how",
-            "title": null,
-            "url": "/are/you",
-            "loc": {
-                "start": {
-                    "line": 33,
                     "column": 0
                 },
                 "end": {
@@ -785,10 +685,10 @@
                 }
             },
             "range": [
-                308,
+                289,
                 323
             ],
-            "raw": "[how]: /are/you"
+            "raw": "hello [world][how]\n[how]: /are/you"
         },
         {
             "type": "Html",

--- a/packages/@textlint/markdown-to-ast/test/fixtures/tricky-list.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/tricky-list.text/output.json
@@ -122,11 +122,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -323,11 +323,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -524,11 +524,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {
@@ -725,11 +725,11 @@
             "type": "List",
             "ordered": false,
             "start": null,
-            "loose": false,
+            "spread": false,
             "children": [
                 {
                     "type": "ListItem",
-                    "loose": false,
+                    "spread": false,
                     "checked": null,
                     "children": [
                         {

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser-test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser-test.ts
@@ -228,9 +228,9 @@ describe("markdown-parser", function () {
         });
         it("should have marker_offser of each items", function () {
             const AST = parse("- item\n" + "   - item2"); // second line should has offset
-            const node = findFirstTypedNode(AST, Syntax.ListItem, " - item2");
+            const node = findFirstTypedNode(AST, Syntax.ListItem, "- item2");
             assert(node);
-            assert.strictEqual(node.raw, " - item2");
+            assert.strictEqual(node.raw, "- item2");
         });
         it("should has implemented TxtNode", function () {
             const text = "text",

--- a/packages/@textlint/markdown-to-ast/test/parsing-test.ts
+++ b/packages/@textlint/markdown-to-ast/test/parsing-test.ts
@@ -2,7 +2,7 @@
 import assert from "assert";
 import fs from "fs";
 import path from "path";
-import { isTxtAST } from "@textlint/ast-tester";
+import { test } from "@textlint/ast-tester";
 import { parse } from "../src/index";
 
 describe("parsing", function () {
@@ -12,7 +12,7 @@ describe("parsing", function () {
         it(`${dirName} match AST`, function () {
             const input = fs.readFileSync(path.join(fixtureDir, filePath, "input.md"), "utf-8");
             const AST = parse(input);
-            assert(isTxtAST(AST), "AST Should be valid AST");
+            test(AST);
             const output = JSON.parse(fs.readFileSync(path.join(fixtureDir, filePath, "output.json"), "utf-8"));
             assert.deepStrictEqual(AST, output);
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,6 +2102,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/mdast@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"
+  integrity sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==
+  dependencies:
+    "@types/unist" "*"
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -2152,7 +2159,7 @@
   resolved "https://registry.yarnpkg.com/@types/traverse/-/traverse-0.6.32.tgz#f9fdfa40cd4898deaa975a14511aec731de8235e"
   integrity sha512-RBz2uRZVCXuMg93WD//aTS5B120QlT4lR/gL+935QtGsKHLS6sCtZBaKfWjIfk7ZXv/r8mtGbwjVIee6/3XTow==
 
-"@types/unist@^2.0.0", "@types/unist@^2.0.2":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
@@ -3661,7 +3668,7 @@ cclog-parser@^1.1.1:
   resolved "https://registry.yarnpkg.com/cclog-parser/-/cclog-parser-1.1.1.tgz#44425a21a458f44985121c04912e5e02d1f04fab"
   integrity sha512-IsnWRC1zqs7h5+Xoocw7cYmlL5t2ysB0/SQB6C3Arr+S2pc2Rbhzp0hXaK36Ew+428in1085slsGtxsJwQB9RA==
 
-ccount@^1.0.3:
+ccount@^1.0.0, ccount@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
@@ -4042,11 +4049,6 @@ coffee-script@^1.12.4:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
   integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
-
-collapse-white-space@^1.0.2:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.6.tgz#e63629c0016665792060dbbeb79c42239d2c5287"
-  integrity sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==
 
 collection-map@^1.0.0:
   version "1.0.0"
@@ -4829,7 +4831,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
+debug@4.3.1, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -5741,7 +5743,7 @@ escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escape-string-regexp@4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -6208,7 +6210,7 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fault@^1.0.1:
+fault@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
   integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
@@ -7983,7 +7985,7 @@ is-boolean-object@^1.0.1, is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
-is-buffer@^1.1.0, is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.6:
+is-buffer@^1.1.0, is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -8426,20 +8428,10 @@ is-valid-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
   integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
 
-is-whitespace-character@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz#0858edd94a95594c7c9dd0b5c174ec6e45ee4aa7"
-  integrity sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==
-
 is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
-
-is-word-character@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.4.tgz#ce0e73216f98599060592f62ff31354ddbeb0230"
-  integrity sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==
 
 is-wsl@^2.1.1:
   version "2.2.0"
@@ -9148,6 +9140,11 @@ lolex@1.3.2:
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
   integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
 
+longest-streak@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
+  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
 longest@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -9296,15 +9293,17 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-escapes@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
-  integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
-
 markdown-link@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-link/-/markdown-link-0.1.1.tgz#32c5c65199a6457316322d1e4229d13407c8c7cf"
   integrity sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=
+
+markdown-table@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
+  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
+  dependencies:
+    repeat-string "^1.0.0"
 
 markdown-toc@^1.2.0:
   version "1.2.0"
@@ -9363,6 +9362,92 @@ md5@^2.3.0:
     charenc "0.0.2"
     crypt "0.0.2"
     is-buffer "~1.1.6"
+
+mdast-util-find-and-replace@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz#b7db1e873f96f66588c321f1363069abf607d1b5"
+  integrity sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
+
+mdast-util-from-markdown@^0.8.0:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
+mdast-util-frontmatter@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz#8bd5cd55e236c03e204a036f7372ebe9e6748240"
+  integrity sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==
+  dependencies:
+    micromark-extension-frontmatter "^0.2.0"
+
+mdast-util-gfm-autolink-literal@^0.1.0:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz#9c4ff399c5ddd2ece40bd3b13e5447d84e385fb7"
+  integrity sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==
+  dependencies:
+    ccount "^1.0.0"
+    mdast-util-find-and-replace "^1.1.0"
+    micromark "^2.11.3"
+
+mdast-util-gfm-strikethrough@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz#45eea337b7fff0755a291844fbea79996c322890"
+  integrity sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+
+mdast-util-gfm-table@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz#af05aeadc8e5ee004eeddfb324b2ad8c029b6ecf"
+  integrity sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==
+  dependencies:
+    markdown-table "^2.0.0"
+    mdast-util-to-markdown "~0.6.0"
+
+mdast-util-gfm-task-list-item@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz#70c885e6b9f543ddd7e6b41f9703ee55b084af10"
+  integrity sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==
+  dependencies:
+    mdast-util-to-markdown "~0.6.0"
+
+mdast-util-gfm@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz#8ecddafe57d266540f6881f5c57ff19725bd351c"
+  integrity sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==
+  dependencies:
+    mdast-util-gfm-autolink-literal "^0.1.0"
+    mdast-util-gfm-strikethrough "^0.2.0"
+    mdast-util-gfm-table "^0.1.0"
+    mdast-util-gfm-task-list-item "^0.1.0"
+    mdast-util-to-markdown "^0.6.1"
+
+mdast-util-to-markdown@^0.6.0, mdast-util-to-markdown@^0.6.1, mdast-util-to-markdown@~0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
+
+mdast-util-to-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
+  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -9488,6 +9573,66 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark-extension-frontmatter@^0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz#61b8e92e9213e1d3c13f5a59e7862f5ca98dfa53"
+  integrity sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==
+  dependencies:
+    fault "^1.0.0"
+
+micromark-extension-gfm-autolink-literal@~0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz#53866c1f0c7ef940ae7ca1f72c6faef8fed9f204"
+  integrity sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==
+  dependencies:
+    micromark "~2.11.3"
+
+micromark-extension-gfm-strikethrough@~0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz#96cb83356ff87bf31670eefb7ad7bba73e6514d1"
+  integrity sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm-table@~0.4.0:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz#4d49f1ce0ca84996c853880b9446698947f1802b"
+  integrity sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm-tagfilter@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz#d9f26a65adee984c9ccdd7e182220493562841ad"
+  integrity sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==
+
+micromark-extension-gfm-task-list-item@~0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz#d90c755f2533ed55a718129cee11257f136283b8"
+  integrity sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==
+  dependencies:
+    micromark "~2.11.0"
+
+micromark-extension-gfm@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz#36d1a4c089ca8bdfd978c9bd2bf1a0cb24e2acfe"
+  integrity sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==
+  dependencies:
+    micromark "~2.11.0"
+    micromark-extension-gfm-autolink-literal "~0.5.0"
+    micromark-extension-gfm-strikethrough "~0.6.5"
+    micromark-extension-gfm-table "~0.4.0"
+    micromark-extension-gfm-tagfilter "~0.3.0"
+    micromark-extension-gfm-task-list-item "~0.3.0"
+
+micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
+  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -10603,10 +10748,10 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-entities@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
-  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+parse-entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
+  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
   dependencies:
     character-entities "^1.0.0"
     character-entities-legacy "^1.0.0"
@@ -12029,34 +12174,28 @@ rehype-parse@^6.0.1:
     parse5 "^5.0.0"
     xtend "^4.0.0"
 
-remark-frontmatter@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz#67ec63c89da5a84bb793ecec166e11b4eb47af10"
-  integrity sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==
+remark-frontmatter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz#ca5d996361765c859bd944505f377d6b186a6ec6"
+  integrity sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==
   dependencies:
-    fault "^1.0.1"
-    xtend "^4.0.1"
+    mdast-util-frontmatter "^0.2.0"
+    micromark-extension-frontmatter "^0.2.0"
 
-remark-parse@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
-  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+remark-gfm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-1.0.0.tgz#9213643001be3f277da6256464d56fd28c3b3c0d"
+  integrity sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==
   dependencies:
-    collapse-white-space "^1.0.2"
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-whitespace-character "^1.0.0"
-    is-word-character "^1.0.0"
-    markdown-escapes "^1.0.0"
-    parse-entities "^1.1.0"
-    repeat-string "^1.5.4"
-    state-toggle "^1.0.0"
-    trim "0.0.1"
-    trim-trailing-lines "^1.0.0"
-    unherit "^1.0.4"
-    unist-util-remove-position "^1.0.0"
-    vfile-location "^2.0.0"
-    xtend "^4.0.1"
+    mdast-util-gfm "^0.1.0"
+    micromark-extension-gfm "^0.3.0"
+
+remark-parse@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
+  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
+  dependencies:
+    mdast-util-from-markdown "^0.8.0"
 
 remarkable@^1.7.1:
   version "1.7.4"
@@ -12106,7 +12245,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
   integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
 
-repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -12117,11 +12256,6 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
-
-replace-ext@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
-  integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
 
 replace-ext@^1.0.0:
   version "1.0.1"
@@ -12966,11 +13100,6 @@ stack-trace@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
-
-state-toggle@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
-  integrity sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -14006,11 +14135,6 @@ trim-repeated@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-trim-trailing-lines@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
-  integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
-
 trim@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
@@ -14280,18 +14404,6 @@ unified@^2.1.0:
     vfile "^1.0.0"
     ware "^1.3.0"
 
-unified@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
-  integrity sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-plain-obj "^1.1.0"
-    trough "^1.0.0"
-    vfile "^2.0.0"
-    x-is-string "^0.1.0"
-
 unified@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-8.4.2.tgz#13ad58b4a437faa2751a4a4c6a16f680c500fff1"
@@ -14299,6 +14411,18 @@ unified@^8.4.0:
   dependencies:
     bail "^1.0.0"
     extend "^3.0.0"
+    is-plain-obj "^2.0.0"
+    trough "^1.0.0"
+    vfile "^4.0.0"
+
+unified@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.1.tgz#ae18d5674c114021bfdbdf73865ca60f410215a3"
+  integrity sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-buffer "^2.0.0"
     is-plain-obj "^2.0.0"
     trough "^1.0.0"
     vfile "^4.0.0"
@@ -14367,13 +14491,6 @@ unist-util-map@^1.0.2:
   dependencies:
     object-assign "^4.0.1"
 
-unist-util-remove-position@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz#ec037348b6102c897703eee6d0294ca4755a2020"
-  integrity sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==
-  dependencies:
-    unist-util-visit "^1.1.0"
-
 unist-util-select@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/unist-util-select/-/unist-util-select-3.0.4.tgz#702c9dc1db1b2bbbfe27f796fce99e43f25edc60"
@@ -14384,11 +14501,6 @@ unist-util-select@^3.0.4:
     nth-check "^2.0.0"
     unist-util-is "^4.0.0"
     zwitch "^1.0.0"
-
-unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
-  integrity sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
@@ -14403,6 +14515,14 @@ unist-util-visit-parents@^2.0.0:
   integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
   dependencies:
     unist-util-is "^3.0.0"
+
+unist-util-visit-parents@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"
+  integrity sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^4.0.0"
 
 unist-util-visit@^1.1.0:
   version "1.4.1"
@@ -14628,18 +14748,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vfile-location@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.6.tgz#8a274f39411b8719ea5728802e10d9e0dff1519e"
-  integrity sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==
-
-vfile-message@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.1.1.tgz#5833ae078a1dfa2d96e9647886cd32993ab313e1"
-  integrity sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==
-  dependencies:
-    unist-util-stringify-position "^1.1.1"
-
 vfile-message@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
@@ -14652,16 +14760,6 @@ vfile@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-1.4.0.tgz#c0fd6fa484f8debdb771f68c31ed75d88da97fe7"
   integrity sha1-wP1vpIT43r23cfaMMe112I2pf+c=
-
-vfile@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
-  integrity sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==
-  dependencies:
-    is-buffer "^1.1.4"
-    replace-ext "1.0.0"
-    unist-util-stringify-position "^1.0.0"
-    vfile-message "^1.0.0"
 
 vfile@^4.0.0:
   version "4.2.1"
@@ -14961,11 +15059,6 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
-
-x-is-string@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
-  integrity sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=
 
 xml-escape@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9372,6 +9372,14 @@ mdast-util-find-and-replace@^1.1.0:
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
 
+mdast-util-footnote@^0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz#4b226caeab4613a3362c144c94af0fdd6f7e0ef0"
+  integrity sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+    micromark "~2.11.0"
+
 mdast-util-from-markdown@^0.8.0:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
@@ -9573,6 +9581,13 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
+
+micromark-extension-footnote@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz#129b74ef4920ce96719b2c06102ee7abb2b88a20"
+  integrity sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==
+  dependencies:
+    micromark "~2.11.0"
 
 micromark-extension-frontmatter@^0.2.0:
   version "0.2.2"
@@ -12173,6 +12188,14 @@ rehype-parse@^6.0.1:
     hast-util-from-parse5 "^5.0.0"
     parse5 "^5.0.0"
     xtend "^4.0.0"
+
+remark-footnotes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-3.0.0.tgz#5756b56f8464fa7ed80dbba0c966136305d8cb8d"
+  integrity sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==
+  dependencies:
+    mdast-util-footnote "^0.1.0"
+    micromark-extension-footnote "^0.3.0"
 
 remark-frontmatter@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
fix #717 

## Tasks

- [x] Review snapshot diffs
- [x] Change slicing text logics for BOM text https://github.com/textlint/textlint/pull/767/commits/09630c90685848648fd59fdd7e9936ff48190513
- [x] Add `FootnoteReference` node support via https://github.com/remarkjs/remark-footnotes 

## Features

### Add `FootnoteReference` node

```markdon
The NATO phonetic alphabet[^wiki].

[^wiki]: Read more about it on wikipedia: <http://en.wikipedia.org/wiki/NATO_phonetic_alphabet>.
```

Previously, It is called `LinkReference`, textlint@12 treat it as `FootnoteReference`.

## Known bugs

- [x] gfm parsing bug that generate broken AST: https://github.com/remarkjs/remark-gfm/issues/16
	- → use workaround:  https://github.com/remarkjs/remark-gfm/issues/16#issuecomment-846357030 at https://github.com/textlint/textlint/commit/c99218ea37518e8a42bb5d283276ccf696618748
	- → markdown-to-ast does not generate broken AST.