### PR TITLE
chore(ast-node-types): add `children` to `TxtNode`

### DIFF
--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -84,10 +84,11 @@ export interface TxtNode {
     raw: string;
     range: TextNodeRange;
     loc: TxtNodeLineLocation;
-    // parent is runtime information
+    // parent and children is runtime information
     // Not need in AST
     // For example, top Root Node like `Document` has not parent.
     parent?: TxtNode;
+    children?: TxtNode;
 
     [index: string]: any;
 }


### PR DESCRIPTION
Thanks for great tool, this PR doesn't relate any issues.

Is there any reason `TxtNode` does not have `children` property?
https://github.com/textlint/textlint/blob/312b2d579ed3bebd786f9674605395458403e55e/packages/%40textlint/ast-node-types/src/index.ts#L82
I'd like to use `text-to-ast` to parse text to AST, and access the node `children` but currently, I guess accessing the node `children` isn't type safe. (`TxtNode["children"]` returns `any`).
