### PR TITLE
textlint: improve debug log

### DIFF
--- a/packages/@textlint/kernel/src/textlint-kernel.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel.ts
@@ -136,10 +136,7 @@ export class TextlintKernel {
         if (plugin === undefined) {
             throw new Error(`Not found available plugin for ${ext}`);
         }
-        debug("used plugin %j", {
-            pluginId: plugin.id,
-            availableExtensions: descriptor.availableExtensions
-        });
+        debug("used plugin %j", plugin.id);
         const processor = plugin.processor;
         const { preProcess, postProcess } = processor.processor(ext);
         invariant(
@@ -223,10 +220,7 @@ See https://textlint.github.io/docs/plugin.html`
         if (plugin === undefined) {
             throw new Error(`Not found available plugin for ${ext}`);
         }
-        debug("used plugin %j", {
-            pluginId: plugin.id,
-            availableExtensions: descriptor.availableExtensions
-        });
+        debug("used plugin %j", plugin.id);
         const processor = plugin.processor;
         const { preProcess, postProcess } = processor.processor(ext);
         invariant(

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -29,13 +29,17 @@ const isStdinExecution = (executeOptions: ExecuteOptions): executeOptions is Std
 
 const loadDescriptor = async (cliOptions: CliOptions) => {
     const cliDescriptor = await loadCliDescriptor(cliOptions);
+    debug("cliDescriptor: %j", cliDescriptor);
     const textlintrcDescriptor = cliOptions.textlintrc
         ? await loadTextlintrc({
               configFilePath: cliOptions.config,
               node_modulesDir: cliOptions.rulesBaseDirectory
           })
         : await loadBuiltinPlugins();
-    return cliDescriptor.concat(textlintrcDescriptor);
+    debug("textlintrcDescriptor: %j", textlintrcDescriptor);
+    const mergedDescriptor = cliDescriptor.concat(textlintrcDescriptor);
+    debug("mergedDescriptor: %j", mergedDescriptor);
+    return mergedDescriptor;
 };
 /**
  * Encapsulates all CLI behavior for eslint. Makes it easier to test as well as
@@ -60,6 +64,7 @@ export const cli = {
             return Promise.resolve(1);
         }
         const files = currentOptions._;
+        debug("cliOptions: %j", currentOptions);
         if (currentOptions.version) {
             Logger.log(`v${version}`);
         } else if (currentOptions.init) {

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -66,8 +66,9 @@ export const createLinter = (options: CreateLinterOptions) => {
             const { availableFiles, unAvailableFiles } = separateByAvailability(targetFiles, {
                 extensions: options.descriptor.availableExtensions
             });
-            debug("Process files", availableFiles);
-            debug("No Process files that are un-support extensions:", unAvailableFiles);
+            debug("Available extensions: %j", options.descriptor.availableExtensions);
+            debug("Process files: %j", availableFiles);
+            debug("No Process files that are un-support extensions: %j", unAvailableFiles);
             return executeFileBackerManger.process(availableFiles, async (filePath) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");
@@ -98,8 +99,9 @@ export const createLinter = (options: CreateLinterOptions) => {
             const { availableFiles, unAvailableFiles } = separateByAvailability(targetFiles, {
                 extensions: options.descriptor.availableExtensions
             });
-            debug("Process files", availableFiles);
-            debug("No Process files that are un-support extensions:", unAvailableFiles);
+            debug("Available extensions: %j", options.descriptor.availableExtensions);
+            debug("Process files: %j", availableFiles);
+            debug("No Process files that are un-support extensions: %j", unAvailableFiles);
             return executeFileBackerManger.process(availableFiles, async (filePath) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");

--- a/website/.textlintrc
+++ b/website/.textlintrc
@@ -37,7 +37,6 @@
         "weasel",
         "readibility"
       ]
-    },
-    "alex": false
+    }
   }
 }


### PR DESCRIPTION
improve textlint debug log

- add descriptors
- add cliOptions
- simplify process files

```
❯ npx textlint --debug "docs/**" --config ./website/.textlintrc
  textlint:cli cliOptions: {"debug":true,"config":"./website/.textlintrc","ignorePath":"/Users/azu/ghq/github.com/textlint/textlint/.textlintignore","init":false,"stdin":false,"format":"stylish","color":true,"quiet":false,"textlintrc":true,"cache":false,"cacheLocation":"/Users/azu/ghq/github.com/textlint/textlint/.textlintcache","_":["docs/**"]} +0ms
  textlint:cli textlint --version: 13.1.1 +1ms
  textlint:cli Running on files, stdin-filename: undefined +0ms
  textlint:cli cliDescriptor: {"rule":[],"filterRule":[],"plugin":[]} +0ms
  textlint:cli textlintrcDescriptor: {"rule":[{"ruleId":"eslint","options":{"configFile":"./.eslintrc.js"}},{"ruleId":"prh","options":{"rulePaths":["./prh.yml"]}},{"ruleId":"unexpanded-acronym","options":{"ignore_acronyms":["SCG","CLI","XML","YAML","JSON","TODO","API","HTML","MIT","FAQ","VIEW"]}},{"ruleId":"rousseau","options":{"showLevels":["warning","error"],"ignoreTypes":["sentence:uppercase","passive","weasel","readibility"]}}],"filterRule":[{"id":"comments","rawOptions":true}],"plugin":[{"id":"@textlint/textlint-plugin-text","rawOptions":true},{"id":"@textlint/textlint-plugin-markdown","rawOptions":true}],"configBaseDir":"/Users/azu/ghq/github.com/textlint/textlint/website"} +138ms
  textlint:cli mergedDescriptor: {"rule":[{"ruleId":"eslint","options":{"configFile":"./.eslintrc.js"}},{"ruleId":"prh","options":{"rulePaths":["./prh.yml"]}},{"ruleId":"unexpanded-acronym","options":{"ignore_acronyms":["SCG","CLI","XML","YAML","JSON","TODO","API","HTML","MIT","FAQ","VIEW"]}},{"ruleId":"rousseau","options":{"showLevels":["warning","error"],"ignoreTypes":["sentence:uppercase","passive","weasel","readibility"]}}],"filterRule":[{"id":"comments","rawOptions":true}],"plugin":[{"id":"@textlint/textlint-plugin-text","rawOptions":true},{"id":"@textlint/textlint-plugin-markdown","rawOptions":true}],"configBaseDir":"/Users/azu/ghq/github.com/textlint/textlint/website"} +0ms
  textlint:find-util findFiles ignore baseDir: /Users/azu/ghq/github.com/textlint/textlint, normalizeIgnoreFilePath: /Users/azu/ghq/github.com/textlint/textlint/.textlintignore +0ms
  textlint:find-util search patterns: [ 'docs/**' ] +0ms
  textlint:find-util search ignore patterns: [ '**/.git/**', '**/node_modules/**' ] +1ms
  textlint:createTextlint Available extensions: [".txt",".text",".md",".markdown",".mdown",".mkdn",".mkd",".mdwn",".mkdown",".ron"] +0ms
  textlint:createTextlint Process files: ["/Users/azu/ghq/github.com/textlint/textlint/docs/cli.md","/Users/azu/ghq/github.com/textlint/textlint/docs/configuring.md","/Users/azu/ghq/github.com/textlint/textlint/docs/CONTRIBUTING.md","/Users/azu/ghq/github.com/textlint/textlint/docs/faq/failed-to-load-textlints-module.md","/Users/azu/ghq/github.com/textlint/textlint/docs/faq/line-column-or-index.md","/Users/azu/ghq/github.com/textlint/textlint/docs/filter-rule.md","/Users/azu/ghq/github.com/textlint/textlint/docs/formatter.md","/Users/azu/ghq/github.com/textlint/textlint/docs/getting-started.md","/Users/azu/ghq/github.com/textlint/textlint/docs/ignore.md","/Users/azu/ghq/github.com/textlint/textlint/docs/integrations.md","/Users/azu/ghq/github.com/textlint/textlint/docs/plugin.md","/Users/azu/ghq/github.com/textlint/textlint/docs/README.md","/Users/azu/ghq/github.com/textlint/textlint/docs/rule-advanced.md","/Users/azu/ghq/github.com/textlint/textlint/docs/rule-fixable.md","/Users/azu/ghq/github.com/textlint/textlint/docs/rule-preset.md","/Users/azu/ghq/github.com/textlint/textlint/docs/rule-tips-after-all.md","/Users/azu/ghq/github.com/textlint/textlint/docs/rule.md","/Users/azu/ghq/github.com/textlint/textlint/docs/txtnode.md","/Users/azu/ghq/github.com/textlint/textlint/docs/use-as-modules.md"] +0ms
  textlint:createTextlint No Process files that are un-support extensions: ["/Users/azu/ghq/github.com/textlint/textlint/docs/assets/architecture.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/ast-explorer.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/fixable-error.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/linter-textlint.gif","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/markdown-to-ast.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/rule-preset-plugin.graphml","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/rule-preset-plugin.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/screenshot-lint-error.png","/Users/azu/ghq/github.com/textlint/textlint/docs/assets/screenshot-lint-pretty-error.png","/Users/azu/ghq/github.com/textlint/textlint/docs/example/rules/example-rule.js"] +0ms
  textlint:kernel used plugin "@textlint/textlint-plugin-markdown" +0ms
  textlint:kernel process file /Users/azu/ghq/github.com/textlint/textlint/docs/cli.md +16ms
  textlint:kernel used plugin "@textlint/textlint-plugin-markdown" +246ms
  textlint:kernel process file /Users/azu/ghq/github.com/textlint/textlint/docs/configuring.md +17ms
  textlint:kernel used plugin "@textlint/textlint-plugin-markdown" +46ms
```