### PR TITLE
docs: fix parameters of loadTextlintrc

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -43,7 +43,7 @@ Lint files and output to console.
 import { createLinter, loadTextlintrc, loadLinterFormatter } from "textlint";
 // descriptor is a structure object for linter
 // It includes rules, plugins, and options
-const descriptor = await loadTextlintrc();
+const descriptor = await loadTextlintrc({});
 const linter = createLinter({
     descriptor
 });
@@ -60,7 +60,7 @@ Fix text and get the fixed text.
 import { createLinter, loadTextlintrc, loadFixerFormatter } from "textlint";
 // descriptor is a structure object for linter
 // It includes rules, plugins, and options
-const descriptor = await loadTextlintrc();
+const descriptor = await loadTextlintrc({});
 const linter = createLinter({
     descriptor
 });
@@ -89,7 +89,7 @@ const customDescriptor = new TextlintKernelDescriptor({
         }
     ]
 });
-const textlintrcDescriptor = await loadTextlintrc();
+const textlintrcDescriptor = await loadTextlintrc({});
 const linter = createLinter({
     // merge customDescriptor and textlintrcDescriptor
     // if same ruleId or pluginId, customDescriptor is used.
@@ -104,7 +104,7 @@ Get lintable file extensions.
 
 ```ts
 import { createLinter, loadTextlintrc } from "textlint";
-const textlintrcDescriptor = await loadTextlintrc();
+const textlintrcDescriptor = await loadTextlintrc({});
 const availableExtensions = textlintrcDescriptor.availableExtensions;
 console.log(availableExtensions); // => [".md", ".txt"]
 ```


### PR DESCRIPTION
```
$ cat test.js
const {loadTextlintrc} = require("textlint");

(async function () {
    const descriptor = await loadTextlintrc();
})()

$ node test.js
/path/to/node_modules/textlint/lib/src/loader/TextlintrcLoader.js:35
const loadTextlintrc = async ({ configFilePath, node_modulesDir }) => {
                                ^

TypeError: Cannot destructure property 'configFilePath' of 'undefined' as it is undefined.
    at loadTextlintrc (/path/to/node_modules/textlint/lib/src/loader/TextlintrcLoader.js:35:33)
    at /path/to/test.js:4:30
    at Object.<anonymous> (/path/to/test.js:5:3)
    at Module._compile (node:internal/modules/cjs/loader:1275:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1329:10)
    at Module.load (node:internal/modules/cjs/loader:1133:32)
    at Module._load (node:internal/modules/cjs/loader:972:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47

Node.js v19.7.0
```

I fix parameters of `loadTextlintrc` in a doc because that function needs parameters.