### PR TITLE
chore(deps): remove unused optionator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32980,7 +32980,6 @@
         "is-file": "^1.0.0",
         "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
-        "optionator": "^0.9.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -41,7 +41,6 @@
         "is-file": "^1.0.0",
         "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
-        "optionator": "^0.9.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",


### PR DESCRIPTION
packages/@textlint/linter-formatter/package.json does not use optionator.