### PR TITLE
fix(ast-node-type): fix Node → TxtNode

### DIFF
--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -231,7 +231,7 @@ export interface TxtLinkNode extends TxtParentNode, TxtResource {
     children: StaticPhrasingContent[];
 }
 
-export interface TxtImageNode extends Node, TxtResource, TxtAlternative {
+export interface TxtImageNode extends TxtNode, TxtResource, TxtAlternative {
     type: "Image";
 }
 

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -241,11 +241,6 @@ export interface TxtResource {
     title?: string | null | undefined;
 }
 
-export interface TxtAssociation {
-    identifier: string;
-    label?: string | null | undefined;
-}
-
 export interface TxtAlternative {
     alt?: string | null | undefined;
 }

--- a/packages/@textlint/ast-node-types/tsconfig.json
+++ b/packages/@textlint/ast-node-types/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "lib": [
+      "esnext"
+      // "dom"
+    ]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/types/tsconfig.json
+++ b/packages/@textlint/types/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "lib": [
+      "esnext"
+      // "dom"
+    ]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
`Node` is DOM Node!
It is wrong type.

- `Node` to `TxtNode` 
- Prevent same mistake by `lib`