### PR TITLE
fix(ast-node-types): remove markdown extension && fix TxtNodeType

### DIFF
--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -12,7 +12,7 @@ import type { ASTNodeTypes } from "./ASTNodeTypes";
  * Key of ASTNodeTypes or any string
  * For example, TxtNodeType is "Document".
  */
-export type TxtNodeType = keyof typeof ASTNodeTypes | string;
+export type TxtNodeType = keyof typeof ASTNodeTypes;
 
 /**
  * Any TxtNode types
@@ -86,10 +86,10 @@ export type Content = TopLevelContent | ListContent | TableContent | RowContent 
 /**
  * All node definition types.
  */
-export type TopLevelContent = BlockContent | DefinitionContent;
+export type TopLevelContent = BlockContent;
 /**
  * All node types that may be used where markdown block content is accepted.
- * These types are accepted inside block quotes, list items, footnotes, and roots.
+ * These types are accepted inside block quotes, list items, and roots.
  */
 export type BlockContent =
     | TxtParagraphNode
@@ -100,8 +100,6 @@ export type BlockContent =
     | TxtTableNode
     | TxtHtmlNode
     | TxtCodeBlockNode;
-
-export type DefinitionContent = TxtDefinitionNode | TxtFootnoteDefinitionNode;
 /**
  * All node types that are acceptable inside lists.
  */
@@ -117,7 +115,7 @@ export type RowContent = TxtTableCellNode;
 /**
  * All node types that are acceptable in a (interactive) phrasing context (so not in links).
  */
-export type PhrasingContent = TxtLinkNode | TxtLinkReferenceNode | StaticPhrasingContent;
+export type PhrasingContent = TxtLinkNode | StaticPhrasingContent;
 /**
  * All node types that are acceptable in a static phrasing context.
  */
@@ -129,10 +127,7 @@ export type StaticPhrasingContent =
     | TxtHtmlNode
     | TxtCodeNode
     | TxtBreakNode
-    | TxtImageNode
-    | TxtImageReferenceNode
-    | TxtFootnoteNode
-    | TxtFootnoteReferenceNode;
+    | TxtImageNode;
 
 export interface TxtDocumentNode extends TxtParentNode {
     type: "Document";
@@ -154,8 +149,8 @@ export interface TxtHorizontalRuleNode extends TxtNode {
 }
 
 export interface TxtBlockQuoteNode extends TxtParentNode {
-    type: "Blockquote";
-    children: Array<BlockContent | DefinitionContent>;
+    type: "BlockQuote";
+    children: BlockContent[];
 }
 
 export interface TxtListNode extends TxtParentNode {
@@ -170,7 +165,7 @@ export interface TxtListItemNode extends TxtParentNode {
     type: "ListItem";
     checked?: boolean | null | undefined;
     spread?: boolean | null | undefined;
-    children: (BlockContent | DefinitionContent)[];
+    children: BlockContent[];
 }
 
 export interface TxtTableNode extends TxtParentNode {
@@ -203,15 +198,6 @@ export interface TxtCodeBlockNode extends TxtTextNode {
     meta?: string | null | undefined;
 }
 
-export interface TxtDefinitionNode extends Node, TxtAssociation, TxtResource {
-    type: "Definition";
-}
-
-export interface TxtFootnoteDefinitionNode extends TxtParentNode, TxtAssociation {
-    type: "FootnoteDefinition";
-    children: (BlockContent | DefinitionContent)[];
-}
-
 export interface TxtStrNode extends TxtTextNode {
     type: "Str";
 }
@@ -231,8 +217,9 @@ export interface TxtDeleteNode extends TxtParentNode {
     children: PhrasingContent[];
 }
 
+// Inline Code
 export interface TxtCodeNode extends TxtTextNode {
-    type: "InlineCode";
+    type: "Code";
 }
 
 export interface TxtBreakNode extends TxtNode {
@@ -240,30 +227,12 @@ export interface TxtBreakNode extends TxtNode {
 }
 
 export interface TxtLinkNode extends TxtParentNode, TxtResource {
-    type: "link";
+    type: "Link";
     children: StaticPhrasingContent[];
 }
 
 export interface TxtImageNode extends Node, TxtResource, TxtAlternative {
     type: "Image";
-}
-
-export interface TxtLinkReferenceNode extends TxtParentNode, TxtReference {
-    type: "LinkReference";
-    children: StaticPhrasingContent[];
-}
-
-export interface TxtImageReferenceNode extends Node, TxtReference, TxtAlternative {
-    type: "ImageReference";
-}
-
-export interface TxtFootnoteNode extends TxtParentNode {
-    type: "Footnote";
-    children: PhrasingContent[];
-}
-
-export interface TxtFootnoteReferenceNode extends Node, TxtAssociation {
-    type: "FootnoteReference";
 }
 
 // Mixin
@@ -277,19 +246,6 @@ export interface TxtAssociation {
     label?: string | null | undefined;
 }
 
-export interface TxtReference extends TxtAssociation {
-    referenceType: ReferenceType;
-}
-
 export interface TxtAlternative {
     alt?: string | null | undefined;
-}
-
-// ================================================================================
-// Markdown extension
-// It is not part of the original markdown spec, but textlint does not support it officially.
-// https://www.npmjs.com/package/@types/mdast
-// ================================================================================
-export interface TxtYAMLNode extends TxtTextNode {
-    type: "Yaml";
 }

--- a/packages/@textlint/kernel/src/context/TextlintRuleContextImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRuleContextImpl.ts
@@ -93,7 +93,7 @@ export class TextlintRuleContextImpl implements TextlintRuleContext {
     /**
      * report function that is called in a rule
      */
-    report = (node: TxtNode, ruleError: TextlintRuleError | TextlintRuleReportedObject, _shouldNotUsed?: any) => {
+    report = (node: TxtNode, ruleError: TextlintRuleError | TextlintRuleReportedObject, _shouldNotUsed?: never) => {
         invariant(
             !(node instanceof TextlintRuleErrorImpl),
             "1st argument should be node. Usage: `report(node, ruleError);`"

--- a/packages/@textlint/kernel/test/helper/BinaryPlugin.ts
+++ b/packages/@textlint/kernel/test/helper/BinaryPlugin.ts
@@ -10,7 +10,7 @@ export interface CreateBinaryPluginOptions {
     extensions?: string[];
     /**
      * Return the text instead of file content.
-     * It simulate intermediate text for a binary,
+     * It simulates intermediate text for a binary,
      */
     dummyText?: string;
 }
@@ -70,7 +70,7 @@ export const createBinaryPluginStub = (options?: CreateBinaryPluginOptions) => {
                                 preProcessArgs = { text, filePath };
                                 const dummyText = (options && options.dummyText) || "this is binary";
                                 const ast = {
-                                    type: "Document",
+                                    type: "Document" as const,
                                     raw: dummyText,
                                     range: [0, dummyText.length] as const,
                                     loc: {

--- a/packages/@textlint/kernel/test/source-location/source-location-test.ts
+++ b/packages/@textlint/kernel/test/source-location/source-location-test.ts
@@ -25,7 +25,7 @@ describe("source-location", function () {
     context("message only", function () {
         it("should return node's start location", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -42,7 +42,7 @@ describe("source-location", function () {
             coreFlags.runningTester = false;
 
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -60,7 +60,7 @@ describe("source-location", function () {
         context("[textlint-tester] when testing", function () {
             it("should throw error in testing.", function () {
                 const node = {
-                    type: "String",
+                    type: "Str" as const,
                     range: [10, 20] as const,
                     raw: "1234567890",
                     loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -75,7 +75,7 @@ describe("source-location", function () {
     context("[deprecated] index only", function () {
         it("should return column, line", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -91,7 +91,7 @@ describe("source-location", function () {
     context("[deprecated] index and column", function () {
         it("should throw error", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -104,7 +104,7 @@ describe("source-location", function () {
         });
         it("should throw error with RuleName", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -207,7 +207,7 @@ describe("source-location", function () {
     context("paddingObject is plain object", function () {
         it("should accept this that same as RuleError", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -235,7 +235,7 @@ describe("source-location", function () {
         });
         it("fix should accept this that same as RuleError", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -254,7 +254,7 @@ describe("source-location", function () {
     describe("resolveFixCommandLocation", function () {
         it("should return {fix}", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -270,7 +270,7 @@ describe("source-location", function () {
         });
         it("range should be absolute of value", function () {
             const node = {
-                type: "String",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "1234567890",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -287,7 +287,7 @@ describe("source-location", function () {
         });
         it("should not adjust fix command range - because it is absolute position", function () {
             const node = {
-                type: "Str",
+                type: "Str" as const,
                 range: [10, 20] as const,
                 raw: "dummy",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }
@@ -302,7 +302,7 @@ describe("source-location", function () {
         });
         it("is not adjust fix command range - because it is absolute position", function () {
             const node: TxtNode = {
-                type: "Str",
+                type: "Str" as const,
                 range: [10, 20],
                 raw: "dummy",
                 loc: { start: { line: 1, column: 10 }, end: { line: 1, column: 20 } }

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -31,6 +31,7 @@ export function parse<T extends TxtNode>(text: string): T {
                 if (!replacedType) {
                     debug(`replacedType : ${replacedType} , node.type: ${node.type}`);
                 } else {
+                    // @ts-expect-error: TxtNodeType + Markdown extension type
                     node.type = replacedType;
                 }
             }

--- a/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
+++ b/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
@@ -37,4 +37,4 @@ export const SyntaxMap = {
      * @deprecated
      */
     ReferenceDef: ASTNodeTypes.ReferenceDef
-};
+} as const;

--- a/packages/@textlint/text-to-ast/src/plaintext-syntax.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-syntax.ts
@@ -8,4 +8,4 @@ export const Syntax = {
     // inline
     Str: ASTNodeTypes.Str, // must
     Break: ASTNodeTypes.Break // must
-};
+} as const;

--- a/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
@@ -23,5 +23,5 @@ export type TextlintRuleContextReportFunction = (args: TextlintRuleContextReport
 
 export interface TextlintRuleContext extends TextlintBaseRuleContext {
     fixer: TextlintRuleContextFixCommandGenerator;
-    report: (node: TxtNode, ruleError: TextlintRuleReportedObject | TextlintRuleError, _shouldNotUsed?: any) => void;
+    report: (node: TxtNode, ruleError: TextlintRuleReportedObject | TextlintRuleError, _shouldNotUsed?: never) => void;
 }

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -1,7 +1,7 @@
 /**
  * Rule reporter function
  */
-import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
+import { AnyTxtNode, ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
 import { TextlintRuleOptions } from "./TextlintRuleOptions";
 import { TextlintRuleContext } from "./TextlintRuleContext";
 /**
@@ -13,7 +13,7 @@ import { TextlintRuleContext } from "./TextlintRuleContext";
  * Each comment is example value of Markdown
  */
 export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> } & {
-    [index: string]: (node: any) => void | Promise<any>;
+    [index: string]: (node: AnyTxtNode) => void | Promise<any>;
 };
 
 /**

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -13,7 +13,7 @@ import { TextlintRuleContext } from "./TextlintRuleContext";
  * Each comment is example value of Markdown
  */
 export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> } & {
-    [index: string]: (node: AnyTxtNode) => void | Promise<any>;
+    [index: string]: (node: any) => void | Promise<any>;
 };
 
 /**

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -1,9 +1,10 @@
 /**
  * Rule reporter function
  */
-import { AnyTxtNode, ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
+import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
 import { TextlintRuleOptions } from "./TextlintRuleOptions";
 import { TextlintRuleContext } from "./TextlintRuleContext";
+
 /**
  * Rule Reporter Handler object define handler for each TxtNode type.
  *
@@ -13,6 +14,7 @@ import { TextlintRuleContext } from "./TextlintRuleContext";
  * Each comment is example value of Markdown
  */
 export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxtNode<P>) => void | Promise<any> } & {
+    // TODO: node should be AnyNodeType
     [index: string]: (node: any) => void | Promise<any>;
 };
 

--- a/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.ts
+++ b/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.ts
@@ -6,6 +6,9 @@ import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types"
 const reporter = (context: TextlintRuleContext): TextlintRuleReportHandler => {
     const { Syntax, fixer, report, getSource } = context;
     return {
+        ["test"](_node) {
+            // console.log(node);
+        },
         [Syntax.Str](node) {
             const text = getSource(node);
             if (/\.$/.test(text)) {

--- a/packages/textlint/test/rule-context/rule-context-test.ts
+++ b/packages/textlint/test/rule-context/rule-context-test.ts
@@ -287,6 +287,7 @@ describe("rule-context-test", function () {
                 "rule-key"(context: TextlintRuleContext): TextlintRuleReportHandler {
                     return {
                         [context.Syntax.Str](node) {
+                            // @ts-expect-error - it is test!
                             context.report(node, new context.RuleError("message"), {
                                 index: 1
                             });


### PR DESCRIPTION
- Correct `type` value in some Nodes
- Remove Markdown Extension from ast-node-types
- Remove `string` from `TxtNodeType`
  - It make `TxtNodeType` as `string`
- `_shouldNotUsed` use `never` type