### PR TITLE
Plugin can return Promise when calling preProcess

### DIFF
--- a/packages/@textlint/kernel/src/fixer/fixer-processor.ts
+++ b/packages/@textlint/kernel/src/fixer/fixer-processor.ts
@@ -66,9 +66,9 @@ export default class FixerProcessor {
         // pre-applyingMessages + remainingMessages
         const originalMessages: TextlintMessage[] = [];
         const fixerProcessList = ruleDescriptors.fixableDescriptors.map((ruleDescriptor) => {
-            return (sourceText: string): Promise<string> => {
+            return async (sourceText: string): Promise<string> => {
                 // create new SourceCode object
-                const preProcessResult = preProcess(sourceText, sourceCode.filePath);
+                const preProcessResult = await Promise.resolve(preProcess(sourceText, sourceCode.filePath));
                 const isParsedObject = isPluginParsedObject(preProcessResult);
                 const textForAST = isParsedObject ? preProcessResult.text : sourceText;
                 const ast = isParsedObject ? preProcessResult.ast : preProcessResult;
@@ -87,7 +87,7 @@ export default class FixerProcessor {
                     configBaseDir
                 });
 
-                return TaskRunner.process(task).then((messages) => {
+                return await TaskRunner.process(task).then((messages) => {
                     const result = postProcess(messages, sourceCode.filePath);
                     const filteredResult = {
                         messages: this.messageProcessManager.process(result.messages),

--- a/packages/@textlint/kernel/src/fixer/fixer-processor.ts
+++ b/packages/@textlint/kernel/src/fixer/fixer-processor.ts
@@ -87,8 +87,8 @@ export default class FixerProcessor {
                     configBaseDir
                 });
 
-                return await TaskRunner.process(task).then((messages) => {
-                    const result = postProcess(messages, sourceCode.filePath);
+                return await TaskRunner.process(task).then(async (messages) => {
+                    const result = await Promise.resolve(postProcess(messages, sourceCode.filePath));
                     const filteredResult = {
                         messages: this.messageProcessManager.process(result.messages),
                         filePath: result.filePath ? result.filePath : `<Unkown${sourceCode.ext}>`

--- a/packages/@textlint/kernel/src/linter/linter-processor.ts
+++ b/packages/@textlint/kernel/src/linter/linter-processor.ts
@@ -52,8 +52,8 @@ export default class LinterProcessor {
             sourceCode,
             configBaseDir
         });
-        return TaskRunner.process(task).then((messages) => {
-            const result = postProcess(messages, sourceCode.filePath);
+        return TaskRunner.process(task).then(async (messages) => {
+            const result = await Promise.resolve(postProcess(messages, sourceCode.filePath));
             result.messages = this.messageProcessManager.process(result.messages);
             if (result.filePath == null) {
                 result.filePath = `<Unkown${sourceCode.ext}>`;

--- a/packages/@textlint/kernel/src/textlint-kernel.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel.ts
@@ -120,7 +120,7 @@ export class TextlintKernel {
      * @returns {Promise.<TextlintResult>}
      * @private
      */
-    private _parallelProcess({
+    private async _parallelProcess({
         descriptor,
         text,
         options
@@ -142,7 +142,7 @@ export class TextlintKernel {
             typeof preProcess === "function" && typeof postProcess === "function",
             `${plugin.id} processor should implements {preProcess, postProcess}`
         );
-        const preProcessResult = preProcess(text, filePath);
+        const preProcessResult = await Promise.resolve(preProcess(text, filePath));
         // { text, ast } or ast
         const isParsedObject = isPluginParsedObject(preProcessResult);
         const textForAST = isParsedObject ? preProcessResult.text : text;
@@ -166,7 +166,7 @@ See https://textlint.github.io/docs/plugin.html`
             filePath
         });
         const linterProcessor = new LinterProcessor(processor, this.messageProcessManager);
-        return linterProcessor
+        return await linterProcessor
             .process({
                 config: this.config,
                 ruleDescriptors: descriptor.rule,
@@ -189,7 +189,7 @@ See https://textlint.github.io/docs/plugin.html`
      * @returns {Promise.<TextlintFixResult>}
      * @private
      */
-    private _sequenceProcess({
+    private async _sequenceProcess({
         descriptor,
         text,
         options
@@ -211,7 +211,7 @@ See https://textlint.github.io/docs/plugin.html`
             typeof preProcess === "function" && typeof postProcess === "function",
             `${plugin.id} processor should implements {preProcess, postProcess}`
         );
-        const preProcessResult = preProcess(text, filePath);
+        const preProcessResult = await Promise.resolve(preProcess(text, filePath));
         // { text, ast } or ast
         const isParsedObject = isPluginParsedObject(preProcessResult);
         const textForAST = isParsedObject ? preProcessResult.text : text;
@@ -235,7 +235,7 @@ See https://textlint.github.io/docs/plugin.html`
             filePath
         });
         const fixerProcessor = new FixerProcessor(processor, this.messageProcessManager);
-        return fixerProcessor
+        return await fixerProcessor
             .process({
                 config: this.config,
                 ruleDescriptors: descriptor.rule,

--- a/packages/@textlint/kernel/test/helper/AsyncPlugin.ts
+++ b/packages/@textlint/kernel/test/helper/AsyncPlugin.ts
@@ -62,7 +62,7 @@ export const createAsyncPluginStub = (options?: CreateAsyncPluginOptions) => {
                                 preProcessArgs = { text, filePath };
                                 return parse(text);
                             },
-                            postProcess(messages: TextlintMessage[], filePath: string) {
+                            async postProcess(messages: TextlintMessage[], filePath: string) {
                                 postProcessArgs = { messages, filePath };
                                 return {
                                     messages,

--- a/packages/@textlint/kernel/test/helper/AsyncPlugin.ts
+++ b/packages/@textlint/kernel/test/helper/AsyncPlugin.ts
@@ -1,0 +1,78 @@
+import { TextlintMessage } from "@textlint/kernel";
+import type { TextlintPluginCreator, TextlintPluginProcessor } from "@textlint/types";
+import { parse } from "@textlint/markdown-to-ast";
+
+export interface AsyncProcessorOptions {
+    testOption: string;
+}
+
+export interface CreateAsyncPluginOptions {
+    extensions?: string[];
+}
+
+/**
+ * Create Async Plugin stub
+ * It spy the assigned argument.
+ * It is compatible with markdown plugin by default.
+ */
+export const createAsyncPluginStub = (options?: CreateAsyncPluginOptions) => {
+    let assignedOptions: undefined | {};
+    let processorArgs: {
+        extension: string;
+    };
+    let preProcessArgs: {
+        text: string;
+        filePath: string;
+    };
+    let postProcessArgs: {
+        messages: TextlintMessage[];
+        filePath?: string;
+    };
+    return {
+        getOptions() {
+            return assignedOptions;
+        },
+        getProcessorArgs() {
+            return processorArgs;
+        },
+        getPreProcessArgs() {
+            return preProcessArgs;
+        },
+        getPostProcessArgs() {
+            return postProcessArgs;
+        },
+        /**
+         * Return plugin module
+         */
+        get plugin(): TextlintPluginCreator {
+            return {
+                Processor: class MockExampleProcessor implements TextlintPluginProcessor {
+                    availableExtensions() {
+                        return (options && options.extensions) || [".md"];
+                    }
+
+                    constructor(public options?: {}) {
+                        assignedOptions = options;
+                    }
+
+                    processor(extension: string) {
+                        processorArgs = { extension };
+                        return {
+                            async preProcess(text: string, filePath: string) {
+                                preProcessArgs = { text, filePath };
+                                return parse(text);
+                            },
+                            postProcess(messages: TextlintMessage[], filePath: string) {
+                                postProcessArgs = { messages, filePath };
+                                return {
+                                    messages,
+                                    filePath: filePath || "unknown"
+                                };
+                            }
+                        };
+                    }
+                }
+            };
+        }
+    };
+};

--- a/packages/@textlint/kernel/test/kernel-plugin-test.ts
+++ b/packages/@textlint/kernel/test/kernel-plugin-test.ts
@@ -4,6 +4,7 @@ import { TextlintKernel, TextlintPluginCreator } from "../src";
 import * as path from "path";
 import * as assert from "assert";
 import { createBinaryPluginStub } from "./helper/BinaryPlugin";
+import { createAsyncPluginStub } from "./helper/AsyncPlugin";
 import type { TextlintRuleReporter } from "@textlint/types";
 import { TextlintKernelOptions } from "../src/textlint-kernel-interface";
 import { TxtNode } from "@textlint/ast-node-types";
@@ -157,6 +158,22 @@ describe("kernel-plugin", () => {
             const text = "text";
             return kernel.fixText(text, options).then((_result) => {
                 assert.strictEqual(getPreProcessArgs().text, dummyText);
+                assert.strictEqual(getPreProcessArgs().filePath, options.filePath);
+            });
+        });
+        it("preProcess can return Promise<{text, ast}>", () => {
+            const kernel = new TextlintKernel();
+            const { plugin, getPreProcessArgs } = createAsyncPluginStub();
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [{ pluginId: "example", plugin: plugin }],
+                rules: [{ ruleId: "error", rule: errorRule }]
+            };
+            const text = "text";
+            return kernel.lintText(text, options).then((_result) => {
+                console.log(_result);
+                assert.strictEqual(getPreProcessArgs().text, text);
                 assert.strictEqual(getPreProcessArgs().filePath, options.filePath);
             });
         });

--- a/packages/@textlint/kernel/test/kernel-plugin-test.ts
+++ b/packages/@textlint/kernel/test/kernel-plugin-test.ts
@@ -172,7 +172,21 @@ describe("kernel-plugin", () => {
             };
             const text = "text";
             return kernel.lintText(text, options).then((_result) => {
-                console.log(_result);
+                assert.strictEqual(getPreProcessArgs().text, text);
+                assert.strictEqual(getPreProcessArgs().filePath, options.filePath);
+            });
+        });
+        it("preProcess can return Promise<{text, ast}> --fix", () => {
+            const kernel = new TextlintKernel();
+            const { plugin, getPreProcessArgs } = createAsyncPluginStub();
+            const options = {
+                filePath: "/path/to/file.md",
+                ext: ".md",
+                plugins: [{ pluginId: "example", plugin: plugin }],
+                rules: [{ ruleId: "error", rule: errorRule }]
+            };
+            const text = "text";
+            return kernel.fixText(text, options).then((_result) => {
                 assert.strictEqual(getPreProcessArgs().text, text);
                 assert.strictEqual(getPreProcessArgs().filePath, options.filePath);
             });
@@ -228,7 +242,7 @@ describe("kernel-plugin", () => {
         });
     });
     describe("#postProcess", () => {
-        it("preProcess should be called with messages and filePath", () => {
+        it("postProcess should be called with messages and filePath", () => {
             const kernel = new TextlintKernel();
             const { plugin, getPostProcessArgs } = createPluginStub();
             const options = {

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -40,7 +40,10 @@ export declare class TextlintPluginProcessor {
          * @param text
          * @param filePath
          */
-        preProcess(text: string, filePath?: string): TxtNode | { text: string; ast: TxtNode };
+        preProcess(
+            text: string,
+            filePath?: string
+        ): TxtNode | { text: string; ast: TxtNode } | Promise<TxtNode> | Promise<{ text: string; ast: TxtNode }>;
         postProcess(messages: Array<any>, filePath?: string): { messages: Array<any>; filePath: string };
     };
 }

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -10,6 +10,7 @@ export declare type TextlintPluginOptions = {
 };
 
 export type TextlintPluginPreProcessResult = TxtNode | { text: string; ast: TxtNode };
+export type TextlintPluginPostProcessResult = { messages: Array<any>; filePath: string };
 
 export interface TextlintPluginProcessorConstructor extends Function {
     new (options?: TextlintPluginOptions): TextlintPluginProcessor;
@@ -46,7 +47,10 @@ export declare class TextlintPluginProcessor {
             text: string,
             filePath?: string
         ): TextlintPluginPreProcessResult | Promise<TextlintPluginPreProcessResult>;
-        postProcess(messages: Array<any>, filePath?: string): { messages: Array<any>; filePath: string };
+        postProcess(
+            messages: Array<any>,
+            filePath?: string
+        ): TextlintPluginPostProcessResult | Promise<TextlintPluginPostProcessResult>;
     };
 }
 

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -9,6 +9,8 @@ export declare type TextlintPluginOptions = {
     [index: string]: any;
 };
 
+export type TextlintPluginPreProcessResult = TxtNode | { text: string; ast: TxtNode };
+
 export interface TextlintPluginProcessorConstructor extends Function {
     new (options?: TextlintPluginOptions): TextlintPluginProcessor;
 
@@ -43,7 +45,7 @@ export declare class TextlintPluginProcessor {
         preProcess(
             text: string,
             filePath?: string
-        ): TxtNode | { text: string; ast: TxtNode } | Promise<TxtNode> | Promise<{ text: string; ast: TxtNode }>;
+        ): TextlintPluginPreProcessResult | Promise<TextlintPluginPreProcessResult>;
         postProcess(messages: Array<any>, filePath?: string): { messages: Array<any>; filePath: string };
     };
 }


### PR DESCRIPTION
## What's changed

- Promise type added to type definition of `preProcess`.
- The method from which preProcess is called is now an `async` function. Fortunately, it was originally a function that returned a Promise, so the change is minimal.

## Why make this change?

In [textlint-plugin-ruby](https://github.com/alpaca-tc/textlint-plugin-ruby), which I'm developing now, it communicates with the backend ruby process to parse the Ruby source code.
However, since node IO is mainly asynchronous, it is difficult to implement unless preProcess supports the Promise type 😭 

---

By the way, thanks for the replies on [twitter](https://twitter.com/azu_re/status/1465771946675945472?s=20)! 💛 