### PR TITLE
support linting dot files

### DIFF
--- a/packages/textlint/src/textlint-core.ts
+++ b/packages/textlint/src/textlint-core.ts
@@ -177,7 +177,7 @@ export class TextLintCore {
      */
     lintFile(filePath: string): Promise<TextlintResult> {
         const absoluteFilePath = path.resolve(process.cwd(), filePath);
-        const ext = path.extname(absoluteFilePath);
+        const ext = path.extname(absoluteFilePath) || path.basename(absoluteFilePath);
         const options = this._mergeSetupOptions({
             ext,
             filePath: absoluteFilePath
@@ -194,7 +194,7 @@ export class TextLintCore {
      */
     fixFile(filePath: string): Promise<TextlintFixResult> {
         const absoluteFilePath = path.resolve(process.cwd(), filePath);
-        const ext = path.extname(absoluteFilePath);
+        const ext = path.extname(absoluteFilePath) || path.basename(absoluteFilePath);
         const options = this._mergeSetupOptions({
             ext,
             filePath: absoluteFilePath

--- a/packages/textlint/src/util/find-util.ts
+++ b/packages/textlint/src/util/find-util.ts
@@ -103,7 +103,7 @@ export function separateByAvailability(
     const availableFiles: string[] = [];
     const unAvailableFiles: string[] = [];
     files.forEach((filePath) => {
-        const extname = path.extname(filePath);
+        const extname = path.extname(filePath) || path.basename(filePath);
         if (extensions.indexOf(extname) === -1) {
             unAvailableFiles.push(filePath);
         } else {

--- a/packages/textlint/test/textlint-core/textlint-core-test.ts
+++ b/packages/textlint/test/textlint-core/textlint-core-test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import { TextLintCore } from "../../src";
 import exampleRule from "./fixtures/rules/example-rule";
+import { createPluginStub } from "../pluguins/fixtures/example-plugin";
 
 describe("textlint-core", function () {
     // Test: https://github.com/textlint/textlint/issues/30
@@ -41,6 +42,26 @@ describe("textlint-core", function () {
         });
         it("should not throw an exception @ file", function () {
             return textlint.lintFile(__dirname + "/fixtures/empty.md").then((result) => {
+                assert.ok(result.messages.length === 0);
+            });
+        });
+    });
+    context("when a linting a dot file", function () {
+        const file = __dirname + "/fixtures/.example";
+        let textlint: TextLintCore;
+        beforeEach(function () {
+            textlint = new TextLintCore();
+            textlint.setupRules({ "example-rule": exampleRule });
+            const { plugin } = createPluginStub();
+            textlint.setupPlugins({ example: plugin });
+        });
+        it.only("should not throw an exception @ file", function () {
+            return textlint.lintFile(file).then((result) => {
+                assert.ok(result.messages.length === 0);
+            });
+        });
+        it("should not throw an exception @ fix", function () {
+            return textlint.fixFile(file).then((result) => {
                 assert.ok(result.messages.length === 0);
             });
         });

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import path from "path";
-import { findFiles } from "../../src/util/find-util";
+import { findFiles, separateByAvailability } from "../../src/util/find-util";
 
 describe("find-util", () => {
     describe("findFiles", () => {
@@ -16,6 +16,16 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with absolute path pattern", () => {
+            const patterns = [path.resolve(cwd, "dir/**/*.md")];
+            const files = findFiles(patterns, { cwd });
+            files.sort();
+            assert.deepStrictEqual(files, [
+                path.resolve(cwd, "dir/ignored.md"),
+                path.resolve(cwd, "dir/subdir/test.md"),
+                path.resolve(cwd, "dir/test.md")
+            ]);
+        });
+        it("should find dot files", () => {
             const patterns = [path.resolve(cwd, "dir/**/*.md")];
             const files = findFiles(patterns, { cwd });
             files.sort();
@@ -62,6 +72,20 @@ describe("find-util", () => {
                     path.resolve(cwd, "dir/test.md")
                 ]);
             });
+        });
+    });
+
+    describe("separateByAvailability", () => {
+        it("should find dot files", () => {
+            const files = [".foo"];
+            const {
+                availableFiles,
+                unAvailableFiles
+            } = separateByAvailability(files, { extensions: [".foo"] });
+            assert.deepStrictEqual(availableFiles, [
+                ".foo"
+            ]);
+            assert.deepStrictEqual(unAvailableFiles, []);
         });
     });
 });


### PR DESCRIPTION
`path.extname('.lint-todo') === ''`, so we have to be a little smarter than node to capture these files.

With this change, I can now use https://github.com/kellyselden/textlint-rule-eol-last to lint `.lint-todo` files with

```
{
  plugins: {
    '@textlint/text': {
      extensions: ['.lint-todo'],
    },
  },
  rules: {
    'eol-last': true,
  },
};
```