### PR TITLE
chore(linter-formatter): added lodash to dependencies

### DIFF
--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -40,14 +40,14 @@
     "debug": "^4.3.4",
     "is-file": "^1.0.0",
     "js-yaml": "^3.14.1",
+    "lodash": "^4.17.21",
     "optionator": "^0.9.1",
     "pluralize": "^2.0.0",
     "string-width": "^4.2.3",
     "strip-ansi": "^6.0.1",
     "table": "^6.8.1",
     "text-table": "^0.2.0",
-    "try-resolve": "^1.0.1",
-    "xml-escape": "^1.1.0"
+    "try-resolve": "^1.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16895,11 +16895,6 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-xml-escape@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/xml-escape/-/xml-escape-1.1.0.tgz#3904c143fa8eb3a0030ec646d2902a2f1b706c44"
-  integrity sha1-OQTBQ/qOs6ADDsZG0pAqLxtwbEQ=
-
 xml-js@^1.6.11:
   version "1.6.11"
   resolved "https://registry.yarnpkg.com/xml-js/-/xml-js-1.6.11.tgz#927d2f6947f7f1c19a316dd8eea3614e8b18f8e9"


### PR DESCRIPTION
... and removed xml-escape which is not used.

fixes https://github.com/textlint/textlint/issues/933.