### PR TITLE
docs: Add semicolon in code

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -49,7 +49,7 @@ const linter = createLinter({
 });
 const results = await linter.lintFiles(["*.md"]);
 // textlint has two types formatter sets for linter and fixer
-const formatter = await loadLinterFormatter({ formatterName: "stylish" })
+const formatter = await loadLinterFormatter({ formatterName: "stylish" });
 const output = formatter.format(results);
 console.log(output);
 ```


### PR DESCRIPTION
 I add a semicolon in the README's code since there is code without a semicolon.