### PR TITLE
fix(textlint): Add `engines` to require Node.js 16+

### DIFF
--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -97,7 +97,7 @@
         "typescript": "~4.9.4"
     },
     "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=16.0.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
textlint v13 require Node.js 16.0.0>=

fix #1042 