### PR TITLE
refactor: update to structured-source@4

### DIFF
--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -46,7 +46,7 @@
         "@textlint/utils": "^12.5.0",
         "debug": "^4.3.4",
         "deep-equal": "^1.1.1",
-        "structured-source": "^3.0.2"
+        "structured-source": "^4.0.0"
     },
     "devDependencies": {
         "@textlint/markdown-to-ast": "^12.5.0",
@@ -54,7 +54,6 @@
         "@types/deep-equal": "^1.0.1",
         "@types/mocha": "^9.1.1",
         "@types/node": "^18.11.18",
-        "@types/structured-source": "^3.0.0",
         "cpx": "^1.5.0",
         "cross-env": "^7.0.3",
         "mocha": "^10.2.0",

--- a/packages/@textlint/kernel/src/context/TextlintSourceCodeImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintSourceCodeImpl.ts
@@ -7,7 +7,7 @@ import type {
 } from "@textlint/types";
 import { AnyTxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
 import * as assert from "assert";
-import StructuredSource from "structured-source";
+import { StructuredSource } from "structured-source";
 
 /**
  * Validates that the given AST has the required information.
@@ -125,7 +125,7 @@ export class TextlintSourceCodeImpl implements TextlintSourceCode {
     }
 
     /**
-     * @param {Position} pos - position indicator.
+     * @param pos - position indicator.
      * @return {number} index.
      */
     positionToIndex(pos: TextlintSourceCodePosition): number {
@@ -133,8 +133,7 @@ export class TextlintSourceCodeImpl implements TextlintSourceCode {
     }
 
     /**
-     * @param {number} index - index to the source code.
-     * @return {Position} position.
+     * @param index - index to the source code.
      */
     indexToPosition(index: number): TextlintSourceCodePosition {
         const indexToPosition = this._structuredSource.indexToPosition(index);

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -72,7 +72,7 @@
         "rc-config-loader": "^3.0.0",
         "read-pkg": "^1.1.0",
         "read-pkg-up": "^3.0.0",
-        "structured-source": "^3.0.2",
+        "structured-source": "^4.0.0",
         "try-resolve": "^1.0.1",
         "unique-concat": "^0.2.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3483,6 +3483,11 @@ boundary@^1.0.1:
   resolved "https://registry.yarnpkg.com/boundary/-/boundary-1.0.1.tgz#4d67dc2602c0cc16dd9bce7ebf87e948290f5812"
   integrity sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww==
 
+boundary@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/boundary/-/boundary-2.0.0.tgz#169c8b1f0d44cf2c25938967a328f37e0a4e5efc"
+  integrity sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -14177,6 +14182,13 @@ structured-source@^3.0.2:
   integrity sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==
   dependencies:
     boundary "^1.0.1"
+
+structured-source@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/structured-source/-/structured-source-4.0.0.tgz#0c9e59ee43dedd8fc60a63731f60e358102a4948"
+  integrity sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==
+  dependencies:
+    boundary "^2.0.0"
 
 stylehacks@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Update to structured-source@4.

- [Release v4.0.0 · textlint/structured-source](https://github.com/textlint/structured-source/releases/tag/v4.0.0)

fix #983 