### PR TITLE
fix(textlint): fix an error on compats fixer formatter

### DIFF
--- a/packages/@textlint/fixer-formatter/src/formatters/compats.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/compats.ts
@@ -9,7 +9,7 @@ function getMessageType(message: any) {
     }
 }
 
-export function format(results: TextlintFixResult[]) {
+export default function (results: TextlintFixResult[]) {
     let output = "";
     let total = 0;
 

--- a/packages/@textlint/fixer-formatter/test/formatters/compats-test.js
+++ b/packages/@textlint/fixer-formatter/test/formatters/compats-test.js
@@ -1,0 +1,84 @@
+"use strict";
+import path from "path";
+import compats from "../../src/formatters/compats";
+import assert from "assert";
+
+const formatter = (code) => {
+    return compats(code, { color: false });
+};
+
+describe("formatter:compats", function () {
+    context("when single modified", function () {
+        it("should return output", function () {
+            const input = path.join(__dirname, "../fixtures", "single.md");
+            const code = require("../fixtures/single");
+            const output = formatter(code, { color: false });
+            assert.strictEqual(
+                output,
+                `
+Fixed✔ ${input}: line 5, col 9, Error - Unexpected foo. (foo)
+
+
+Fixed 1 problem
+`.trim()
+            );
+        });
+    });
+    context("when double modified", function () {
+        it("should return output", function () {
+            const input = path.join(__dirname, "../fixtures", "double.md");
+            const code = require("../fixtures/double");
+            const output = formatter(code, { color: false });
+            assert.strictEqual(
+                output,
+                `
+Fixed✔ ${input}: line 5, col 1, Error - Unexpected foo. (foo)
+Fixed✔ ${input}: line 6, col 1, Error - Unexpected bar. (foo)
+
+
+Fixed 2 problems
+`.trim()
+            );
+        });
+    });
+    context("when multiple files results", function () {
+        it("should return output", function () {
+            const singleFile = path.join(__dirname, "../fixtures", "single.md");
+            const multiple = path.join(__dirname, "../fixtures", "multiple.md");
+            const code = require("../fixtures/multiple");
+            const output = formatter(code, { color: false });
+            assert.strictEqual(
+                output,
+                `
+Fixed✔ ${singleFile}: line 5, col 9, Error - Unexpected foo. (foo)
+Fixed✔ ${multiple}: line 1, col 1, Error - Unexpected foo. (foo)
+Fixed✔ ${multiple}: line 1, col 4, Error - Unexpected bar. (foo)
+Fixed✔ ${multiple}: line 3, col 1, Error - Unexpected foo. (foo)
+Fixed✔ ${multiple}: line 3, col 4, Error - Unexpected bar. (foo)
+Fixed✔ ${multiple}: line 7, col 1, Error - Unexpected foo. (foo)
+Fixed✔ ${multiple}: line 7, col 4, Error - Unexpected bar. (foo)
+
+
+Fixed 7 problems
+`.trim()
+            );
+        });
+    });
+
+    context("when remaining messages", function () {
+        it("should return output", function () {
+            const input = path.join(__dirname, "../fixtures", "remaining.md");
+            const code = require("../fixtures/remaining");
+            const output = formatter(code, { color: false });
+            assert.strictEqual(
+                output,
+                `
+Fixed✔ ${input}: line 5, col 9, Error - Unexpected foo. (foo)
+
+
+Fixed 1 problem
+`.trim()
+            );
+        });
+    });
+});


### PR DESCRIPTION
This PR tries to fix a bug that occurs when the `compats` option is specified for the fixer formatter.

Closes #979

# TEST
```sh
>>> npm install /Users/sho0628/projects/textlint/packages/@textlint/fixer-formatter /Users/sho0628/projects/textlint/packages/textlint --save-dev

>>> npx textlint file.md --fix --format compats
Fixed✔ /Users/sho0628/projects/textlint_test/file.md: line 2, col 7, Error - Should remove period mark(".") at end of list item. (period-in-list-item)


Fixed 1 problem
```