### PR TITLE
fix(ast-node-types): remove `[index:string]: any;` from `TxtNode`

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -36,8 +36,6 @@ interface TxtNode {
     // Not need in AST
     // For example, top Root Node like `Document` has not parent.
     parent?: TxtNode;
-
-    [index: string]: any;
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2174,7 +2174,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2187,7 +2187,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -3988,28 +3988,28 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tufjs/canonical-json": {
@@ -4155,7 +4155,7 @@
       "version": "18.18.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
       "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4489,7 +4489,7 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4512,7 +4512,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4937,7 +4937,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -8225,7 +8225,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -17694,7 +17694,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -27124,7 +27124,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
@@ -27306,7 +27306,7 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -27409,7 +27409,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/unherit": {
       "version": "1.1.3",
@@ -27988,7 +27988,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8flags": {
@@ -28743,7 +28743,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -54,8 +54,6 @@ export interface TxtNode {
     loc: TxtNodeLocation;
     // `parent` is created by runtime
     parent?: TxtParentNode;
-
-    [index: string]: any;
 }
 
 /**

--- a/packages/@textlint/ast-traverse/src/index.ts
+++ b/packages/@textlint/ast-traverse/src/index.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import { AnyTxtNode, TxtNode, TxtParentNode } from "@textlint/ast-node-types";
+import type { AnyTxtNode, TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 
 /**
  * is TxtNode?
@@ -148,7 +148,8 @@ class Controller {
                 let current = candidates.length;
                 while ((current -= 1) >= 0) {
                     const key = candidates[current];
-                    const candidate = node[key];
+                    // @ts-expect-error: ignore dynamic access
+                    const candidate: keyof typeof node | undefined = node[key];
                     if (!candidate) {
                         continue;
                     }

--- a/packages/@textlint/ast-traverse/test/txt-traverse-test.ts
+++ b/packages/@textlint/ast-traverse/test/txt-traverse-test.ts
@@ -196,7 +196,7 @@ describe("txt-traverse", () => {
     });
     describe("#parents", () => {
         it("should return parent nodes", () => {
-            const AST = parse<TxtParentNode>("Hello*world*");
+            const AST = parse("Hello*world*");
             const controller = new Controller();
             let emParents: any[] = [];
             let documentParents: any[] = [];
@@ -222,7 +222,7 @@ describe("txt-traverse", () => {
     });
     describe("#current", () => {
         it("should return current node", () => {
-            const AST = parse<TxtParentNode>("Hello*world*");
+            const AST = parse("Hello*world*");
             const controller = new Controller();
             controller.traverse(AST, {
                 enter(node) {

--- a/packages/@textlint/kernel/test/helper/BinaryPlugin.ts
+++ b/packages/@textlint/kernel/test/helper/BinaryPlugin.ts
@@ -1,6 +1,7 @@
 // MIT © 2017 azu
 import { TextlintMessage } from "@textlint/kernel";
 import type { TextlintPluginCreator, TextlintPluginProcessor } from "@textlint/types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 
 export interface BinaryPluginProcessorOptions {
     testOption: string;
@@ -69,7 +70,7 @@ export const createBinaryPluginStub = (options?: CreateBinaryPluginOptions) => {
                             preProcess(text: string, filePath: string) {
                                 preProcessArgs = { text, filePath };
                                 const dummyText = (options && options.dummyText) || "this is binary";
-                                const ast = {
+                                const ast: TxtDocumentNode = {
                                     type: "Document" as const,
                                     raw: dummyText,
                                     range: [0, dummyText.length] as const,

--- a/packages/@textlint/kernel/test/kernel-plugin-test.ts
+++ b/packages/@textlint/kernel/test/kernel-plugin-test.ts
@@ -7,7 +7,7 @@ import { createBinaryPluginStub } from "./helper/BinaryPlugin";
 import { createAsyncPluginStub } from "./helper/AsyncPlugin";
 import type { TextlintRuleReporter } from "@textlint/types";
 import { TextlintKernelOptions } from "../src/textlint-kernel-interface";
-import { TxtNode } from "@textlint/ast-node-types";
+import { TxtDocumentNode } from "@textlint/ast-node-types";
 import { coreFlags, resetFlags } from "@textlint/feature-flag";
 
 describe("kernel-plugin", () => {
@@ -206,7 +206,7 @@ describe("kernel-plugin", () => {
                             // THIS IS FOR TESTING
                             return {
                                 invalid: "THIS IS NOT TxtAST"
-                            } as any as TxtNode;
+                            } as any as TxtDocumentNode;
                         },
                         postProcess(messages: Array<any>, filePath?: string) {
                             return {

--- a/packages/@textlint/kernel/test/source-location/source-location-test.ts
+++ b/packages/@textlint/kernel/test/source-location/source-location-test.ts
@@ -119,6 +119,7 @@ describe("source-location", function () {
     context("[deprecated] when line only", function () {
         it("should add line to the node.start", function () {
             const source = createDummySourceCode("1234567890\n\n1234567890\n", "test.md");
+            // @ts-expect-error : any node may have not children
             const node = source.ast.children[0].children[0];
             const ruleError = { line: 1, message: "error message" };
             const result = resolveLocation({ source, ruleId: "test", node, ruleError });

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -1,5 +1,5 @@
 import { SyntaxMap } from "./mapping/markdown-syntax-map";
-import type { TxtNode } from "@textlint/ast-node-types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 import { ASTNodeTypes } from "@textlint/ast-node-types";
 import traverse from "traverse";
 import debug0 from "debug";
@@ -12,9 +12,8 @@ export { ASTNodeTypes as Syntax };
 /**
  * parse Markdown text and return ast mapped location info.
  * @param {string} text
- * @returns {TxtNode}
  */
-export function parse<T extends TxtNode>(text: string): T {
+export function parse(text: string): TxtDocumentNode {
     // remark-parse's AST does not consider BOM
     // AST's position does not +1 by BOM
     // So, just trim BOM and parse it for `raw` property
@@ -58,5 +57,5 @@ export function parse<T extends TxtNode>(text: string): T {
             }
         }
     });
-    return ast as T;
+    return ast as TxtDocumentNode;
 }

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -1,5 +1,6 @@
 import { SyntaxMap } from "./mapping/markdown-syntax-map";
-import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
+import { ASTNodeTypes } from "@textlint/ast-node-types";
 import traverse from "traverse";
 import debug0 from "debug";
 import { parseMarkdown } from "./parse-markdown";
@@ -9,7 +10,7 @@ const debug = debug0("@textlint/markdown-to-ast");
 export { ASTNodeTypes as Syntax };
 
 /**
- * parse markdown text and return ast mapped location info.
+ * parse Markdown text and return ast mapped location info.
  * @param {string} text
  * @returns {TxtNode}
  */
@@ -23,7 +24,7 @@ export function parse<T extends TxtNode>(text: string): T {
     const hasBOM = text.charCodeAt(0) === 0xfeff;
     const textWithoutBOM = hasBOM ? text.slice(1) : text;
     const ast = parseMarkdown(textWithoutBOM);
-    traverse(ast).forEach(function (node: TxtNode) {
+    traverse(ast).forEach(function (node) {
         // eslint-disable-next-line no-invalid-this
         if (this.notLeaf) {
             if (node.type) {
@@ -31,7 +32,6 @@ export function parse<T extends TxtNode>(text: string): T {
                 if (!replacedType) {
                     debug(`replacedType : ${replacedType} , node.type: ${node.type}`);
                 } else {
-                    // @ts-expect-error: TxtNodeType + Markdown extension type
                     node.type = replacedType;
                 }
             }

--- a/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
+++ b/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
@@ -10,10 +10,11 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import frontmatter from "remark-frontmatter";
 import footnotes from "remark-footnotes";
+import type { Node } from "unist";
 
 const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes, {
     inlineNotes: true
 });
-export const parseMarkdown = (text: string) => {
+export const parseMarkdown = (text: string): Node => {
     return remark.parse(text);
 };

--- a/packages/@textlint/markdown-to-ast/test/compliance-tests.ts
+++ b/packages/@textlint/markdown-to-ast/test/compliance-tests.ts
@@ -1,11 +1,13 @@
 import assert from "assert";
 import { test } from "@textlint/ast-tester";
 import { parse } from "../src";
+import { TxtNode } from "@textlint/ast-node-types";
+import type { Node } from "unist";
 // String -> [String]
 describe("Compliance tests", function () {
     context("compatible for Unist", function () {
         it("should have position", function () {
-            const AST = parse("text");
+            const AST: TxtNode & Node = parse("text");
             test(AST);
             assert(typeof AST.position === "object");
             assert(typeof AST.position.start === "object");

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser-test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser-test.ts
@@ -5,7 +5,7 @@ import { parse, Syntax } from "../src/index";
 import assert from "assert";
 import traverse from "traverse";
 
-const inspect = (obj: Record<string, unknown>) => JSON.stringify(obj, null, 4);
+const inspect = (obj: unknown) => JSON.stringify(obj, null, 4);
 
 function findFirstTypedNode(node: TxtNode, type: string, value?: string): TxtNode {
     let result: TxtNode | null = null;

--- a/packages/@textlint/text-to-ast/src/plaintext-parser.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-parser.ts
@@ -1,9 +1,10 @@
 // LICENSE : MIT
 "use strict";
 import { Syntax } from "./plaintext-syntax";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtBreakNode, TxtDocumentNode, TxtNode, TxtParagraphNode } from "@textlint/ast-node-types";
+import { TxtStrNode } from "@textlint/ast-node-types";
 
-function parseLine(lineText: string, lineNumber: number, startIndex: number): TxtNode {
+function parseLine(lineText: string, lineNumber: number, startIndex: number): TxtStrNode {
     // Inline Node have `value`. It it not part of TxtNode.
     // TODO: https://github.com/textlint/textlint/issues/141
     return {
@@ -29,7 +30,7 @@ function parseLine(lineText: string, lineNumber: number, startIndex: number): Tx
  * @param {TxtNode} prevNode previous node from BreakNode
  * @param lineBreakText
  */
-function createEndedBRNode({ prevNode, lineBreakText }: { prevNode: TxtNode; lineBreakText: string }): TxtNode {
+function createEndedBRNode({ prevNode, lineBreakText }: { prevNode: TxtNode; lineBreakText: string }): TxtBreakNode {
     return {
         type: Syntax.Break,
         raw: lineBreakText,
@@ -58,7 +59,7 @@ function createBRNode({
     lineBreak: string;
     lineNumber: number;
     startIndex: number;
-}): TxtNode {
+}): TxtBreakNode {
     return {
         type: Syntax.Break,
         raw: lineBreak,
@@ -81,7 +82,7 @@ function createBRNode({
  * @param {TxtNode[]} nodes
  * @returns {TxtNode} Paragraph node
  */
-function createParagraph(nodes: TxtNode[]): TxtNode {
+function createParagraph(nodes: TxtStrNode[]): TxtParagraphNode {
     const firstNode = nodes[0];
     const lastNode = nodes[nodes.length - 1];
     return {
@@ -137,7 +138,7 @@ type LineWithBreak = { text: string; lineBreak: string };
  * @param {string} text
  * @returns {TxtNode}
  */
-export function parse(text: string): TxtNode {
+export function parse(text: string): TxtDocumentNode {
     const textLineByLine = splitTextByLine(text);
     // it should be alternately Str and Break
     let startIndex = 0;
@@ -179,7 +180,7 @@ export function parse(text: string): TxtNode {
             result.push(breakNode);
         }
         return result;
-    }, [] as TxtNode[]);
+    }, [] as (TxtBreakNode | TxtParagraphNode)[]);
     const lastLine = textLineByLine[textLineByLine.length - 1];
     if (lastLine === undefined) {
         return {

--- a/packages/@textlint/textlint-plugin-text/src/TextProcessor.ts
+++ b/packages/@textlint/textlint-plugin-text/src/TextProcessor.ts
@@ -3,7 +3,6 @@
 "use strict";
 import { parse } from "@textlint/text-to-ast";
 import type { TextlintPluginProcessor, TextlintPluginOptions } from "@textlint/types";
-import { TxtNode } from "@textlint/ast-node-types";
 
 export class TextProcessor implements TextlintPluginProcessor {
     config: TextlintPluginOptions;
@@ -20,7 +19,7 @@ export class TextProcessor implements TextlintPluginProcessor {
 
     processor(_ext: string) {
         return {
-            preProcess(text: string, _filePath?: string): TxtNode | { text: string; ast: TxtNode } {
+            preProcess(text: string, _filePath?: string) {
                 return parse(text);
             },
             postProcess(messages: Array<any>, filePath?: string): { messages: Array<any>; filePath: string } {

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -1,5 +1,5 @@
 // Plugin
-import { TxtDocumentNode, TxtNode } from "@textlint/ast-node-types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 
 /**
  * textlint plugin option values is object or boolean.

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -1,5 +1,5 @@
 // Plugin
-import { TxtNode } from "@textlint/ast-node-types";
+import { TxtDocumentNode, TxtNode } from "@textlint/ast-node-types";
 
 /**
  * textlint plugin option values is object or boolean.
@@ -9,7 +9,7 @@ export declare type TextlintPluginOptions = {
     [index: string]: any;
 };
 
-export type TextlintPluginPreProcessResult = TxtNode | { text: string; ast: TxtNode };
+export type TextlintPluginPreProcessResult = TxtDocumentNode | { text: string; ast: TxtDocumentNode };
 export type TextlintPluginPostProcessResult = { messages: Array<any>; filePath: string };
 
 export interface TextlintPluginProcessorConstructor extends Function {

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.ts
@@ -1,4 +1,4 @@
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 import { TextlintPluginProcessorConstructor } from "@textlint/kernel";
 
 class ExampleProcessor {
@@ -12,7 +12,7 @@ class ExampleProcessor {
 
     processor(_extension: string) {
         return {
-            preProcess(_text: string, _filePath: string): TxtNode {
+            preProcess(_text: string, _filePath: string): TxtDocumentNode {
                 return {
                     type: "Document",
                     children: [],

--- a/packages/textlint/test/pluguins/fixtures/example-plugin.ts
+++ b/packages/textlint/test/pluguins/fixtures/example-plugin.ts
@@ -1,5 +1,5 @@
-import { TxtNode } from "@textlint/ast-node-types";
-import { TextlintPluginCreator, TextlintPluginOptions } from "@textlint/types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
+import type { TextlintPluginCreator, TextlintPluginOptions } from "@textlint/types";
 
 // MIT © 2017 azu
 export class ExampleProcessor {
@@ -13,11 +13,10 @@ export class ExampleProcessor {
 
     processor(_extension: string) {
         return {
-            preProcess(_text: string, _filePath: string): TxtNode {
+            preProcess(_text: string, _filePath: string): TxtDocumentNode {
                 return {
                     type: "Document",
                     children: [],
-                    value: "",
                     raw: "",
                     range: [0, 0],
                     loc: {


### PR DESCRIPTION
This PR fixed types of textlint.
It does not change the behavior of textlint.

## Changes

- Remove `[index:string]: any;` from `TxtNode`
- Plugin's `preProcess` should return `TxtDocumentNode`
  - Previously, it allow return `TxtNode`.


For plugin developer:

You may be necessary to change the type that returns preProcess as follows

```diff
-            preProcess(_text: string, _filePath: string): TxtNode {
+            preProcess(_text: string, _filePath: string): TxtDocumentNode {
```

## Related

- fix #1294 
