### PR TITLE
feat(ast-node-types): Add individual Node type and Add Table/TableRow/TableCell node 

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -71,11 +71,11 @@ type TextNodeRange = [number, number];
     - if you want to get raw value, please use `getSource(<node>)` instead of it..
 - `loc`: location object
 - `range`: location info array like `[startIndex, endIndex]`
-- `parent`: (optional) parent node of this node. 
+- `parent`: (optional) parent node of this node.
     - It is attached in runtime
     - Parser user ignore this property
-    
-### `TxtTextNode` 
+
+### `TxtTextNode`
 
 `TxtTextNode` is inherit the `TxtNode` abstract interface.
 
@@ -97,7 +97,7 @@ interface TxtTextNode extends TxtNode {
 Example: `Str` node is a `TxtTextNode`.
 
 ### `TxtParentNode`
- 
+
 `TxtParentNode` is inherit the `TxtNode` abstract interface.
 
 ```typescript
@@ -125,6 +125,7 @@ You can use this `ASTNodeTypes` value via following way:
 
 ```js
 import { ASTNodeTypes } from "@textlint/ast-node-types";
+
 console.log(ASTNodeTypes.Str); // "Str"
 ```
 
@@ -133,55 +134,68 @@ You can get Node type for Type name by `TypeofTxtNode` in TypeScript.
 ```ts
 // In TypeScript
 import { ASTNodeTypes } from "@textlint/ast-node-types";
+
 const nodeType = TypeofTxtNode<ASTNodeTypes.Str>; // TxtTextNode
 ```
 
-These types are defined in `@textlint/ast-node-types`.
+These types are defined in [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).
 
-| Type name                       | Node type     | Description                          |
-| ------------------------------- | ------------- | ------------------------------------ |
-| ASTNodeTypes.Document           | TxtParentNode | Root Node                            |
-| ASTNodeTypes.DocumentExit       | TxtParentNode |                                      |
-| ASTNodeTypes.Paragraph          | TxtParentNode | Paragraph Node                       |
-| ASTNodeTypes.ParagraphExit      | TxtParentNode |                                      |
-| ASTNodeTypes.BlockQuote         | TxtParentNode | > Block Quote Node                   |
-| ASTNodeTypes.BlockQuoteExit     | TxtParentNode |                                      |
-| ASTNodeTypes.List               | TxtParentNode | List Node                            |
-| ASTNodeTypes.ListExit           | TxtParentNode |                                      |
-| ASTNodeTypes.ListItem           | TxtParentNode | List (each) item Node                |
-| ASTNodeTypes.ListItemExit       | TxtParentNode |                                      |
-| ASTNodeTypes.Header             | TxtParentNode | # Header Node                        |
-| ASTNodeTypes.HeaderExit         | TxtParentNode |                                      |
-| ASTNodeTypes.CodeBlock          | TxtParentNode | Code Block Node                      |
-| ASTNodeTypes.CodeBlockExit      | TxtParentNode |                                      |
-| ASTNodeTypes.HtmlBlock          | TxtParentNode | HTML Block Node                      |
-| ASTNodeTypes.HtmlBlockExit      | TxtParentNode |                                      |
-| ASTNodeTypes.Link               | TxtParentNode | Link Node                            |
-| ASTNodeTypes.LinkExit           | TxtParentNode |                                      |
-| ASTNodeTypes.Delete             | TxtParentNode | Delete Node(`~Str~`)                 |
-| ASTNodeTypes.DeleteExit         | TxtParentNode |                                      |
-| ASTNodeTypes.Emphasis           | TxtParentNode | Emphasis(`*Str*`)                    |
-| ASTNodeTypes.EmphasisExit       | TxtParentNode |                                      |
-| ASTNodeTypes.Strong             | TxtParentNode | Strong Node(`**Str**`)               |
-| ASTNodeTypes.StrongExit         | TxtParentNode |                                      |
-| ASTNodeTypes.Break              | TxtNode       | Hard Break Node(`Str<space><space>`) |
-| ASTNodeTypes.BreakExit          | TxtNode       |                                      |
-| ASTNodeTypes.Image              | TxtNode       | Image Node                           |
-| ASTNodeTypes.ImageExit          | TxtNode       |                                      |
-| ASTNodeTypes.HorizontalRule     | TxtNode       | Horizontal Node(`---`)               |
-| ASTNodeTypes.HorizontalRuleExit | TxtNode       |                                      |
-| ASTNodeTypes.Comment            | TxtTextNode   | Comment Node                         |
-| ASTNodeTypes.CommentExit        | TxtTextNode   |                                      |
-| ASTNodeTypes.Str                | TxtTextNode   | Str Node                             |
-| ASTNodeTypes.StrExit            | TxtTextNode   |                                      |
-| ASTNodeTypes.Code               | TxtTextNode   | Inline Code Node                     |
-| ASTNodeTypes.CodeExit           | TxtTextNode   |                                      |
-| ASTNodeTypes.Html               | TxtTextNode   | Inline HTML Node                     |
-| ASTNodeTypes.HtmlExit           | TxtTextNode   |                                      |
+| Type name                       | Node type                        | Description                          |
+|---------------------------------|----------------------------------|--------------------------------------|
+| ASTNodeTypes.Document           | TxtDocumentNode(TxtParentNode)   | Root Node                            |
+| ASTNodeTypes.DocumentExit       | TxtDocumentNode(TxtParentNode)   |                                      |
+| ASTNodeTypes.Paragraph          | TxtParagraphNode(TxtParentNode)  | Paragraph Node                       |
+| ASTNodeTypes.ParagraphExit      | TxtParagraphNode(TxtParentNode)  |                                      |
+| ASTNodeTypes.BlockQuote         | TxtBlockQuoteNode(TxtParentNode) | > Block Quote Node                   |
+| ASTNodeTypes.BlockQuoteExit     | TxtBlockQuoteNode(TxtParentNode) |                                      |
+| ASTNodeTypes.List               | TxtListNode(TxtParentNode)       | List Node                            |
+| ASTNodeTypes.ListExit           | TxtListNode(TxtParentNode)       |                                      |
+| ASTNodeTypes.ListItem           | TxtListItemNode(TxtParentNode)   | List (each) item Node                |
+| ASTNodeTypes.ListItemExit       | TxtListItemNode(TxtParentNode)   |                                      |
+| ASTNodeTypes.Header             | TxtHeaderNode(TxtParentNode)     | # Header Node                        |
+| ASTNodeTypes.HeaderExit         | TxtHeaderNode(TxtParentNode)     |                                      |
+| ASTNodeTypes.CodeBlock          | TxtCodeBlockNode(TxtParentNode)  | Code Block Node                      |
+| ASTNodeTypes.CodeBlockExit      | TxtCodeBlockNode(TxtParentNode)  |                                      |
+| ASTNodeTypes.HtmlBlock          | TxtHtmlBlockNode(TxtParentNode)  | HTML Block Node                      |
+| ASTNodeTypes.HtmlBlockExit      | TxtHtmlBlockNode(TxtParentNode)  |                                      |
+| ASTNodeTypes.Link               | TxtLinkNode(TxtParentNode)       | Link Node                            |
+| ASTNodeTypes.LinkExit           | TxtLinkNode(TxtParentNode)       |                                      |
+| ASTNodeTypes.Delete             | TxtDeleteNode(TxtParentNode)     | Delete Node(`~Str~`)                 |
+| ASTNodeTypes.DeleteExit         | TxtDeleteNode(TxtParentNode)     |                                      |
+| ASTNodeTypes.Emphasis           | TxtEmphasisNode(TxtParentNode)   | Emphasis(`*Str*`)                    |
+| ASTNodeTypes.EmphasisExit       | TxtEmphasisNode(TxtParentNode)   |                                      |
+| ASTNodeTypes.Strong             | TxtStrongNode(TxtParentNode)     | Strong Node(`**Str**`)               |
+| ASTNodeTypes.StrongExit         | TxtStrongNode(TxtParentNode)     |                                      |
+| ASTNodeTypes.Break              | TxtBreakNode                     | Hard Break Node(`Str<space><space>`) |
+| ASTNodeTypes.BreakExit          | TxtBreakNode                     |                                      |
+| ASTNodeTypes.Image              | TxtImageNode                     | Image Node                           |
+| ASTNodeTypes.ImageExit          | TxtImageNode                     |                                      |
+| ASTNodeTypes.HorizontalRule     | TxtHorizontalRuleNode            | Horizontal Node(`---`)               |
+| ASTNodeTypes.HorizontalRuleExit | TxtHorizontalRuleNode            |                                      |
+| ASTNodeTypes.Comment            | TxtCommentNode                   | Comment Node                         |
+| ASTNodeTypes.CommentExit        | TxtCommentNode                   |                                      |
+| ASTNodeTypes.Str                | TxtStrNode                       | Str Node                             |
+| ASTNodeTypes.StrExit            | TxtStrNode                       |                                      |
+| ASTNodeTypes.Code               | TxtCodeNode                      | Inline Code Node                     |
+| ASTNodeTypes.CodeExit           | TxtCodeNode                      |                                      |
+| ASTNodeTypes.Html               | TxtHtmlNode                      | Inline HTML Node                     |
+| ASTNodeTypes.HtmlExit           | TxtHtmlNode                      |                                      |
 
+For more details, see [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).
 
-The type is based on HTML tag and Markdown syntax.
-Other plugin has define other node type that is not defined in `@textlint/ast-node-types`, but you can specify it as just a string.
+These type are based on HTML tag and Markdown syntax.
+Other plugin has defined other node type that is not defined in `@textlint/ast-node-types`, but you can specify it as just a string.
+
+```js
+// A rule can treat "Example" node type
+export default () => {
+  return {
+    ["Example"](node){
+      // do something
+    }
+  }
+}
+```
 
 ### Minimal node property
 
@@ -205,10 +219,10 @@ But, Following node **should** have some properties.
 
 textlint has built-in parsers.
 
-| Package | Version | Description |
-|---------|---------|-------------|
-| [`@textlint/markdown-to-ast`](https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast) | [![npm](https://img.shields.io/npm/v/@textlint/markdown-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/@textlint/markdown-to-ast) | markdown parser |
-| [`@textlint/text-to-ast`](https://github.com/textlint/textlint/tree/master/packages/@textlint/text-to-ast) | [![npm](https://img.shields.io/npm/v/@textlint/text-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/@textlint/text-to-ast) | plain text parser |
+| Package                                                                                                            | Version                                                                                                                                         | Description       |
+|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
+| [`@textlint/markdown-to-ast`](https://github.com/textlint/textlint/tree/master/packages/@textlint/markdown-to-ast) | [![npm](https://img.shields.io/npm/v/@textlint/markdown-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/@textlint/markdown-to-ast) | markdown parser   |
+| [`@textlint/text-to-ast`](https://github.com/textlint/textlint/tree/master/packages/@textlint/text-to-ast)         | [![npm](https://img.shields.io/npm/v/@textlint/text-to-ast.svg?style=flat-square)](https://www.npmjs.com/package/@textlint/text-to-ast)         | plain text parser |
 
 If you want to get other type, please [create new issue](https://github.com/textlint/textlint/issues/new).
 
@@ -230,17 +244,19 @@ Minimum(recommended) rules is following code:
 /**
  * @param {RuleContext} context
  */
-export default function (context) {
+export default function(context) {
     const { Syntax } = context;
     // root object
     return {
-        [Syntax.Document](node) {},
-        [Syntax.Paragraph](node) {},
-        [Syntax.Str](node) {}
+        [Syntax.Document](node) {
+        },
+        [Syntax.Paragraph](node) {
+        },
+        [Syntax.Str](node) {
+        }
     };
 }
 ```
-
 
 ### `loc`
 
@@ -284,83 +300,83 @@ Output: The AST by [AST explorer for textlint](https://textlint.github.io/astexp
 
 ```json
 {
-    "type": "Document",
-    "children": [
+  "type": "Document",
+  "children": [
+    {
+      "type": "Paragraph",
+      "children": [
         {
-            "type": "Paragraph",
-            "children": [
-                {
-                    "type": "Emphasis",
-                    "children": [
-                        {
-                            "type": "Str",
-                            "value": "text",
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 1
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 5
-                                }
-                            },
-                            "range": [
-                                1,
-                                5
-                            ],
-                            "raw": "text"
-                        }
-                    ],
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 0
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 6
-                        }
-                    },
-                    "range": [
-                        0,
-                        6
-                    ],
-                    "raw": "*text*"
-                }
-            ],
-            "loc": {
+          "type": "Emphasis",
+          "children": [
+            {
+              "type": "Str",
+              "value": "text",
+              "loc": {
                 "start": {
-                    "line": 1,
-                    "column": 0
+                  "line": 1,
+                  "column": 1
                 },
                 "end": {
-                    "line": 1,
-                    "column": 6
+                  "line": 1,
+                  "column": 5
                 }
+              },
+              "range": [
+                1,
+                5
+              ],
+              "raw": "text"
+            }
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
             },
-            "range": [
-                0,
-                6
-            ],
-            "raw": "*text*"
+            "end": {
+              "line": 1,
+              "column": 6
+            }
+          },
+          "range": [
+            0,
+            6
+          ],
+          "raw": "*text*"
         }
-    ],
-    "loc": {
+      ],
+      "loc": {
         "start": {
-            "line": 1,
-            "column": 0
+          "line": 1,
+          "column": 0
         },
         "end": {
-            "line": 1,
-            "column": 6
+          "line": 1,
+          "column": 6
         }
-    },
-    "range": [
+      },
+      "range": [
         0,
         6
-    ],
-    "raw": "*text*"
+      ],
+      "raw": "*text*"
+    }
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 6
+    }
+  },
+  "range": [
+    0,
+    6
+  ],
+  "raw": "*text*"
 }
 ```
 
@@ -387,7 +403,7 @@ Illustration
 
 `TxtAST` have a minimum of compatibility for [unist: Universal Syntax Tree](https://github.com/syntax-tree/unist "wooorm/unist: Universal Syntax Tree").
 
-We discuss about Unist in [Compliances tests for TxtNode #141](https://github.com/textlint/textlint/issues/141 "Compliances tests for TxtNode #141").
+We discuss Unist in [Compliances tests for TxtNode #141](https://github.com/textlint/textlint/issues/141 "Compliances tests for TxtNode #141").
 
 ## For testing Processor plugin
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -12,7 +12,7 @@ TxtAST define AST(Abstract Syntax Tree) for processing in textlint.
 textlint's plugin parse text to AST. AST is a tree structure that is consist of `Txt{{Type}}Node` like `TxtParagraphNode`.
 Each node has common properties like `type`, `raw`, `loc`, `range` and `parent` that is defined in `TxtNode` interface.
 
-Additionally, each node has own properties that is defined in each node type.
+Each node has own properties that is defined in each node type.
 
 [![ast-explorer fork](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -77,7 +77,7 @@ type TextNodeRange = [number, number];
 
 ### `TxtTextNode`
 
-`TxtTextNode` is inherit the `TxtNode` abstract interface.
+`TxtTextNode` is an abstract node that inherit `TxtNode` interface.
 
 ```typescript
 /**
@@ -98,7 +98,7 @@ Example: `Str` node is a `TxtTextNode`.
 
 ### `TxtParentNode`
 
-`TxtParentNode` is inherit the `TxtNode` abstract interface.
+`TxtParentNode` is an abstract node that inherit `TxtNode` interface.
 
 ```typescript
 /**
@@ -183,11 +183,24 @@ These types are defined in [`@textlint/ast-node-types`](https://github.com/textl
 | ASTNodeTypes.Table              | TxtTableNode                     | Table node. textlint 13+             |
 | ASTNodeTypes.TableExit          | TxtTableNode                     |                                      |
 | ASTNodeTypes.TableRow           | TxtTableRowNode                  | Table row node. textlint 13+         |
-| ASTNodeTypes.TableRowExit       | TxtTableRowNode                     |                                      |
+| ASTNodeTypes.TableRowExit       | TxtTableRowNode                  |                                      |
 | ASTNodeTypes.TableCell          | TxtTableCellNode                 | Table cell node. textlint 13+        |
 | ASTNodeTypes.TableCellExit      | TxtTableCellNode                 |                                      |
 
+Some node have additional properties.
+For example, `TxtHeaderNode` has `level` property.
+
+```ts
+export interface TxtHeaderNode extends TxtParentNode {
+    type: "Header";
+    depth: 1 | 2 | 3 | 4 | 5 | 6;
+    children: PhrasingContent[];
+}
+```
+
 For more details, see [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).
+
+- [`@textlint/ast-node-types/src/NodeType.ts`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types/src/NodeType.ts).
 
 These type are based on HTML tag and Markdown syntax.
 Other plugin has defined other node type that is not defined in `@textlint/ast-node-types`, but you can specify it as just a string.
@@ -430,8 +443,7 @@ test(AST); // if the AST is invalid, then throw Error
 isTxtAST(AST); // true or false
 ```
 
-## Warning
+:warning: Current `test` function does not check node specific properties.
+For example, `TxtHeaderNode` has `level` property, but `test` function does not check it.
 
-Other properties is not assured.
-
-For example, markdown's `Header` node has `level` property, but other format has not it.
+- Issue: [ast-tester should validate individual Node type · Issue #1009 · textlint/textlint](https://github.com/textlint/textlint/issues/1009)

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -180,6 +180,12 @@ These types are defined in [`@textlint/ast-node-types`](https://github.com/textl
 | ASTNodeTypes.CodeExit           | TxtCodeNode                      |                                      |
 | ASTNodeTypes.Html               | TxtHtmlNode                      | Inline HTML Node                     |
 | ASTNodeTypes.HtmlExit           | TxtHtmlNode                      |                                      |
+| ASTNodeTypes.Table              | TxtTableNode                     | Table node. textlint 13+             |
+| ASTNodeTypes.TableExit          | TxtTableNode                     |                                      |
+| ASTNodeTypes.TableRow           | TxtTableRowNode                  | Table row node. textlint 13+         |
+| ASTNodeTypes.TableRowExit       | TxtTableRowNode                     |                                      |
+| ASTNodeTypes.TableCell          | TxtTableCellNode                 | Table cell node. textlint 13+        |
+| ASTNodeTypes.TableCellExit      | TxtTableCellNode                 |                                      |
 
 For more details, see [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -427,7 +427,7 @@ Illustration
 
 `TxtAST` have a minimum of compatibility for [unist: Universal Syntax Tree](https://github.com/syntax-tree/unist "wooorm/unist: Universal Syntax Tree").
 
-We discuss Unist in [Compliances tests for TxtNode #141](https://github.com/textlint/textlint/issues/141 "Compliances tests for TxtNode #141").
+We have discussed Unist in [Compliances tests for TxtNode #141](https://github.com/textlint/textlint/issues/141 "Compliances tests for TxtNode #141").
 
 ## For testing Processor plugin
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -14,7 +14,7 @@ Each node has common properties like `type`, `raw`, `loc`, `range` and `parent` 
 
 Each node has own properties that is defined in each node type.
 
-[![ast-explorer fork](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
+[![textlint ast-explorer](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
 
 [AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") is useful for understanding AST.
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -9,7 +9,10 @@ TxtAST define AST(Abstract Syntax Tree) for processing in textlint.
 
 [Abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree "Abstract syntax tree - Wikipedia, the free encyclopedia") is a tree representation of the abstract syntactic structure of text.
 
-Each node of the tree has same interface, is called `TxtNode`.
+textlint's plugin parse text to AST. AST is a tree structure that is consist of `Txt{{Type}}Node` like `TxtParagraphNode`.
+Each node has common properties like `type`, `raw`, `loc`, `range` and `parent` that is defined in `TxtNode` interface.
+
+Additionally, each node has own properties that is defined in each node type.
 
 [![ast-explorer fork](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
 
@@ -137,6 +140,8 @@ import { ASTNodeTypes } from "@textlint/ast-node-types";
 
 const nodeType = TypeofTxtNode<ASTNodeTypes.Str>; // TxtTextNode
 ```
+
+### All node types
 
 These types are defined in [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -189,12 +189,12 @@ Other plugin has defined other node type that is not defined in `@textlint/ast-n
 ```js
 // A rule can treat "Example" node type
 export default () => {
-  return {
-    ["Example"](node){
-      // do something
-    }
-  }
-}
+    return {
+        ["Example"](node) {
+            // do something
+        }
+    };
+};
 ```
 
 ### Minimal node property

--- a/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
+++ b/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
@@ -48,5 +48,12 @@ export enum ASTNodeTypes {
     Code = "Code",
     CodeExit = "Code:exit",
     Delete = "Delete",
-    DeleteExit = "Delete:exit"
+    DeleteExit = "Delete:exit",
+    // Table is supported in textlint v13+
+    Table = "Table",
+    TableExit = "Table:exit",
+    TableRow = "TableRow",
+    TableRowExit = "TableRow:exit",
+    TableCell = "TableCell",
+    TableCellExit = "TableCell:exit"
 }

--- a/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
+++ b/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
@@ -1,3 +1,11 @@
+// Notes: Add new Node types
+// 1. Add new Node type to ASTNodeTypes
+// 2. Update txtnode.md
+// 3. Add test to packages/@textlint/types/test/Rule/TxtNode-test.ts
+
+/**
+ * ASTNodeTypes is a list of ASTNode type.
+ */
 export enum ASTNodeTypes {
     Document = "Document",
     DocumentExit = "Document:exit",

--- a/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
+++ b/packages/@textlint/ast-node-types/src/ASTNodeTypes.ts
@@ -1,0 +1,52 @@
+export enum ASTNodeTypes {
+    Document = "Document",
+    DocumentExit = "Document:exit",
+    Paragraph = "Paragraph",
+    ParagraphExit = "Paragraph:exit",
+    BlockQuote = "BlockQuote",
+    BlockQuoteExit = "BlockQuote:exit",
+    ListItem = "ListItem",
+    ListItemExit = "ListItem:exit",
+    List = "List",
+    ListExit = "List:exit",
+    Header = "Header",
+    HeaderExit = "Header:exit",
+    CodeBlock = "CodeBlock",
+    CodeBlockExit = "CodeBlock:exit",
+    /**
+     * @deprecated use Html instead of it
+     */
+    HtmlBlock = "HtmlBlock",
+    HtmlBlockExit = "HtmlBlock:exit",
+    HorizontalRule = "HorizontalRule",
+    HorizontalRuleExit = "HorizontalRule:exit",
+    Comment = "Comment",
+    CommentExit = "Comment:exit",
+    /**
+     * @deprecated
+     */
+    ReferenceDef = "ReferenceDef",
+    /**
+     * @deprecated
+     */
+    ReferenceDefExit = "ReferenceDef:exit",
+    // inline
+    Str = "Str",
+    StrExit = "Str:exit",
+    Break = "Break", // well-known Hard Break
+    BreakExit = "Break:exit", // well-known Hard Break
+    Emphasis = "Emphasis",
+    EmphasisExit = "Emphasis:exit",
+    Strong = "Strong",
+    StrongExit = "Strong:exit",
+    Html = "Html",
+    HtmlExit = "Html:exit",
+    Link = "Link",
+    LinkExit = "Link:exit",
+    Image = "Image",
+    ImageExit = "Image:exit",
+    Code = "Code",
+    CodeExit = "Code:exit",
+    Delete = "Delete",
+    DeleteExit = "Delete:exit"
+}

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -1,0 +1,292 @@
+// ================================================================================
+// Node Abstract Syntax Tree
+// ================================================================================
+/**
+ * AST Node types list on TxtNode.
+ * Constant value of types
+ * @see https://github.com/textlint/textlint/blob/master/docs/txtnode.md
+ */
+import type { ASTNodeTypes } from "./ASTNodeTypes";
+
+/**
+ * Key of ASTNodeTypes or any string
+ * For example, TxtNodeType is "Document".
+ */
+export type TxtNodeType = keyof typeof ASTNodeTypes | string;
+
+/**
+ * Any TxtNode types
+ */
+export type AnyTxtNode = TxtNode | TxtTextNode | TxtParentNode;
+
+/**
+ * Position's line start with 1.
+ * Position's column start with 0.
+ * This is for compatibility with JavaScript AST.
+ * https://gist.github.com/azu/8866b2cb9b7a933e01fe
+ */
+export type TxtNodePosition = {
+    line: number; // start with 1
+    column: number; // start with 0
+};
+
+/**
+ * Location
+ */
+export type TxtNodeLineLocation = {
+    start: TxtNodePosition;
+    end: TxtNodePosition;
+};
+
+/**
+ * Range starts with 0
+ */
+export type TextNodeRange = readonly [startIndex: number, endIndex: number];
+
+/**
+ * TxtNode is abstract interface of AST Node.
+ * Probably, Real TxtNode implementation has more properties.
+ */
+export interface TxtNode {
+    type: TxtNodeType;
+    raw: string;
+    range: TextNodeRange;
+    loc: TxtNodeLineLocation;
+    // parent is runtime information
+    // Not need in AST
+    // For example, top Root Node like `Document` has not parent.
+    parent?: TxtNode;
+
+    [index: string]: any;
+}
+
+/**
+ * Text Node.
+ * Text Node has inline value.
+ * For example, `Str` Node is an TxtTextNode.
+ */
+export interface TxtTextNode extends TxtNode {
+    value: string;
+}
+
+/**
+ * Parent Node.
+ * Parent Node has children that are consist of TxtParentNode or TxtTextNode
+ */
+export interface TxtParentNode extends TxtNode {
+    children: Content[];
+}
+
+// ================================================================================
+// Node types
+// ================================================================================
+export type AlignType = "left" | "right" | "center" | null;
+export type ReferenceType = "shortcut" | "collapsed" | "full";
+
+export type Content = TopLevelContent | ListContent | TableContent | RowContent | PhrasingContent;
+
+/**
+ * All node definition types.
+ */
+export type TopLevelContent = BlockContent | DefinitionContent;
+/**
+ * All node types that may be used where markdown block content is accepted.
+ * These types are accepted inside block quotes, list items, footnotes, and roots.
+ */
+export type BlockContent =
+    | TxtParagraphNode
+    | TxtHeaderNode
+    | TxtHorizontalRuleNode
+    | TxtBlockquoteNode
+    | TxtListNode
+    | TxtTableNode
+    | TxtHtmlNode
+    | TxtCodeBlockNode;
+
+export type DefinitionContent = TxtDefinitionNode | TxtFootnoteDefinitionNode;
+/**
+ * All node types that are acceptable inside lists.
+ */
+export type ListContent = TxtListItemNode;
+/**
+ * All node types that are acceptable inside tables (not table cells).
+ */
+export type TableContent = TxtTableRowNode;
+/**
+ * All node types that are acceptable inside tables rows (not table cells)
+ */
+export type RowContent = TxtTableCellNode;
+/**
+ * All node types that are acceptable in a (interactive) phrasing context (so not in links).
+ */
+export type PhrasingContent = TxtLinkNode | TxtLinkReferenceNode | StaticPhrasingContent;
+/**
+ * All node types that are acceptable in a static phrasing context.
+ */
+export type StaticPhrasingContent =
+    | TxtStrNode
+    | TxtEmphasisNode
+    | TxtStrongNode
+    | TxtDeleteNode
+    | TxtHtmlNode
+    | TxtInlineCodeNode
+    | TxtBreakNode
+    | TxtImageNode
+    | TxtImageReferenceNode
+    | TxtFootnoteNode
+    | TxtFootnoteReferenceNode;
+
+export interface TxtDocumentNode extends TxtParentNode {
+    type: "Document";
+}
+
+export interface TxtParagraphNode extends TxtParentNode {
+    type: "Paragraph";
+    children: PhrasingContent[];
+}
+
+export interface TxtHeaderNode extends TxtParentNode {
+    type: "Header";
+    depth: 1 | 2 | 3 | 4 | 5 | 6;
+    children: PhrasingContent[];
+}
+
+export interface TxtHorizontalRuleNode extends TxtNode {
+    type: "HorizontalRule";
+}
+
+export interface TxtBlockquoteNode extends TxtParentNode {
+    type: "Blockquote";
+    children: Array<BlockContent | DefinitionContent>;
+}
+
+export interface TxtListNode extends TxtParentNode {
+    type: "List";
+    ordered?: boolean | null | undefined;
+    start?: number | null | undefined;
+    spread?: boolean | null | undefined;
+    children: ListContent[];
+}
+
+export interface TxtListItemNode extends TxtParentNode {
+    type: "ListItem";
+    checked?: boolean | null | undefined;
+    spread?: boolean | null | undefined;
+    children: (BlockContent | DefinitionContent)[];
+}
+
+export interface TxtTableNode extends TxtParentNode {
+    type: "Table";
+    align?: AlignType[] | null | undefined;
+    children: TableContent[];
+}
+
+export interface TxtTableRowNode extends TxtParentNode {
+    type: "TableRow";
+    children: RowContent[];
+}
+
+export interface TxtTableCellNode extends TxtParentNode {
+    type: "TableCell";
+    children: PhrasingContent[];
+}
+
+export interface TxtHtmlNode extends TxtTextNode {
+    type: "Html";
+}
+
+export interface TxtCommentNode extends TxtTextNode {
+    type: "Comment";
+}
+
+export interface TxtCodeBlockNode extends TxtTextNode {
+    type: "CodeBlock";
+    lang?: string | null | undefined;
+    meta?: string | null | undefined;
+}
+
+export interface TxtYAMLNode extends TxtTextNode {
+    type: "Yaml";
+}
+
+export interface TxtDefinitionNode extends Node, TxtAssociation, TxtResource {
+    type: "Definition";
+}
+
+export interface TxtFootnoteDefinitionNode extends TxtParentNode, TxtAssociation {
+    type: "FootnoteDefinition";
+    children: (BlockContent | DefinitionContent)[];
+}
+
+export interface TxtStrNode extends TxtTextNode {
+    type: "Str";
+}
+
+export interface TxtEmphasisNode extends TxtParentNode {
+    type: "Emphasis";
+    children: PhrasingContent[];
+}
+
+export interface TxtStrongNode extends TxtParentNode {
+    type: "Strong";
+    children: PhrasingContent[];
+}
+
+export interface TxtDeleteNode extends TxtParentNode {
+    type: "Delete";
+    children: PhrasingContent[];
+}
+
+export interface TxtInlineCodeNode extends TxtTextNode {
+    type: "InlineCode";
+}
+
+export interface TxtBreakNode extends TxtNode {
+    type: "Break";
+}
+
+export interface TxtLinkNode extends TxtParentNode, TxtResource {
+    type: "link";
+    children: StaticPhrasingContent[];
+}
+
+export interface TxtImageNode extends Node, TxtResource, TxtAlternative {
+    type: "Image";
+}
+
+export interface TxtLinkReferenceNode extends TxtParentNode, TxtReference {
+    type: "LinkReference";
+    children: StaticPhrasingContent[];
+}
+
+export interface TxtImageReferenceNode extends Node, TxtReference, TxtAlternative {
+    type: "ImageReference";
+}
+
+export interface TxtFootnoteNode extends TxtParentNode {
+    type: "Footnote";
+    children: PhrasingContent[];
+}
+
+export interface TxtFootnoteReferenceNode extends Node, TxtAssociation {
+    type: "FootnoteReference";
+}
+
+// Mixin
+export interface TxtResource {
+    url: string;
+    title?: string | null | undefined;
+}
+
+export interface TxtAssociation {
+    identifier: string;
+    label?: string | null | undefined;
+}
+
+export interface TxtReference extends TxtAssociation {
+    referenceType: ReferenceType;
+}
+
+export interface TxtAlternative {
+    alt?: string | null | undefined;
+}

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -97,7 +97,7 @@ export type BlockContent =
     | TxtParagraphNode
     | TxtHeaderNode
     | TxtHorizontalRuleNode
-    | TxtBlockquoteNode
+    | TxtBlockQuoteNode
     | TxtListNode
     | TxtTableNode
     | TxtHtmlNode
@@ -129,7 +129,7 @@ export type StaticPhrasingContent =
     | TxtStrongNode
     | TxtDeleteNode
     | TxtHtmlNode
-    | TxtInlineCodeNode
+    | TxtCodeNode
     | TxtBreakNode
     | TxtImageNode
     | TxtImageReferenceNode
@@ -155,7 +155,7 @@ export interface TxtHorizontalRuleNode extends TxtNode {
     type: "HorizontalRule";
 }
 
-export interface TxtBlockquoteNode extends TxtParentNode {
+export interface TxtBlockQuoteNode extends TxtParentNode {
     type: "Blockquote";
     children: Array<BlockContent | DefinitionContent>;
 }
@@ -233,7 +233,7 @@ export interface TxtDeleteNode extends TxtParentNode {
     children: PhrasingContent[];
 }
 
-export interface TxtInlineCodeNode extends TxtTextNode {
+export interface TxtCodeNode extends TxtTextNode {
     type: "InlineCode";
 }
 

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -52,10 +52,8 @@ export interface TxtNode {
     raw: string;
     range: TextNodeRange;
     loc: TxtNodeLineLocation;
-    // parent is runtime information
-    // Not need in AST
-    // For example, top Root Node like `Document` has not parent.
-    parent?: TxtNode;
+    // `parent` is created by runtime
+    parent?: TxtParentNode;
 
     [index: string]: any;
 }

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -205,10 +205,6 @@ export interface TxtCodeBlockNode extends TxtTextNode {
     meta?: string | null | undefined;
 }
 
-export interface TxtYAMLNode extends TxtTextNode {
-    type: "Yaml";
-}
-
 export interface TxtDefinitionNode extends Node, TxtAssociation, TxtResource {
     type: "Definition";
 }
@@ -289,4 +285,13 @@ export interface TxtReference extends TxtAssociation {
 
 export interface TxtAlternative {
     alt?: string | null | undefined;
+}
+
+// ================================================================================
+// Markdown extension
+// It is not part of the original markdown spec, but textlint does not support it officially.
+// https://www.npmjs.com/package/@types/mdast
+// ================================================================================
+export interface TxtYAMLNode extends TxtTextNode {
+    type: "Yaml";
 }

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -37,80 +37,80 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
     T extends ASTNodeTypes.Document
         ? TxtDocumentNode
         : T extends ASTNodeTypes.DocumentExit
-        ? TxtDocumentNode // Paragraph Str.
-        : T extends ASTNodeTypes.Paragraph
+        ? TxtDocumentNode
+        : T extends ASTNodeTypes.Paragraph // Paragraph Str.
         ? TxtParagraphNode
         : T extends ASTNodeTypes.ParagraphExit
-        ? TxtParagraphNode // > Str
-        : T extends ASTNodeTypes.BlockQuote
+        ? TxtParagraphNode
+        : T extends ASTNodeTypes.BlockQuote // > Str
         ? TxtBlockquoteNode
         : T extends ASTNodeTypes.BlockQuoteExit
-        ? TxtBlockquoteNode // - item
-        : T extends ASTNodeTypes.List
+        ? TxtBlockquoteNode
+        : T extends ASTNodeTypes.List // - item
         ? TxtListNode
         : T extends ASTNodeTypes.ListExit
-        ? TxtListNode // - item
-        : T extends ASTNodeTypes.ListItem
+        ? TxtListNode
+        : T extends ASTNodeTypes.ListItem // - item
         ? TxtListItemNode
         : T extends ASTNodeTypes.ListItemExit
-        ? TxtListItemNode // # Str
-        : T extends ASTNodeTypes.Header
+        ? TxtListItemNode
+        : T extends ASTNodeTypes.Header // # Str
         ? TxtHeaderNode
         : T extends ASTNodeTypes.HeaderExit
         ? TxtHeaderNode
-        : /* ```
-         * code block
-         * ```
-         */
-        T extends ASTNodeTypes.CodeBlock
-        ? TxtCodeBlockNode
+        : T extends ASTNodeTypes.CodeBlock
+        ? /* ```
+           * code block
+           * ```
+           */
+          TxtCodeBlockNode
         : T extends ASTNodeTypes.CodeBlockExit
-        ? TxtCodeBlockNode // <div>\n</div>
-        : T extends ASTNodeTypes.HtmlBlock
+        ? TxtCodeBlockNode
+        : T extends ASTNodeTypes.HtmlBlock // <div>\n</div>
         ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlBlockExit
-        ? TxtHtmlNode // [link](https://example.com)
-        : T extends ASTNodeTypes.Link
+        ? TxtHtmlNode
+        : T extends ASTNodeTypes.Link // [link](https://example.com)
         ? TxtLinkNode
         : T extends ASTNodeTypes.LinkExit
-        ? TxtLinkNode // ~~Str~~
-        : T extends ASTNodeTypes.Delete
+        ? TxtLinkNode
+        : T extends ASTNodeTypes.Delete // ~~Str~~
         ? TxtDeleteNode
         : T extends ASTNodeTypes.DeleteExit
-        ? TxtDeleteNode // *Str*
-        : T extends ASTNodeTypes.Emphasis
+        ? TxtDeleteNode
+        : T extends ASTNodeTypes.Emphasis // *Str*
         ? TxtEmphasisNode
         : T extends ASTNodeTypes.EmphasisExit
-        ? TxtEmphasisNode // __Str__
-        : T extends ASTNodeTypes.Strong
+        ? TxtEmphasisNode
+        : T extends ASTNodeTypes.Strong // __Str__
         ? TxtStrongNode
         : T extends ASTNodeTypes.StrongExit
-        ? TxtStrongNode // Str<space><space>
-        : T extends ASTNodeTypes.Break
+        ? TxtStrongNode
+        : T extends ASTNodeTypes.Break // Str<space><space>
         ? TxtBreakNode
         : T extends ASTNodeTypes.BreakExit
-        ? TxtBreakNode // ![alt](https://example.com/img)
-        : T extends ASTNodeTypes.Image
+        ? TxtBreakNode
+        : T extends ASTNodeTypes.Image // ![alt](https://example.com/img)
         ? TxtImageNode
         : T extends ASTNodeTypes.ImageExit
-        ? TxtImageNode // ----
-        : T extends ASTNodeTypes.HorizontalRule
+        ? TxtImageNode
+        : T extends ASTNodeTypes.HorizontalRule // ----
         ? TxtHorizontalRuleNode
         : T extends ASTNodeTypes.HorizontalRuleExit
-        ? TxtHorizontalRuleNode // <!-- Str -->
-        : T extends ASTNodeTypes.Comment
+        ? TxtHorizontalRuleNode
+        : T extends ASTNodeTypes.Comment // Markdown does not have comment(It is Html comment). Some plugins use comment as a marker.
         ? TxtCommentNode
         : T extends ASTNodeTypes.CommentExit
-        ? TxtCommentNode // Str
-        : T extends ASTNodeTypes.Str
+        ? TxtCommentNode
+        : T extends ASTNodeTypes.Str // Str
         ? TxtStrNode
         : T extends ASTNodeTypes.StrExit
-        ? TxtStrNode // `code`
-        : T extends ASTNodeTypes.Code
+        ? TxtStrNode
+        : T extends ASTNodeTypes.Code // `code`
         ? TxtCodeBlockNode
         : T extends ASTNodeTypes.CodeExit
-        ? TxtCodeBlockNode // <span>Str</span>
-        : T extends ASTNodeTypes.Html
+        ? TxtCodeBlockNode
+        : T extends ASTNodeTypes.Html // <span>Str</span>
         ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlExit
         ? TxtHtmlNode

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -1,91 +1,114 @@
-import { ASTNodeTypes, TxtNode, TxtParentNode, TxtTextNode } from "./index";
+import type { ASTNodeTypes } from "./ASTNodeTypes";
+import type {
+    AnyTxtNode,
+    TxtBlockquoteNode,
+    TxtBreakNode,
+    TxtCodeBlockNode,
+    TxtCommentNode,
+    TxtDeleteNode,
+    TxtDocumentNode,
+    TxtEmphasisNode,
+    TxtHeaderNode,
+    TxtHorizontalRuleNode,
+    TxtHtmlNode,
+    TxtImageNode,
+    TxtLinkNode,
+    TxtListItemNode,
+    TxtListNode,
+    TxtParagraphNode,
+    TxtStrNode,
+    TxtStrongNode
+} from "./NodeType";
+
 /**
- * Return TxtNode type of ASTNodeTypes | string
+ * Type utility for TxtNodeType
+ * Return TxtNode interface for the TxtNodeTYpe
  *
  * @example
- * ```
+ * ```ts
  * type NodeType = TxtNodeTypeOfNode<ASTNodeTypes.Document>;
+ * ```
  */
 export type TypeofTxtNode<T extends ASTNodeTypes | string> =
     // Root
     T extends ASTNodeTypes.Document
-        ? TxtParentNode
+        ? TxtDocumentNode
         : T extends ASTNodeTypes.DocumentExit
-        ? TxtParentNode // Paragraph Str.
+        ? TxtDocumentNode // Paragraph Str.
         : T extends ASTNodeTypes.Paragraph
-        ? TxtParentNode
+        ? TxtParagraphNode
         : T extends ASTNodeTypes.ParagraphExit
-        ? TxtParentNode // > Str
+        ? TxtParagraphNode // > Str
         : T extends ASTNodeTypes.BlockQuote
-        ? TxtParentNode
+        ? TxtBlockquoteNode
         : T extends ASTNodeTypes.BlockQuoteExit
-        ? TxtParentNode // - item
+        ? TxtBlockquoteNode // - item
         : T extends ASTNodeTypes.List
-        ? TxtParentNode
+        ? TxtListNode
         : T extends ASTNodeTypes.ListExit
-        ? TxtParentNode // - item
+        ? TxtListNode // - item
         : T extends ASTNodeTypes.ListItem
-        ? TxtParentNode
+        ? TxtListItemNode
         : T extends ASTNodeTypes.ListItemExit
-        ? TxtParentNode // # Str
+        ? TxtListItemNode // # Str
         : T extends ASTNodeTypes.Header
-        ? TxtParentNode
+        ? TxtHeaderNode
         : T extends ASTNodeTypes.HeaderExit
-        ? TxtParentNode
+        ? TxtHeaderNode
         : /* ```
-         * code
+         * code block
          * ```
          */
         T extends ASTNodeTypes.CodeBlock
-        ? TxtParentNode
+        ? TxtCodeBlockNode
         : T extends ASTNodeTypes.CodeBlockExit
-        ? TxtParentNode // <div>\n</div>
+        ? TxtCodeBlockNode // <div>\n</div>
         : T extends ASTNodeTypes.HtmlBlock
-        ? TxtParentNode
+        ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlBlockExit
-        ? TxtParentNode // [link](https://example.com)
+        ? TxtHtmlNode // [link](https://example.com)
         : T extends ASTNodeTypes.Link
-        ? TxtParentNode
+        ? TxtLinkNode
         : T extends ASTNodeTypes.LinkExit
-        ? TxtParentNode // ~~Str~~
+        ? TxtLinkNode // ~~Str~~
         : T extends ASTNodeTypes.Delete
-        ? TxtParentNode
+        ? TxtDeleteNode
         : T extends ASTNodeTypes.DeleteExit
-        ? TxtParentNode // *Str*
+        ? TxtDeleteNode // *Str*
         : T extends ASTNodeTypes.Emphasis
-        ? TxtParentNode
+        ? TxtEmphasisNode
         : T extends ASTNodeTypes.EmphasisExit
-        ? TxtParentNode // __Str__
+        ? TxtEmphasisNode // __Str__
         : T extends ASTNodeTypes.Strong
-        ? TxtParentNode
+        ? TxtStrongNode
         : T extends ASTNodeTypes.StrongExit
-        ? TxtParentNode // Str<space><space>
+        ? TxtStrongNode // Str<space><space>
         : T extends ASTNodeTypes.Break
-        ? TxtNode
+        ? TxtBreakNode
         : T extends ASTNodeTypes.BreakExit
-        ? TxtNode // ![alt](https://example.com/img)
+        ? TxtBreakNode // ![alt](https://example.com/img)
         : T extends ASTNodeTypes.Image
-        ? TxtNode
+        ? TxtImageNode
         : T extends ASTNodeTypes.ImageExit
-        ? TxtNode // ----
+        ? TxtImageNode // ----
         : T extends ASTNodeTypes.HorizontalRule
-        ? TxtNode
+        ? TxtHorizontalRuleNode
         : T extends ASTNodeTypes.HorizontalRuleExit
-        ? TxtNode // <!-- Str -->
+        ? TxtHorizontalRuleNode // <!-- Str -->
         : T extends ASTNodeTypes.Comment
-        ? TxtTextNode
+        ? TxtCommentNode
         : T extends ASTNodeTypes.CommentExit
-        ? TxtTextNode // Str
+        ? TxtCommentNode // Str
         : T extends ASTNodeTypes.Str
-        ? TxtTextNode
+        ? TxtStrNode
         : T extends ASTNodeTypes.StrExit
-        ? TxtTextNode // `code`
+        ? TxtStrNode // `code`
         : T extends ASTNodeTypes.Code
-        ? TxtTextNode
+        ? TxtCodeBlockNode
         : T extends ASTNodeTypes.CodeExit
-        ? TxtTextNode // <span>Str</span>
+        ? TxtCodeBlockNode // <span>Str</span>
         : T extends ASTNodeTypes.Html
-        ? TxtTextNode
+        ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlExit
-        ? TxtTextNode
-        : any;
+        ? TxtHtmlNode
+        : AnyTxtNode;

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -17,7 +17,10 @@ import type {
     TxtListNode,
     TxtParagraphNode,
     TxtStrNode,
-    TxtStrongNode
+    TxtStrongNode,
+    TxtTableCellNode,
+    TxtTableNode,
+    TxtTableRowNode
 } from "./NodeType";
 
 /**
@@ -111,4 +114,16 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlExit
         ? TxtHtmlNode
+        : T extends ASTNodeTypes.Table
+        ? TxtTableNode
+        : T extends ASTNodeTypes.TableExit
+        ? TxtTableNode
+        : T extends ASTNodeTypes.TableRow
+        ? TxtTableRowNode
+        : T extends ASTNodeTypes.TableRowExit
+        ? TxtTableRowNode
+        : T extends ASTNodeTypes.TableCell
+        ? TxtTableCellNode
+        : T extends ASTNodeTypes.TableCellExit
+        ? TxtTableCellNode
         : AnyTxtNode;

--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -1,7 +1,7 @@
 import type { ASTNodeTypes } from "./ASTNodeTypes";
 import type {
     AnyTxtNode,
-    TxtBlockquoteNode,
+    TxtBlockQuoteNode,
     TxtBreakNode,
     TxtCodeBlockNode,
     TxtCommentNode,
@@ -12,6 +12,7 @@ import type {
     TxtHorizontalRuleNode,
     TxtHtmlNode,
     TxtImageNode,
+    TxtCodeNode,
     TxtLinkNode,
     TxtListItemNode,
     TxtListNode,
@@ -43,9 +44,9 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         : T extends ASTNodeTypes.ParagraphExit
         ? TxtParagraphNode
         : T extends ASTNodeTypes.BlockQuote // > Str
-        ? TxtBlockquoteNode
+        ? TxtBlockQuoteNode
         : T extends ASTNodeTypes.BlockQuoteExit
-        ? TxtBlockquoteNode
+        ? TxtBlockQuoteNode
         : T extends ASTNodeTypes.List // - item
         ? TxtListNode
         : T extends ASTNodeTypes.ListExit
@@ -107,9 +108,9 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
         : T extends ASTNodeTypes.StrExit
         ? TxtStrNode
         : T extends ASTNodeTypes.Code // `code`
-        ? TxtCodeBlockNode
+        ? TxtCodeNode
         : T extends ASTNodeTypes.CodeExit
-        ? TxtCodeBlockNode
+        ? TxtCodeNode
         : T extends ASTNodeTypes.Html // <span>Str</span>
         ? TxtHtmlNode
         : T extends ASTNodeTypes.HtmlExit

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -23,6 +23,9 @@ export type {
     TxtParagraphNode,
     TxtCodeNode,
     TxtStrNode,
-    TxtStrongNode
+    TxtStrongNode,
+    TxtTableNode,
+    TxtTableRowNode,
+    TxtTableCellNode
 } from "./NodeType";
 export type { TypeofTxtNode } from "./TypeofTxtNode";

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -1,6 +1,11 @@
 export { ASTNodeTypes } from "./ASTNodeTypes";
 export type {
+    // abstract
     AnyTxtNode,
+    TxtNode,
+    TxtParentNode,
+    TxtTextNode,
+    // node types
     TxtBlockquoteNode,
     TxtBreakNode,
     TxtCodeBlockNode,

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -1,134 +1,22 @@
-// MIT © 2017 azu
-"use strict";
-
-/**
- * AST Node types list on TxtNode.
- * Constant value of types
- * @see https://github.com/textlint/textlint/blob/master/docs/txtnode.md
- */
-import { TypeofTxtNode } from "./TypeofTxtNode";
-
-export enum ASTNodeTypes {
-    Document = "Document",
-    DocumentExit = "Document:exit",
-    Paragraph = "Paragraph",
-    ParagraphExit = "Paragraph:exit",
-    BlockQuote = "BlockQuote",
-    BlockQuoteExit = "BlockQuote:exit",
-    ListItem = "ListItem",
-    ListItemExit = "ListItem:exit",
-    List = "List",
-    ListExit = "List:exit",
-    Header = "Header",
-    HeaderExit = "Header:exit",
-    CodeBlock = "CodeBlock",
-    CodeBlockExit = "CodeBlock:exit",
-    HtmlBlock = "HtmlBlock",
-    HtmlBlockExit = "HtmlBlock:exit",
-    HorizontalRule = "HorizontalRule",
-    HorizontalRuleExit = "HorizontalRule:exit",
-    Comment = "Comment",
-    CommentExit = "Comment:exit",
-    /**
-     * @deprecated
-     */
-    ReferenceDef = "ReferenceDef",
-    /**
-     * @deprecated
-     */
-    ReferenceDefExit = "ReferenceDef:exit",
-    // inline
-    Str = "Str",
-    StrExit = "Str:exit",
-    Break = "Break", // well-known Hard Break
-    BreakExit = "Break:exit", // well-known Hard Break
-    Emphasis = "Emphasis",
-    EmphasisExit = "Emphasis:exit",
-    Strong = "Strong",
-    StrongExit = "Strong:exit",
-    Html = "Html",
-    HtmlExit = "Html:exit",
-    Link = "Link",
-    LinkExit = "Link:exit",
-    Image = "Image",
-    ImageExit = "Image:exit",
-    Code = "Code",
-    CodeExit = "Code:exit",
-    Delete = "Delete",
-    DeleteExit = "Delete:exit"
-}
-
-/**
- * Key of ASTNodeTypes or any string
- * For example, TxtNodeType is "Document".
- */
-export type TxtNodeType = keyof typeof ASTNodeTypes | string;
-
-/**
- * Type utility for TxtNodeType
- * Return TxtNode interface for the TxtNodeTYpe
- */
-export { TypeofTxtNode };
-
-/**
- * Any TxtNode types
- */
-export type AnyTxtNode = TxtNode | TxtTextNode | TxtParentNode;
-
-/**
- * Basic TxtNode
- * Probably, Real TxtNode implementation has more properties.
- */
-export interface TxtNode {
-    type: TxtNodeType;
-    raw: string;
-    range: TextNodeRange;
-    loc: TxtNodeLineLocation;
-    // parent is runtime information
-    // Not need in AST
-    // For example, top Root Node like `Document` has not parent.
-    parent?: TxtNode;
-
-    [index: string]: any;
-}
-
-/**
- * Location
- */
-export interface TxtNodeLineLocation {
-    start: TxtNodePosition;
-    end: TxtNodePosition;
-}
-
-/**
- * Position's line start with 1.
- * Position's column start with 0.
- * This is for compatibility with JavaScript AST.
- * https://gist.github.com/azu/8866b2cb9b7a933e01fe
- */
-export interface TxtNodePosition {
-    line: number; // start with 1
-    column: number; // start with 0
-}
-
-/**
- * Range starts with 0
- */
-export type TextNodeRange = readonly [startIndex: number, endIndex: number];
-
-/**
- * Text Node.
- * Text Node has inline value.
- * For example, `Str` Node is an TxtTextNode.
- */
-export interface TxtTextNode extends TxtNode {
-    value: string;
-}
-
-/**
- * Parent Node.
- * Parent Node has children that are consist of TxtNode or TxtTextNode
- */
-export interface TxtParentNode extends TxtNode {
-    children: Array<TxtNode | TxtTextNode>;
-}
+export { ASTNodeTypes } from "./ASTNodeTypes";
+export type {
+    AnyTxtNode,
+    TxtBlockquoteNode,
+    TxtBreakNode,
+    TxtCodeBlockNode,
+    TxtCommentNode,
+    TxtDeleteNode,
+    TxtDocumentNode,
+    TxtEmphasisNode,
+    TxtHeaderNode,
+    TxtHorizontalRuleNode,
+    TxtHtmlNode,
+    TxtImageNode,
+    TxtLinkNode,
+    TxtListItemNode,
+    TxtListNode,
+    TxtParagraphNode,
+    TxtStrNode,
+    TxtStrongNode
+} from "./NodeType";
+export type { TypeofTxtNode } from "./TypeofTxtNode";

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -1,6 +1,6 @@
 export { ASTNodeTypes } from "./ASTNodeTypes";
 export type {
-    // abstract
+    // abstract node types
     AnyTxtNode,
     TxtNode,
     TxtParentNode,

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -6,7 +6,7 @@ export type {
     TxtParentNode,
     TxtTextNode,
     // node types
-    TxtBlockquoteNode,
+    TxtBlockQuoteNode,
     TxtBreakNode,
     TxtCodeBlockNode,
     TxtCommentNode,
@@ -21,6 +21,7 @@ export type {
     TxtListItemNode,
     TxtListNode,
     TxtParagraphNode,
+    TxtCodeNode,
     TxtStrNode,
     TxtStrongNode
 } from "./NodeType";

--- a/packages/@textlint/types/test/Rule/TextlintRuleModule-test.ts
+++ b/packages/@textlint/types/test/Rule/TextlintRuleModule-test.ts
@@ -1,8 +1,6 @@
-import { TextlintRuleReporter } from "../../src";
-import { TextlintRuleModule, TextlintRuleOptions } from "../../src";
+import { TextlintRuleModule, TextlintRuleOptions, TextlintRuleReporter } from "../../src/index";
 
 const noop = (..._args: any[]) => {};
-
 // test any
 const report0: TextlintRuleReporter = (context, options = {}) => {
     const { Syntax } = context;
@@ -49,11 +47,13 @@ const report3: TextlintRuleReporter = (context, options = {}) => {
     const { Syntax } = context;
     console.log(options.custom);
     return {
-        [Syntax.Str]() {
+        [Syntax.Str](node) {
+            console.log(node.value);
             return;
         },
     };
 };
+
 const report3Module = { linter: report3, fixer: report3 } as TextlintRuleModule<Report3options>;
 
 noop(report0);

--- a/packages/@textlint/types/test/Rule/TxtNode-test.ts
+++ b/packages/@textlint/types/test/Rule/TxtNode-test.ts
@@ -19,6 +19,7 @@ import {
     TxtStrNode,
     TxtStrongNode,
 } from "@textlint/ast-node-types";
+import { TxtTableCellNode, TxtTableNode, TxtTableRowNode } from "@textlint/ast-node-types/lib/src/NodeType";
 import { TextlintRuleReporter } from "../../src/index";
 
 const noop = (..._args: any[]) => {};
@@ -134,6 +135,25 @@ const report: TextlintRuleReporter = (context) => {
         },
         [Syntax.HtmlExit](node) {
             expectType<TxtHtmlNode>(node);
+        },
+        [Syntax.Table](node) {
+            // eslint-disable-next-line no-undef
+            expectType<TxtTableNode>(node);
+        },
+        [Syntax.TableExit](node) {
+            expectType<TxtTableNode>(node);
+        },
+        [Syntax.TableRow](node) {
+            expectType<TxtTableRowNode>(node);
+        },
+        [Syntax.TableRowExit](node) {
+            expectType<TxtTableRowNode>(node);
+        },
+        [Syntax.TableCell](node) {
+            expectType<TxtTableCellNode>(node);
+        },
+        [Syntax.TableCellExit](node) {
+            expectType<TxtTableCellNode>(node);
         },
     };
 };

--- a/packages/@textlint/types/test/Rule/TxtNode-test.ts
+++ b/packages/@textlint/types/test/Rule/TxtNode-test.ts
@@ -1,0 +1,139 @@
+// Node type test
+import {
+    TxtBlockQuoteNode,
+    TxtBreakNode,
+    TxtCodeBlockNode,
+    TxtCommentNode,
+    TxtDeleteNode,
+    TxtDocumentNode,
+    TxtEmphasisNode,
+    TxtHeaderNode,
+    TxtHorizontalRuleNode,
+    TxtHtmlNode,
+    TxtCodeNode,
+    TxtImageNode,
+    TxtLinkNode,
+    TxtListItemNode,
+    TxtListNode,
+    TxtParagraphNode,
+    TxtStrNode,
+    TxtStrongNode,
+} from "@textlint/ast-node-types";
+import { TextlintRuleReporter } from "../../src/index";
+
+const noop = (..._args: any[]) => {};
+export const expectType = <Type>(_: Type): void => void 0;
+const report: TextlintRuleReporter = (context) => {
+    const { Syntax } = context;
+    return {
+        [Syntax.Document](node) {
+            expectType<TxtDocumentNode>(node);
+        },
+        [Syntax.DocumentExit](node) {
+            expectType<TxtDocumentNode>(node);
+        },
+        [Syntax.Paragraph](node) {
+            expectType<TxtParagraphNode>(node);
+        },
+        [Syntax.ParagraphExit](node) {
+            expectType<TxtParagraphNode>(node);
+        },
+        [Syntax.BlockQuote](node) {
+            expectType<TxtBlockQuoteNode>(node);
+        },
+        [Syntax.BlockQuoteExit](node) {
+            expectType<TxtBlockQuoteNode>(node);
+        },
+        [Syntax.List](node) {
+            expectType<TxtListNode>(node);
+        },
+        [Syntax.ListExit](node) {
+            expectType<TxtListNode>(node);
+        },
+        [Syntax.ListItem](node) {
+            expectType<TxtListItemNode>(node);
+        },
+        [Syntax.ListItemExit](node) {
+            expectType<TxtListItemNode>(node);
+        },
+        [Syntax.Header](node) {
+            expectType<TxtHeaderNode>(node);
+        },
+        [Syntax.HeaderExit](node) {
+            expectType<TxtHeaderNode>(node);
+        },
+        [Syntax.CodeBlock](node) {
+            expectType<TxtCodeBlockNode>(node);
+        },
+        [Syntax.CodeBlockExit](node) {
+            expectType<TxtCodeBlockNode>(node);
+        },
+        [Syntax.Link](node) {
+            expectType<TxtLinkNode>(node);
+        },
+        [Syntax.LinkExit](node) {
+            expectType<TxtLinkNode>(node);
+        },
+        [Syntax.Delete](node) {
+            expectType<TxtDeleteNode>(node);
+        },
+        [Syntax.DeleteExit](node) {
+            expectType<TxtDeleteNode>(node);
+        },
+        [Syntax.Emphasis](node) {
+            expectType<TxtEmphasisNode>(node);
+        },
+        [Syntax.EmphasisExit](node) {
+            expectType<TxtEmphasisNode>(node);
+        },
+        [Syntax.Strong](node) {
+            expectType<TxtStrongNode>(node);
+        },
+        [Syntax.StrongExit](node) {
+            expectType<TxtStrongNode>(node);
+        },
+        [Syntax.Break](node) {
+            expectType<TxtBreakNode>(node);
+        },
+        [Syntax.BreakExit](node) {
+            expectType<TxtBreakNode>(node);
+        },
+        [Syntax.Image](node) {
+            expectType<TxtImageNode>(node);
+        },
+        [Syntax.ImageExit](node) {
+            expectType<TxtImageNode>(node);
+        },
+        [Syntax.HorizontalRule](node) {
+            expectType<TxtHorizontalRuleNode>(node);
+        },
+        [Syntax.HorizontalRuleExit](node) {
+            expectType<TxtHorizontalRuleNode>(node);
+        },
+        [Syntax.Comment](node) {
+            expectType<TxtCommentNode>(node);
+        },
+        [Syntax.CommentExit](node) {
+            expectType<TxtCommentNode>(node);
+        },
+        [Syntax.Str](node) {
+            expectType<TxtStrNode>(node);
+        },
+        [Syntax.StrExit](node) {
+            expectType<TxtStrNode>(node);
+        },
+        [Syntax.Code](node) {
+            expectType<TxtCodeNode>(node);
+        },
+        [Syntax.CodeExit](node) {
+            expectType<TxtCodeNode>(node);
+        },
+        [Syntax.Html](node) {
+            expectType<TxtHtmlNode>(node);
+        },
+        [Syntax.HtmlExit](node) {
+            expectType<TxtHtmlNode>(node);
+        },
+    };
+};
+noop(report);

--- a/packages/@textlint/types/test/Rule/TxtNode-test.ts
+++ b/packages/@textlint/types/test/Rule/TxtNode-test.ts
@@ -23,6 +23,7 @@ import { TextlintRuleReporter } from "../../src/index";
 
 const noop = (..._args: any[]) => {};
 export const expectType = <Type>(_: Type): void => void 0;
+// Test: each node type match to AST node type
 const report: TextlintRuleReporter = (context) => {
     const { Syntax } = context;
     return {


### PR DESCRIPTION
- fix #764 as Breaking Changes
- ref #902 
- fix #740 as Feature
- close #944 - TxtNode is an abstract node that has common property. `children` is not common.

### All node types

These types are defined in [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).

| Type name                       | Node type                        | Description                          |
|---------------------------------|----------------------------------|--------------------------------------|
| ASTNodeTypes.Document           | TxtDocumentNode(TxtParentNode)   | Root Node                            |
| ASTNodeTypes.DocumentExit       | TxtDocumentNode(TxtParentNode)   |                                      |
| ASTNodeTypes.Paragraph          | TxtParagraphNode(TxtParentNode)  | Paragraph Node                       |
| ASTNodeTypes.ParagraphExit      | TxtParagraphNode(TxtParentNode)  |                                      |
| ASTNodeTypes.BlockQuote         | TxtBlockQuoteNode(TxtParentNode) | > Block Quote Node                   |
| ASTNodeTypes.BlockQuoteExit     | TxtBlockQuoteNode(TxtParentNode) |                                      |
| ASTNodeTypes.List               | TxtListNode(TxtParentNode)       | List Node                            |
| ASTNodeTypes.ListExit           | TxtListNode(TxtParentNode)       |                                      |
| ASTNodeTypes.ListItem           | TxtListItemNode(TxtParentNode)   | List (each) item Node                |
| ASTNodeTypes.ListItemExit       | TxtListItemNode(TxtParentNode)   |                                      |
| ASTNodeTypes.Header             | TxtHeaderNode(TxtParentNode)     | # Header Node                        |
| ASTNodeTypes.HeaderExit         | TxtHeaderNode(TxtParentNode)     |                                      |
| ASTNodeTypes.CodeBlock          | TxtCodeBlockNode(TxtParentNode)  | Code Block Node                      |
| ASTNodeTypes.CodeBlockExit      | TxtCodeBlockNode(TxtParentNode)  |                                      |
| ASTNodeTypes.HtmlBlock          | TxtHtmlBlockNode(TxtParentNode)  | HTML Block Node                      |
| ASTNodeTypes.HtmlBlockExit      | TxtHtmlBlockNode(TxtParentNode)  |                                      |
| ASTNodeTypes.Link               | TxtLinkNode(TxtParentNode)       | Link Node                            |
| ASTNodeTypes.LinkExit           | TxtLinkNode(TxtParentNode)       |                                      |
| ASTNodeTypes.Delete             | TxtDeleteNode(TxtParentNode)     | Delete Node(`~Str~`)                 |
| ASTNodeTypes.DeleteExit         | TxtDeleteNode(TxtParentNode)     |                                      |
| ASTNodeTypes.Emphasis           | TxtEmphasisNode(TxtParentNode)   | Emphasis(`*Str*`)                    |
| ASTNodeTypes.EmphasisExit       | TxtEmphasisNode(TxtParentNode)   |                                      |
| ASTNodeTypes.Strong             | TxtStrongNode(TxtParentNode)     | Strong Node(`**Str**`)               |
| ASTNodeTypes.StrongExit         | TxtStrongNode(TxtParentNode)     |                                      |
| ASTNodeTypes.Break              | TxtBreakNode                     | Hard Break Node(`Str<space><space>`) |
| ASTNodeTypes.BreakExit          | TxtBreakNode                     |                                      |
| ASTNodeTypes.Image              | TxtImageNode                     | Image Node                           |
| ASTNodeTypes.ImageExit          | TxtImageNode                     |                                      |
| ASTNodeTypes.HorizontalRule     | TxtHorizontalRuleNode            | Horizontal Node(`---`)               |
| ASTNodeTypes.HorizontalRuleExit | TxtHorizontalRuleNode            |                                      |
| ASTNodeTypes.Comment            | TxtCommentNode                   | Comment Node                         |
| ASTNodeTypes.CommentExit        | TxtCommentNode                   |                                      |
| ASTNodeTypes.Str                | TxtStrNode                       | Str Node                             |
| ASTNodeTypes.StrExit            | TxtStrNode                       |                                      |
| ASTNodeTypes.Code               | TxtCodeNode                      | Inline Code Node                     |
| ASTNodeTypes.CodeExit           | TxtCodeNode                      |                                      |
| ASTNodeTypes.Html               | TxtHtmlNode                      | Inline HTML Node                     |
| ASTNodeTypes.HtmlExit           | TxtHtmlNode                      |                                      |
| ASTNodeTypes.Table              | TxtTableNode                     | Table node. textlint 13+             |
| ASTNodeTypes.TableExit          | TxtTableNode                     |                                      |
| ASTNodeTypes.TableRow           | TxtTableRowNode                  | Table row node. textlint 13+         |
| ASTNodeTypes.TableRowExit       | TxtTableRowNode                  |                                      |
| ASTNodeTypes.TableCell          | TxtTableCellNode                 | Table cell node. textlint 13+        |
| ASTNodeTypes.TableCellExit      | TxtTableCellNode                 |                                      |

Some node have additional properties.
For example, `TxtHeaderNode` has `level` property.

```ts
export interface TxtHeaderNode extends TxtParentNode {
    type: "Header";
    depth: 1 | 2 | 3 | 4 | 5 | 6;
    children: PhrasingContent[];
}
```

For more details, see [`@textlint/ast-node-types`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types).

- [`@textlint/ast-node-types/src/NodeType.ts`](https://github.com/textlint/textlint/tree/master/packages/%40textlint/ast-node-types/src/NodeType.ts).
