### PR TITLE
chore: export more symbols to public API

### DIFF
--- a/packages/@textlint/kernel/src/index.ts
+++ b/packages/@textlint/kernel/src/index.ts
@@ -3,7 +3,12 @@ export { TextlintKernel } from "./textlint-kernel";
 // Kernel Descriptor
 export * from "./descriptor/index";
 // Kernel rule/filter/plugin format
-export { TextlintKernelRule, TextlintKernelFilterRule, TextlintKernelPlugin } from "./textlint-kernel-interface";
+export {
+    TextlintKernelRule,
+    TextlintKernelFilterRule,
+    TextlintKernelPlugin,
+    TextlintKernelOptions
+} from "./textlint-kernel-interface";
 
 /**
  * Types of textlint lint/fix result

--- a/packages/textlint/src/index.ts
+++ b/packages/textlint/src/index.ts
@@ -26,3 +26,6 @@ export { TextFixEngine } from "./textfix-engine";
 
 // Core API for linting a **single** text or file.
 export { TextLintCore } from "./textlint-core";
+
+// Config API for loading textlint config
+export { Config } from "./config/config";


### PR DESCRIPTION
In `@markuplint/textlint`, we're using some symbols but not exported from `textlint` and `@textlint/kernel`'s entry.

https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rule-textlint/src/helper.ts#L2

https://github.com/markuplint/markuplint/blob/main/packages/%40markuplint/rule-textlint/src/verify.ts#L2

---

Besides, maybe `export *` can be used.