### PR TITLE
 CI: add release script 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - 'Type: Meta'
+      - 'Type: Question'
+      - 'Type: Release'
+
+  categories:
+    - title: Security Fixes
+      labels: ['Type: Security']
+    - title: Breaking Changes
+      labels: ['Type: Breaking Change']
+    - title: Features
+      labels: ['Type: Feature']
+    - title: Bug Fixes
+      labels: ['Type: Bug']
+    - title: Documentation
+      labels: ['Type: Documentation']
+    - title: Refactoring
+      labels: ['Type: Refactoring']
+    - title: Testing
+      labels: ['Type: Testing']
+    - title: Maintenance
+      labels: ['Type: Maintenance']
+    - title: CI
+      labels: ['Type: CI']
+    - title: Dependency Updates
+      labels: ['Type: Dependencies', "dependencies"]
+    - title: Other Changes
+      labels: ['*']

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,74 @@
+name: Create Release PR
+on:
+  workflow_dispatch:
+    inputs:
+      semver:
+        description: 'New Version(semver)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: '18'
+      - name: Install
+        run: yarn install
+      - name: Update Version
+        run: |
+          git config --global user.email "${GIT_AUTHOR_EMAIL}"
+          git config --global user.name "${GIT_AUTHOR_NAME}"
+          yarn run ci:versionup:${SEMVER} --yes
+        env:
+          SEMVER: ${{ github.event.inputs.semver }}
+          GIT_AUTHOR_NAME: ${{ github.actor }}
+          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+      - name: Set PACKAGE_VERSION
+        run: echo "PACKAGE_VERSION=$(cat lerna.json | jq -r .version)" >> $GITHUB_ENV
+      - name: Set GitHub Release Note
+        id: release_note
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const result = await exec.getExecOutput(`gh api "/repos/{owner}/{repo}/releases/generate-notes" -f tag_name="${process.env.PACKAGE_VERSION}" --jq .body`, [], {
+              ignoreReturnCode: true,
+            })
+            core.setOutput('stdout', result.stdout)
+        env:
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(release): v${{ env.PACKAGE_VERSION }}"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          assignees: ${{ github.actor }}
+          signoff: false
+          branch: release/${{ env.PACKAGE_VERSION }}
+          branch-suffix: timestamp
+          delete-branch: true
+          title: 'v${{ env.PACKAGE_VERSION }}'
+          body: |
+            ${{ steps.release_note.outputs.stdout }}
+          labels: "Type: Release"
+      - name: Check Pull Request
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+# This workflow often runs following steps when a PR is merged to main branch.
+# 1. jobs.check checks if we need to release
+# 2. jobs.release publish packages
+#
+# Note: Force publish
+# You can publish packages manually by running workflow dispatch
+# This workflow dispatch skip jobs.check process
+# 1. dispatch "release" workflow
+# 2. Open Release Page
+# 3. Generate Release Note
+name: Release
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+    types: [ closed ]
+  workflow_dispatch: # force release
+
+jobs:
+  check:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      EXISTS_TAG: ${{ steps.tag_check.outputs.EXISTS_TAG }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set PACKAGE_VERSION
+        run: echo "PACKAGE_VERSION=$(cat lerna.json | jq -r .version)" >> $GITHUB_ENV
+      - name: Tag Check
+        id: tag_check
+        run: |
+          GET_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}"
+          http_status_code=$(curl -LI $GET_API_URL -o /dev/null -w '%{http_code}\n' -s \
+            -H "Authorization: token ${GITHUB_TOKEN}")
+          if [ "$http_status_code" -ne "404" ] ; then
+            echo "EXISTS_TAG=true" >> $GITHUB_OUTPUT
+          else
+            echo "EXISTS_TAG=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          TAG_NAME: v${{ env.PACKAGE_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: check
+    if: always() && (needs.check.outputs.EXISTS_TAG == 'false')
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          node-version: 18
+          # for publishing packages to npm
+          registry-url: https://registry.npmjs.org
+      - name: Git Identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set PACKAGE_VERSION
+        run: echo "PACKAGE_VERSION=$(cat lerna.json | jq -r .version)" >> $GITHUB_ENV
+      - name: Install
+        run: yarn install
+      - name: Publish
+        run: npm run ci:release
+        env:
+          # actions/setup-node create .npmrc with `NODE_AUTH_TOKEN` env if `registry-url` is defined
+          # === `echo "${ registry-url }/:_authToken=${ NODE_AUTH_TOKEN }" > .npmrc`
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Git Tag
+        uses: pkgdeps/git-tag-action@v2
+        with:
+          version: ${{ env.PACKAGE_VERSION }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repo: ${{ github.repository }}
+          git_commit_sha: ${{ github.sha }}
+          git_tag_prefix: "v"
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.PACKAGE_VERSION }}
+          # Copy Pull Request's tile and body to Release Note
+          release_name: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false
+          generate_release_notes: ${{ !github.event.pull_request.body }}
+      - uses: actions/github-script@v6
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🎉 Release https://github.com/${{ github.repository }}/releases/tag/v${{ env.PACKAGE_VERSION }}'
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           # actions/setup-node create .npmrc with `NODE_AUTH_TOKEN` env if `registry-url` is defined
           # === `echo "${ registry-url }/:_authToken=${ NODE_AUTH_TOKEN }" > .npmrc`
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # textlint-user
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Git Tag
         uses: pkgdeps/git-tag-action@v2

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -220,7 +220,7 @@ Please see [Commit Message Format](https://github.com/conventional-changelog/con
 
 ##### Versioning
 
-We care version number while releasing packages to npm registry so you should not modify `version` field of `package.json`. For the record, we use [Semantic Versioning](https://semver.org/).
+We care version number while releasing packages to npm registry so you should not modify `version` field of `package.json`. For the record, we use [Semantic Versioning](https://semver.org/).
 
 - Patch release (intended to not break your lint build)
     - A bug fix to the CLI or core (including formatters)
@@ -317,38 +317,21 @@ After all participants on pull request are satisfied to the changes, we will mer
 
 A Maintainer release new version of textlint by following way.
 
-1. Checkout release branch
+1. Create Release PR via GitHub Actions: <https://github.com/textlint/textlint/actions/workflows/create-release-pr.yml>
+  - Run workflow with `version` input
+    - You can select new version with semver(patch,minor,major)
+2. [CI] Create Release PR
+  - Update `lerna.json`'s `version` and `packages/*/package.json`'s `version`
+  - Fill the Pull Request body with [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+  - e.g. https://github.com/azu/monorepo-github-releases/pull/18
+3. Review the Release PR
+  - You can modify PR body for changelog
+4. Merge the Release PR
+5. [CI] Publish new version to npm and GitHub Release
+  - The release note content is same to PR body
+  - CI copy to release note from PR body when merge the PR
+  - e.g. https://github.com/azu/monorepo-github-releases/releases/tag/v1.6.3
 
-```
-# checkout release branch like "release-2019-10-10"
-git checkout -b "release-$(date '+%Y-%m-%d')"
-# push current branch 
-git push origin HEAD -u
-```
-
-2. Version up and Update CHANGELOG
-
-```
-# bump vesrion and update changelog
-npm run versionup
-## npm run versionup:{patch,minor,major}
-# bump version and update changelog and update GitHub release notes
-## GH_TOKEN="${GITHUB_TOKEN}" npm run versionup -- --create-release=github
-# push the changes to release branch
-git push
-```
-
-Tips: Copy changelogs from CHANGELOG.md
-
-```
-## Collect changelog in the versionup
-yarn run collect-changelog # pbcopy
-```
-
-3. Create a Pull Request and Review the release
-    - If you need, write blog posts in website/blog
-4. Publish to npm
-
-```
-npm run release
-```
+> **Warning**
+> If the publishing(Step 5) is failed, you can re-run the workflow.  
+> Or, Open <https://github.com/textlint/textlint/actions/workflows/release.yml> and do "Run workflow".

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -318,19 +318,19 @@ After all participants on pull request are satisfied to the changes, we will mer
 A Maintainer release new version of textlint by following way.
 
 1. Create Release PR via GitHub Actions: <https://github.com/textlint/textlint/actions/workflows/create-release-pr.yml>
-  - Run workflow with `version` input
-    - You can select new version with semver(patch,minor,major)
+   - Run workflow with `version` input
+      - You can select new version with semver(patch,minor,major)
 2. [CI] Create Release PR
-  - Update `lerna.json`'s `version` and `packages/*/package.json`'s `version`
-  - Fill the Pull Request body with [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
-  - e.g. https://github.com/azu/monorepo-github-releases/pull/18
+   - Update `lerna.json`'s `version` and `packages/*/package.json`'s `version`
+   - Fill the Pull Request body with [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
+   - e.g. https://github.com/azu/monorepo-github-releases/pull/18
 3. Review the Release PR
-  - You can modify PR body for changelog
+   - You can modify PR body for changelog
 4. Merge the Release PR
 5. [CI] Publish new version to npm and GitHub Release
-  - The release note content is same to PR body
-  - CI copy to release note from PR body when merge the PR
-  - e.g. https://github.com/azu/monorepo-github-releases/releases/tag/v1.6.3
+   - The release note content is same to PR body
+   - CI copy to release note from PR body when merge the PR
+   - e.g. https://github.com/azu/monorepo-github-releases/releases/tag/v1.6.3
 
 > **Warning**
 > If the publishing(Step 5) is failed, you can re-run the workflow.  


### PR DESCRIPTION
# New Release Flow

A Maintainer release new version of textlint by following way.

1. Create Release PR via GitHub Actions: <https://github.com/textlint/textlint/actions/workflows/create-release-pr.yml>
   - Run workflow with `version` input
      - You can select new version with semver(patch,minor,major)
2. [CI] Create Release PR
   - Update `lerna.json`'s `version` and `packages/*/package.json`'s `version`
   - Fill the Pull Request body with [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
   - e.g. https://github.com/azu/monorepo-github-releases/pull/18
3. Review the Release PR
   - You can modify PR body for changelog
4. Merge the Release PR
5. [CI] Publish new version to npm and GitHub Release
   - The release note content is same to PR body
   - CI copy to release note from PR body when merge the PR
   - e.g. https://github.com/azu/monorepo-github-releases/releases/tag/v1.6.3

> **Warning**
> If the publishing(Step 5) is failed, you can re-run the workflow.  
> Or, Open <https://github.com/textlint/textlint/actions/workflows/release.yml> and do "Run workflow".



fix #994 