### PR TITLE
feat(textlint): add --print-config flag for New CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,45 +89,48 @@ Run `npx textlint -h` for information on how to use the CLI.
 
 ```
 $ textlint [options] file.md [file|dir|glob*]
-  Options:
-    -h, --help                  Show help.
-    -c, --config path::String   Use configuration from this file or sharable config.
-    --ignore-path path::String  Specify path to a file containing patterns that describes files to ignore. - default: .textlintignore
-    --init                      Create the config file if not existed. - default: false
-    --fix                       Automatically fix problems
-    --dry-run                   Enable dry-run mode for --fix. Only show result, don't change the file.
-    --debug                     Outputs debugging information
-    -v, --version               Outputs the version number.
 
-  Using stdin:
-    --stdin                     Lint text provided on <STDIN>. - default: false
-    --stdin-filename String     Specify filename to process STDIN as
+Options:
+  -h, --help                  Show help.
+  -c, --config path::String   Use configuration from this file or sharable config.
+  --ignore-path path::String  Specify path to a file containing patterns that describes files to ignore. - default: .textlintignore
+  --init                      Create the config file if not existed. - default: false
+  --fix                       Automatically fix problems
+  --dry-run                   Enable dry-run mode for --fix. Only show result, don't change the file.
+  --debug                     Outputs debugging information
+  --print-config              Print the config object to stdout
+  -v, --version               Outputs the version number.
 
-  Output:
-    -o, --output-file path::String  Enable report to be written to a file.
-    -f, --format String         Use a specific output format.
-                                Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
-                                Available formatter for --fix: compats, diff, json, stylish
-    --no-color                  Disable color in piped output.
-    --quiet                     Report errors only. - default: false
+Using stdin:
+  --stdin                     Lint text provided on <STDIN>. - default: false
+  --stdin-filename String     Specify filename to process STDIN as
 
-  Specifying rules and plugins:
-    --no-textlintrc             Disable .textlintrc
-    --plugin [String]           Set plugin package name
-    --rule [String]             Set rule package name
-    --preset [String]           Set preset package name and load rules from preset package.
-    --rulesdir [path::String]   Use additional rules from this directory
+Output:
+  -o, --output-file path::String  Enable report to be written to a file.
+  -f, --format String         Use a specific output format.
 
-  Caching:
-    --cache                     Only check changed files - default: false
-    --cache-location path::String  Path to the cache file or directory
+                              Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
 
-  Experimental:
-    --experimental              Enable experimental flag.Some feature use on experimental.
-    --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
-    --parallel                  Lint files in parallel
-    --max-concurrency Number    maxConcurrency for --parallel
+                              Available formatter for --fix: compats, diff, json, stylish - default: stylish
+  --no-color                  Disable color in piped output.
+  --quiet                     Report errors only. - default: false
 
+Specifying rules and plugins:
+  --no-textlintrc             Disable .textlintrc
+  --plugin [String]           Set plugin package name
+  --rule [String]             Set rule package name
+  --preset [String]           Set preset package name and load rules from preset package.
+  --rulesdir [path::String]   Use additional rules from this directory
+
+Caching:
+  --cache                     Only check changed files - default: false
+  --cache-location path::String  Path to the cache file or directory - default: .textlintcache
+
+Experimental:
+  --experimental              Enable experimental flag.Some feature use on experimental.
+  --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --parallel                  Lint files in parallel
+  --max-concurrency Number    maxConcurrency for --parallel
 ```
 
 When running texlint, you can target files to lint using the glob patterns.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,45 +32,48 @@ You can view all the CLI options by running `textlint --help`.
 
 ```sh
 $ textlint [options] file.md [file|dir|glob*]
-  Options:
-    -h, --help                  Show help.
-    -c, --config path::String   Use configuration from this file or sharable config.
-    --ignore-path path::String  Specify path to a file containing patterns that describes files to ignore. - default: .textlintignore
-    --init                      Create the config file if not existed. - default: false
-    --fix                       Automatically fix problems
-    --dry-run                   Enable dry-run mode for --fix. Only show result, don't change the file.
-    --debug                     Outputs debugging information
-    -v, --version               Outputs the version number.
 
-  Using stdin:
-    --stdin                     Lint text provided on <STDIN>. - default: false
-    --stdin-filename String     Specify filename to process STDIN as
+Options:
+  -h, --help                  Show help.
+  -c, --config path::String   Use configuration from this file or sharable config.
+  --ignore-path path::String  Specify path to a file containing patterns that describes files to ignore. - default: .textlintignore
+  --init                      Create the config file if not existed. - default: false
+  --fix                       Automatically fix problems
+  --dry-run                   Enable dry-run mode for --fix. Only show result, don't change the file.
+  --debug                     Outputs debugging information
+  --print-config              Print the config object to stdout
+  -v, --version               Outputs the version number.
 
-  Output:
-    -o, --output-file path::String  Enable report to be written to a file.
-    -f, --format String         Use a specific output format.
-                                Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
-                                Available formatter for --fix: compats, diff, json, stylish
-    --no-color                  Disable color in piped output.
-    --quiet                     Report errors only. - default: false
+Using stdin:
+  --stdin                     Lint text provided on <STDIN>. - default: false
+  --stdin-filename String     Specify filename to process STDIN as
 
-  Specifying rules and plugins:
-    --no-textlintrc             Disable .textlintrc
-    --plugin [String]           Set plugin package name
-    --rule [String]             Set rule package name
-    --preset [String]           Set preset package name and load rules from preset package.
-    --rulesdir [path::String]   Use additional rules from this directory
+Output:
+  -o, --output-file path::String  Enable report to be written to a file.
+  -f, --format String         Use a specific output format.
 
-  Caching:
-    --cache                     Only check changed files - default: false
-    --cache-location path::String  Path to the cache file or directory
+                              Available formatter          : checkstyle, compact, jslint-xml, json, junit, pretty-error, stylish, table, tap, unix
 
-  Experimental:
-    --experimental              Enable experimental flag.Some feature use on experimental.
-    --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
-    --parallel                  Lint files in parallel
-    --max-concurrency Number    maxConcurrency for --parallel
+                              Available formatter for --fix: compats, diff, json, stylish - default: stylish
+  --no-color                  Disable color in piped output.
+  --quiet                     Report errors only. - default: false
 
+Specifying rules and plugins:
+  --no-textlintrc             Disable .textlintrc
+  --plugin [String]           Set plugin package name
+  --rule [String]             Set rule package name
+  --preset [String]           Set preset package name and load rules from preset package.
+  --rulesdir [path::String]   Use additional rules from this directory
+
+Caching:
+  --cache                     Only check changed files - default: false
+  --cache-location path::String  Path to the cache file or directory - default: .textlintcache
+
+Experimental:
+  --experimental              Enable experimental flag.Some feature use on experimental.
+  --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --parallel                  Lint files in parallel
+  --max-concurrency Number    maxConcurrency for --parallel
 ```
 
 ## Pipe to textlint

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -107,7 +107,7 @@ export function getFixerFormatterList(): FixerFormatterDetail[] {
         .readdirSync(path.join(__dirname, "formatters"))
         .filter((file: string) => {
             const fileName = path.extname(file);
-            return fileName === ".js" || fileName === ".ts";
+            return fileName === ".js" || (fileName === ".ts" && !file.endsWith("d.ts"));
         })
         .map((file: string) => {
             return { name: path.basename(file, path.extname(file)) };

--- a/packages/textlint/src/loader/TextlintrcLoader.ts
+++ b/packages/textlint/src/loader/TextlintrcLoader.ts
@@ -17,6 +17,26 @@ export type LoadTextlintrcOptions = {
      */
     node_modulesDir?: string;
 };
+// Built-in plugins should be loaded from same directory with `textlint` package
+export const builtInPlugins: TextlintKernelPlugin[] = [
+    {
+        pluginId: "@textlint/textlint-plugin-text",
+        plugin: textPlugin,
+        options: true
+    },
+    {
+        pluginId: "@textlint/textlint-plugin-markdown",
+        plugin: markdownPlugin,
+        options: true
+    }
+];
+export const loadBuiltinPlugins = async (): Promise<TextlintKernelDescriptor> => {
+    return new TextlintKernelDescriptor({
+        rules: [],
+        filterRules: [],
+        plugins: builtInPlugins
+    });
+};
 export const loadTextlintrc = async ({
     configFilePath,
     node_modulesDir
@@ -25,26 +45,10 @@ export const loadTextlintrc = async ({
         configFilePath,
         node_modulesDir
     });
-    // Built-in plugins should be loaded from same directory with `textlint` package
-    const builtInPlugins: TextlintKernelPlugin[] = [
-        {
-            pluginId: "@textlint/textlint-plugin-text",
-            plugin: textPlugin,
-            options: true
-        },
-        {
-            pluginId: "@textlint/textlint-plugin-markdown",
-            plugin: markdownPlugin,
-            options: true
-        }
-    ];
+
     if (!result.ok) {
         debug("loadTextlintrc failed: %o", result);
-        return new TextlintKernelDescriptor({
-            rules: [],
-            filterRules: [],
-            plugins: builtInPlugins
-        });
+        return loadBuiltinPlugins();
     }
     const { rules, plugins, filterRules } = result.config;
     return new TextlintKernelDescriptor({

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -37,6 +37,7 @@ export type CliOptions = {
     fix: boolean;
     dryRun: boolean;
     debug: boolean;
+    printConfig: boolean;
     stdin: boolean;
     stdinFilename?: string;
     version: boolean;
@@ -97,6 +98,12 @@ export const options = optionator({
             type: "Boolean",
             default: false,
             description: "Outputs debugging information"
+        },
+        {
+            option: "print-config",
+            type: "Boolean",
+            default: false,
+            description: "Print the config object to stdout"
         },
         {
             option: "version",

--- a/packages/textlint/test/cli-new/cli-test.ts
+++ b/packages/textlint/test/cli-new/cli-test.ts
@@ -37,7 +37,7 @@ const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unk
     try {
         await cb(context);
     } catch (error) {
-        // eslint-disablfe-next-line no-console
+        // eslint-disable-next-line no-console
         console.log("Logs", context.getLogs());
         throw error;
     }


### PR DESCRIPTION
- Fix `--no-textlintrc` handling on New CLI #973 
- Add `--print-config` for debug/testing on New CLI

fix https://github.com/textlint/textlint/issues/973