### PR TITLE
fix(textlint-tester): use `export default` instead of `export =`

### DIFF
--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -1,6 +1,6 @@
 # textlint-tester
 
-[Mocha](http://mochajs.org/ "Mocha") test helper library for [textlint](https://github.com/textlint/textlint "textlint") [rule](../../docs/rule.md).
+[Mocha](http://mochajs.org/ "Mocha") test helper library for [textlint](https://github.com/textlint/textlint "textlint") [rule](https://textlint.github.io/docs/rule.html).
 
 ## Installation
 

--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -9,6 +9,33 @@
 ## Usage
 
 1. Write tests by using `textlint-tester`
+   
+```js
+import TextLintTester from "textlint-tester";
+// a rule for testing
+import rule from "textlint-rule-no-todo";
+const tester = new TextLintTester();
+// ruleName, rule, { valid, invalid }
+tester.run("no-todo", rule, {
+    valid: [
+        "This is ok",
+    ],
+    invalid: [
+        // line, column
+        {
+            text: "- [ ] string",
+            errors: [
+                {
+                    message: "Found TODO: '- [ ] string'",
+                    line: 1,
+                    column: 3
+                }
+            ]
+        }
+    ]
+});
+```
+
 2. Run tests by [Mocha](http://mochajs.org/ "Mocha")
 
 ```sh
@@ -127,7 +154,7 @@ export declare type TesterValid = string | {
         - `{object[]} errors`: an array of error objects which should be raised against the text.
         - `{object} options`: options to be passed to the rule. Will throw assertion error if `testConfig` is specified
 
-TypeScript declaration is as follows:
+TypeScript's declaration is as follows:
 
 ```typescript
 export declare type TesterInvalid = {
@@ -171,10 +198,10 @@ export declare type TesterInvalid = {
 `test/example-test.js`:
 
 ```js
-const TextLintTester = require("textlint-tester");
+import TextLintTester from "textlint-tester";
+// a rule for testing
+import rule from "textlint-rule-no-todo";
 const tester = new TextLintTester();
-// rule
-const rule = require("textlint-rule-no-todo").default;
 // ruleName, rule, { valid, invalid }
 tester.run("no-todo", rule, {
     valid: [

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -32,7 +32,7 @@
     "build": "tsc -b",
     "clean": "rimraf lib/ out/",
     "prepublish": "npm run --if-present build",
-    "test": "mocha \"test/**/*.{js,ts}\"",
+    "test": "mocha \"test/**/*-test.{js,ts}\"",
     "watch": "tsc -b --watch"
   },
   "dependencies": {

--- a/packages/textlint-tester/src/index.ts
+++ b/packages/textlint-tester/src/index.ts
@@ -1,3 +1,3 @@
 import { TextLintTester } from "./textlint-tester";
 
-export = TextLintTester;
+export default TextLintTester;

--- a/packages/textlint-tester/test/async-test.ts
+++ b/packages/textlint-tester/test/async-test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import TextLintTester = require("../src/index");
+import TextLintTester from "../src/index";
 import type { TextlintRuleReporter } from "@textlint/types";
 
 const tester = new TextLintTester();

--- a/packages/textlint-tester/test/textlint-tester-fixer-test.ts
+++ b/packages/textlint-tester/test/textlint-tester-fixer-test.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
-const TextLintTester = require("../src/index");
-const path = require("path");
+import TextLintTester from "../src/index";
+import path from "path";
 const fixerRule = require("./fixtures/rule/fixer-rule-add");
 const tester = new TextLintTester();
 tester.run("fixer-rule-add", fixerRule, {

--- a/packages/textlint-tester/test/textlint-tester-invalid-test.ts
+++ b/packages/textlint-tester/test/textlint-tester-invalid-test.ts
@@ -1,11 +1,8 @@
 // LICENSE : MIT
 "use strict";
 import * as assert from "assert";
-
 import * as fs from "fs";
-
 import * as path from "path";
-
 import { TextLintCore } from "textlint";
 import { testInvalid } from "../src/test-util";
 

--- a/packages/textlint-tester/test/textlint-tester-invalid-testcofig-test.ts
+++ b/packages/textlint-tester/test/textlint-tester-invalid-testcofig-test.ts
@@ -1,11 +1,10 @@
-// LICENSE : MIT
-"use strict";
-
 import * as assert from "assert";
-
-const htmlPlugin = require("textlint-plugin-html");
-const noTodoRule = require("textlint-rule-no-todo").default;
-const maxNumberOfLineRule = require("textlint-rule-max-number-of-lines");
+// @ts-expect-error: no types
+import htmlPlugin from "textlint-plugin-html";
+// @ts-expect-error: no types
+import noTodoRule from "textlint-rule-no-todo";
+// @ts-expect-error: no types
+import maxNumberOfLineRule from "textlint-rule-max-number-of-lines";
 import { TextLintTester } from "../src/textlint-tester";
 
 const tester = new TextLintTester();

--- a/packages/textlint-tester/test/textlint-tester-plugin.ts
+++ b/packages/textlint-tester/test/textlint-tester-plugin.ts
@@ -1,11 +1,10 @@
-// LICENSE : MIT
-"use strict";
-
-import TextLintTester = require("../src/index");
-
-const htmlPlugin = require("textlint-plugin-html");
-const noTodoRule = require("textlint-rule-no-todo").default;
-const maxNumberOfLineRule = require("textlint-rule-max-number-of-lines");
+import TextLintTester from "../src/index";
+// @ts-expect-error: no types
+import htmlPlugin from "textlint-plugin-html";
+// @ts-expect-error: no types
+import noTodoRule from "textlint-rule-no-todo";
+// @ts-expect-error: no types
+import maxNumberOfLineRule from "textlint-rule-max-number-of-lines";
 const tester = new TextLintTester();
 
 tester.run(

--- a/packages/textlint-tester/test/textlint-tester-test.ts
+++ b/packages/textlint-tester/test/textlint-tester-test.ts
@@ -1,11 +1,10 @@
-// LICENSE : MIT
-"use strict";
 import * as path from "path";
+import TextLintTester from "../src/index";
+// @ts-expect-error: no types
+import noTodo from "textlint-rule-no-todo";
+// @ts-expect-error: no types
+import maxNumberOfLine from "textlint-rule-max-number-of-lines";
 
-import TextLintTester = require("../src/index");
-
-const noTodo = require("textlint-rule-no-todo").default;
-const maxNumberOfLine = require("textlint-rule-max-number-of-lines");
 const tester = new TextLintTester();
 tester.run("no-todo", noTodo, {
     valid: [

--- a/packages/textlint-tester/test/tsconfig.json
+++ b/packages/textlint-tester/test/tsconfig.json
@@ -5,6 +5,7 @@
     "composite": false
   },
   "include": [
-    "src/**/*"
-  ]
+    "../src/**/*",
+    "**/*"
+  ],
 }


### PR DESCRIPTION
- use `export default` instead of `export =`

The `textlint-tester` user should use `import` instead of ` require`.

```diff
- const TextLintTester = require("textlint-tester");
+ import TextLintTester from "textlint-tester";
```

of pick `default` property.

```diff
- const TextLintTester = require("textlint-tester");
+ const TextLintTester = require("textlint-tester").default;
```

fix #689 