### PR TITLE
fix(textlint): fix to print results when the `--dry-run` option is specified.

### DIFF
--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -138,7 +138,7 @@ export const cli = {
             // --dry-run
             if (cliOptions.dryRun) {
                 debug("Enable dry-run mode");
-                return Promise.resolve(0);
+                return printResults(output, cliOptions) ? Promise.resolve(0) : Promise.resolve(2);
             }
             // modify file and return exit status
             await fixer.write(results);

--- a/packages/textlint/test/cli/cli-test.ts
+++ b/packages/textlint/test/cli/cli-test.ts
@@ -311,6 +311,17 @@ describe("cli-test", function () {
                 const resultContent = await fs.promises.readFile(targetFilePath, "utf-8");
                 assert.strictEqual(resultContent, inputContent);
             });
+            it("should not modify the file when --dry-run and output result contents when --stdin is given", async () => {
+                return runWithMockLog(async ({ getLogs }) => {
+                    const ruleDir = path.join(__dirname, "fixtures/fixer-rules");
+                    const result = await cli.execute(
+                        `--rulesdir ${ruleDir} --fix --dry-run --stdin --stdin-filename test.md --format fixed-result`,
+                        "This is fix<REMOVE_MARK>"
+                    );
+                    assert.strictEqual(getLogs()[0], `This is fixed.`);
+                    assert.strictEqual(result, 0);
+                });
+            });
         });
     });
 


### PR DESCRIPTION
This PR attempts to fix to print results when the `--dry-run` option is specified.


fixes: #1091

## TEST
```sh
>>> echo 'jquery' | npx textlint --fix --dry-run --stdin --stdin-filename test.md --format fixed-result --rule 'textlint-rule-terminology'
jQuery
```
