### PR TITLE
loadFixerFormatter is not use in example.

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -57,7 +57,7 @@ console.log(output);
 Fix text and get the fixed text.
 
 ```ts
-import { createLinter, loadTextlintrc, loadFixerFormatter } from "textlint";
+import { createLinter, loadTextlintrc } from "textlint";
 // descriptor is a structure object for linter
 // It includes rules, plugins, and options
 const descriptor = await loadTextlintrc();

--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -64,7 +64,7 @@ const descriptor = await loadTextlintrc();
 const linter = createLinter({
     descriptor
 });
-const result = await linter.fixText("TODO: fix me");
+const result = await linter.fixText("TODO: fix me", "DUMMY.md");
 console.log(result.output); // fixed result
 ```
 


### PR DESCRIPTION
When I tried this sample code, I did not need `loadFixerFormatter `.So I deleted it.

Also, according to the type definition, `fixText` must require a file path as the second argument, which is correct?