### PR TITLE
fix(ast-node-types): export { TxtNodeRange, TxtNodeLocation, TxtNodePosition }

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -30,7 +30,7 @@ Each node has own properties that is defined in each node type.
 interface TxtNode {
     type: string;
     raw: string;
-    range: TextNodeRange;
+    range: TxtNodeRange;
     loc: TxtNodeLineLocation;
     // parent is runtime information
     // Not need in AST
@@ -63,8 +63,7 @@ interface TxtNodePosition {
 /**
  * Range start with 0
  */
-type TextNodeRange = [number, number];
-
+export type TxtNodeRange = readonly [startIndex: number, endIndex: number];
 ```
 
 `TxtNode` **must** have these properties.

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -33,7 +33,7 @@ export type TxtNodePosition = {
 /**
  * Location
  */
-export type TxtNodeLineLocation = {
+export type TxtNodeLocation = {
     start: TxtNodePosition;
     end: TxtNodePosition;
 };
@@ -41,7 +41,7 @@ export type TxtNodeLineLocation = {
 /**
  * Range starts with 0
  */
-export type TextNodeRange = readonly [startIndex: number, endIndex: number];
+export type TxtNodeRange = readonly [startIndex: number, endIndex: number];
 
 /**
  * TxtNode is abstract interface of AST Node.
@@ -50,8 +50,8 @@ export type TextNodeRange = readonly [startIndex: number, endIndex: number];
 export interface TxtNode {
     type: TxtNodeType;
     raw: string;
-    range: TextNodeRange;
-    loc: TxtNodeLineLocation;
+    range: TxtNodeRange;
+    loc: TxtNodeLocation;
     // `parent` is created by runtime
     parent?: TxtParentNode;
 

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -5,6 +5,10 @@ export type {
     TxtNode,
     TxtParentNode,
     TxtTextNode,
+    // properties
+    TxtNodeRange,
+    TxtNodeLocation,
+    TxtNodePosition,
     // node types
     TxtBlockQuoteNode,
     TxtBreakNode,


### PR DESCRIPTION
These are missing exports in v13.

- Rename `TextNodeRange` to `TxtNodeRange`. It is typo
- Rename `TxtNodeLineLocation` to `TxtNodeLocation`.
- export `{ TxtNodeRange, TxtNodeLocation, TxtNodePosition }`

```diff
- import type { TextNodeRange, TxtNodeLineLocation, TxtNodePosition } from "@textlint/ast-node-types";
+ import type { TxtNodeRange, TxtNodeLocation, TxtNodePosition } from "@textlint/ast-node-types";
```