### PR TITLE
docs: replace `./node_modules/.bin/` with `npx`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ You can run `textlint` on any Markdown files:
 ```
 
 ```
-./node_modules/.bin/textlint --rule no-todo file.md
+npx textlint --rule no-todo file.md
 ```
 
 ![screenshot lint error](assets/screenshot-lint-error.png)
@@ -72,7 +72,7 @@ We recommend using `textlint` with `.textlintrc` configuration file.
 Create a `.textlintrc` file in your workspace:
 
 ```
-./node_modules/.bin/textlint --init
+npx textlint --init
 ```
 
 In this file, you'll see some rules configured like this:
@@ -89,7 +89,7 @@ In this file, you'll see some rules configured like this:
 If there is a `.textlintrc` file in your workspace, `textlint` loads `.textlintrc` automatically. So you can run textlint without any command line options:
 
 ```
-./node_modules/.bin/textlint file.md
+npx textlint file.md
 ```
 
 ## Next Steps

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -175,13 +175,13 @@ const GetStartedSection = (props) => {
                             <li>
                                 Create .textlintrc file:
                                 <div className="getStartedStep">
-                                    <MarkdownBlock>{bash`./node_modules/.bin/textlint --init`}</MarkdownBlock>
+                                    <MarkdownBlock>{bash`npx textlint --init`}</MarkdownBlock>
                                 </div>
                             </li>
                             <li>
                                 Run textlint:
                                 <div className="getStartedStep">
-                                    <MarkdownBlock>{bash`./node_modules/.bin/textlint README.md`}</MarkdownBlock>
+                                    <MarkdownBlock>{bash`npx textlint README.md`}</MarkdownBlock>
                                 </div>
                             </li>
                         </ol>
@@ -223,7 +223,7 @@ added 239 packages in 10.23s`}
                             <li>
                                 <img
                                     src={imgUrl("get-started-steps/4.png")}
-                                    alt={`$ ./node_modules/.bin/textlint --init
+                                    alt={`$ npx textlint --init
 
 Create .textlintrc`}
                                 />
@@ -231,7 +231,7 @@ Create .textlintrc`}
                             <li>
                                 <img
                                     src={imgUrl("get-started-steps/5.png")}
-                                    alt={`$./node_modules/.bin/textlint README.md
+                                    alt={`$npx textlint README.md
 
 ~/textlint-demo/README.md
   1:3  error  Found TODO: '- [ ] Write usage'  no-todo


### PR DESCRIPTION
At the risk of nitpicking, I prefer `npx` introduced in npm 5.2 (released in July 2017) over `./node_modules/.bin/` here.