### PR TITLE
fix(@textlint/linter-formatter, @textlint/fixer-formatter): allow missing parameters for loadFormatter

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -49,7 +49,7 @@ const linter = createLinter({
 });
 const results = await linter.lintFiles(["*.md"]);
 // textlint has two types formatter sets for linter and fixer
-const formatter = await loadLinterFormatter({ formatterName: "stylish" })
+const formatter = await loadLinterFormatter()
 const output = formatter.format(results);
 console.log(output);
 ```

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -23,7 +23,7 @@ const debug = debug0("textlint:textfix-formatter");
 
 export type FormatterConfig = { color?: boolean; formatterName: string };
 
-export async function loadFormatter(formatterConfig: FormatterConfig) {
+export async function loadFormatter(formatterConfig: FormatterConfig = { formatterName: "stylish" }) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
     let formatter: (results: TextlintFixResult[], formatterConfig: FormatterConfig) => string;

--- a/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter-test.ts
+++ b/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter-test.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import assert from "assert";
-import { getFixerFormatterList } from "../src";
+import { getFixerFormatterList, loadFormatter } from "../src";
 
 describe("@textlint/fixer-formatter-test", function () {
     describe("getFormatterList", function () {
@@ -14,5 +14,10 @@ describe("@textlint/fixer-formatter-test", function () {
                 { name: "stylish" }
             ]);
         });
+    });
+    describe("loadFormatter", async function () {
+        assert.doesNotThrow(async () => {
+            await loadFormatter();
+        }, TypeError);
     });
 });

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -28,7 +28,7 @@ export interface FormatterConfig {
     color?: boolean;
 }
 
-export async function loadFormatter(formatterConfig: FormatterConfig) {
+export async function loadFormatter(formatterConfig: FormatterConfig = { formatterName: "stylish" }) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
     let formatter: (results: TextlintResult[], formatterConfig: FormatterConfig) => string;

--- a/packages/@textlint/linter-formatter/test/textlint-formatter-test.ts
+++ b/packages/@textlint/linter-formatter/test/textlint-formatter-test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import { createFormatter, getFormatterList } from "@textlint/linter-formatter";
+import { createFormatter, getFormatterList, loadFormatter } from "@textlint/linter-formatter";
 
 import * as path from "path";
 import * as assert from "assert";
@@ -201,5 +201,10 @@ describe("@textlint/linter-formatter-test", function () {
                 { name: "unix" }
             ]);
         });
+    });
+    describe("loadFormatter", async function () {
+        assert.doesNotThrow(async () => {
+            await loadFormatter();
+        }, TypeError);
     });
 });


### PR DESCRIPTION
In CLI, default formatter is `stylish`.
Therefore, I also make `stylish` the default formatter in modules.