### PR TITLE
Fix Full Changelog URL for release information

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const result = await exec.getExecOutput(`gh api "/repos/{owner}/{repo}/releases/generate-notes" -f tag_name="${process.env.PACKAGE_VERSION}" --jq .body`, [], {
+            const result = await exec.getExecOutput(`gh api "/repos/{owner}/{repo}/releases/generate-notes" -f tag_name="v${process.env.PACKAGE_VERSION}" --jq .body`, [], {
               ignoreReturnCode: true,
             })
             core.setOutput('stdout', result.stdout)


### PR DESCRIPTION
This is the same fix as [secretlint/secretlint#717](https://github.com/secretlint/secretlint/pull/717)