### PR TITLE
chore: remove the husky config and update the related docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -141,7 +141,7 @@ We are migrating entire codes to TypeScript.
 
 ##### Linting and Style
 
-This repository uses [ESLint](https://eslint.org/) for JavaScript linter and [Prettier](https://prettier.io/) for code formatter. We use [`lint-staged`](https://www.npmjs.com/package/lint-staged) and [`husky`](https://www.npmjs.com/package/husky) to make coding style consistent before commit, but if you have your own [Git hooks](https://git-scm.com/book/gr/v2/Customizing-Git-Git-Hooks) locally, these setup doesn't work. In such case, please run ESLint and Prettier manually as below after making changes.
+This repository uses [ESLint](https://eslint.org/) for JavaScript linter and [Prettier](https://prettier.io/) for code formatter. We use [`lint-staged`](https://www.npmjs.com/package/lint-staged) and [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to make coding style consistent before commit, but if you have your own Git hooks locally, these setup doesn't work. In such case, please run ESLint and Prettier manually as below after making changes.
 
 - Run ESLint:
 
@@ -158,7 +158,7 @@ This repository uses [ESLint](https://eslint.org/) for JavaScript linter and [Pr
 - Run Prettier to reformat code:
 
     ```sh
-    $ yarn prettier
+    $ yarn format
     ```
 
 ##### Commit Message Format

--- a/package.json
+++ b/package.json
@@ -63,11 +63,5 @@
     "packages/@textlint/*",
     "test/integration-test",
     "website"
-  ],
-  "husky": {
-    "hooks": {
-      "post-commit": "git reset",
-      "pre-commit": "lint-staged"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
`husky` was removed from this project in this commit: [Drop to support Node.js 10.x by azu · Pull Request #773 · textlint/textlint](https://github.com/textlint/textlint/pull/773/commits/f25da7e91ff30f473287c9c4d69946f4750bc966#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43) so I believe we don't need husky related config anymore.

I found a husky-related description in `docs/CONTIRIBUTING.md` and updated it. Also, `npm run prettier` was replaced with `npm run format` by the same commit. I updated that command too.