### PR TITLE
textlint-scripts: add typescript and ts-node as peerDependencies

### DIFF
--- a/packages/textlint-scripts/configs/ts-node-register.js
+++ b/packages/textlint-scripts/configs/ts-node-register.js
@@ -3,7 +3,7 @@
  * It does transpile and type-check.
  *
  * Note: It does not babel-plugin-static-fs
- * Some behavior is a bit difference
+ * Some behavior is a bit of difference
  */
 const fs = require("fs");
 const paths = require("../configs/paths");

--- a/packages/textlint-scripts/package.json
+++ b/packages/textlint-scripts/package.json
@@ -51,6 +51,18 @@
         "pkg-to-readme": "^1.1.2",
         "textlint-tester": "^13.3.1"
     },
+    "peerDependencies": {
+        "typescript": "*",
+        "ts-node": "*"
+    },
+    "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+    },
     "prettier": {
         "singleQuote": false,
         "printWidth": 120,


### PR DESCRIPTION
Add `peerDependnecies` to `textlint-scripts`, but it is optional.