### PR TITLE
fix(ast-node-types): export { TxtNodeType }

### DIFF
--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -3,9 +3,9 @@ export type {
     // abstract node types
     AnyTxtNode,
     TxtNode,
+    TxtNodeType,
     TxtParentNode,
     TxtTextNode,
-    TxtNodeType,
     // properties
     TxtNodeRange,
     TxtNodeLocation,

--- a/packages/@textlint/ast-node-types/src/index.ts
+++ b/packages/@textlint/ast-node-types/src/index.ts
@@ -5,6 +5,7 @@ export type {
     TxtNode,
     TxtParentNode,
     TxtTextNode,
+    TxtNodeType,
     // properties
     TxtNodeRange,
     TxtNodeLocation,


### PR DESCRIPTION
Add `TxtNodeType` as public API.
v12 exported it.