### PR TITLE
fix(markdown-to-ast): add `mdast-util-gfm-autolink-literal` to explicit deps

### DIFF
--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -41,6 +41,7 @@
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",
+    "mdast-util-gfm-autolink-literal": "^0.1.0",
     "traverse": "^0.6.6",
     "unified": "^9.2.2"
   },


### PR DESCRIPTION
pnpm or yarn 2+ require explicit `dependencies`.

fix #903 