### PR TITLE
fix(config-loader): enhance config-loader results

### DIFF
--- a/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
+++ b/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
@@ -13,6 +13,12 @@ export type TextlintConfigPlugin = TextlintKernelPlugin & {
      * plugin module name
      */
     moduleName: string;
+    /**
+     * Inputted module name
+     * This module name is resolved by config-loader
+     * The resolved module name will be `moduleName`.
+     */
+    inputModuleName: string;
 };
 //  a rule module
 export type TextlintConfigSingleRule = TextlintKernelRule & {
@@ -26,6 +32,12 @@ export type TextlintConfigSingleRule = TextlintKernelRule & {
      * @example "textlint-rule-example"
      */
     moduleName: string;
+    /**
+     * Inputted module name
+     * This module name is resolved by config-loader
+     * The resolved module name will be `moduleName`.
+     */
+    inputModuleName: string;
 };
 // a rule in preset module
 export type TextlintConfigRuleInPreset = TextlintKernelRule & {
@@ -44,6 +56,12 @@ export type TextlintConfigRuleInPreset = TextlintKernelRule & {
      * @example "{moduleName}/{ruleKey}"
      */
     ruleKey: string;
+    /**
+     * Inputted module name
+     * This module name is resolved by config-loader
+     * The resolved module name will be `moduleName`.
+     */
+    inputModuleName: string;
 };
 export type TextlintConfigRule = TextlintConfigSingleRule | TextlintConfigRuleInPreset;
 export type TextlintConfigFilterRule = TextlintKernelFilterRule & {
@@ -56,6 +74,12 @@ export type TextlintConfigFilterRule = TextlintKernelFilterRule & {
      * @example "textlint-filter-rule-example"
      */
     moduleName: string;
+    /**
+     * Inputted module name
+     * This module name is resolved by config-loader
+     * The resolved module name will be `moduleName`.
+     */
+    inputModuleName: string;
 };
 export type TextlintConfigRulePreset = {
     id: string;

--- a/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
+++ b/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
@@ -5,21 +5,29 @@ import type { TextlintRuleModule, TextlintRuleOptions } from "@textlint/types";
 
 export type TextlintConfigPlugin = TextlintKernelPlugin & {
     filePath: string;
-    // TODO: moduleName is a file Path - need to rename
+    /**
+     * plugin module name
+     */
     moduleName: string;
 };
 //  a rule module
 export type TextlintConfigSingleRule = TextlintKernelRule & {
     type: "Rule";
     filePath: string;
-    // TODO: moduleName is a file Path - need to rename
+    /**
+     * rule module name
+     * @example "textlint-rule-example"
+     */
     moduleName: string;
 };
 // a rule in preset module
 export type TextlintConfigRuleInPreset = TextlintKernelRule & {
     type: "RuleInPreset";
     filePath: string;
-    // TODO: moduleName is a file Path - need to rename
+    /**
+     * preset module name
+     * @example "textlint-rule-preset-example"
+     */
     moduleName: string;
     /**
      * rule key in preset

--- a/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
+++ b/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
@@ -4,6 +4,7 @@ import type { TextlintKernelFilterRule, TextlintKernelPlugin, TextlintKernelRule
 import type { TextlintRuleModule, TextlintRuleOptions } from "@textlint/types";
 
 export type TextlintConfigPlugin = TextlintKernelPlugin & {
+    type: "Plugin";
     filePath: string;
     /**
      * plugin module name

--- a/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
+++ b/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
@@ -5,6 +5,9 @@ import type { TextlintRuleModule, TextlintRuleOptions } from "@textlint/types";
 
 export type TextlintConfigPlugin = TextlintKernelPlugin & {
     type: "Plugin";
+    /**
+     * Absolute file path to the rule module
+     */
     filePath: string;
     /**
      * plugin module name
@@ -14,6 +17,9 @@ export type TextlintConfigPlugin = TextlintKernelPlugin & {
 //  a rule module
 export type TextlintConfigSingleRule = TextlintKernelRule & {
     type: "Rule";
+    /**
+     * Absolute file path to the rule module
+     */
     filePath: string;
     /**
      * rule module name
@@ -24,6 +30,9 @@ export type TextlintConfigSingleRule = TextlintKernelRule & {
 // a rule in preset module
 export type TextlintConfigRuleInPreset = TextlintKernelRule & {
     type: "RuleInPreset";
+    /**
+     * Absolute file path to the rule module
+     */
     filePath: string;
     /**
      * preset module name
@@ -32,12 +41,22 @@ export type TextlintConfigRuleInPreset = TextlintKernelRule & {
     moduleName: string;
     /**
      * rule key in preset
-     * @example "{preset-name}/{rule-key}"
+     * @example "{moduleName}/{ruleKey}"
      */
     ruleKey: string;
 };
 export type TextlintConfigRule = TextlintConfigSingleRule | TextlintConfigRuleInPreset;
-export type TextlintConfigFilterRule = TextlintKernelFilterRule & { filePath: string; moduleName: string };
+export type TextlintConfigFilterRule = TextlintKernelFilterRule & {
+    /**
+     * Absolute file path to the rule module
+     */
+    filePath: string;
+    /**
+     * filter rule module name
+     * @example "textlint-filter-rule-example"
+     */
+    moduleName: string;
+};
 export type TextlintConfigRulePreset = {
     id: string;
     preset: {

--- a/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
+++ b/packages/@textlint/config-loader/src/TextlintConfigDescriptor.ts
@@ -53,13 +53,17 @@ export type TextlintConfigRuleInPreset = TextlintKernelRule & {
     moduleName: string;
     /**
      * rule key in preset
-     * @example "{moduleName}/{ruleKey}"
+     * @example In "{moduleName}/{ruleKey}", the ruleKey is "ruleKey"
      */
     ruleKey: string;
     /**
      * Inputted module name
      * This module name is resolved by config-loader
      * The resolved module name will be `moduleName`.
+     *
+     * Difference with `ruleId` is that `ruleId` is rule identifier and includes `preset-name`.
+     * For example, `ruleId` is `preset-name/rule-key`.
+     * But, `inputModuleName` is `preset-name`.
      */
     inputModuleName: string;
 };

--- a/packages/@textlint/config-loader/src/loader.ts
+++ b/packages/@textlint/config-loader/src/loader.ts
@@ -48,6 +48,7 @@ For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs
                     );
                 }
                 plugins.push({
+                    type: "Plugin",
                     pluginId,
                     plugin,
                     filePath: resolvedModule.filePath,
@@ -87,6 +88,7 @@ For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs
                         }
 
                         plugins.push({
+                            type: "Plugin",
                             pluginId,
                             plugin,
                             options: pluginOptions,

--- a/packages/@textlint/config-loader/src/loader.ts
+++ b/packages/@textlint/config-loader/src/loader.ts
@@ -52,7 +52,8 @@ For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs
                     pluginId,
                     plugin,
                     filePath: resolvedModule.filePath,
-                    moduleName: resolvedModule.moduleName
+                    moduleName: resolvedModule.moduleName,
+                    inputModuleName: resolvedModule.inputModuleName
                 });
             })
         );
@@ -93,7 +94,8 @@ For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs
                             plugin,
                             options: pluginOptions,
                             filePath: resolvedPlugin.filePath,
-                            moduleName: resolvedPlugin.moduleName
+                            moduleName: resolvedPlugin.moduleName,
+                            inputModuleName: resolvedPlugin.inputModuleName
                         });
                     }
                 } catch (error) {
@@ -159,7 +161,8 @@ export const loadFilterRules = async ({
                         rule: ruleModule,
                         options: ruleOptions,
                         filePath: resolvePackage.filePath,
-                        moduleName: resolvePackage.moduleName
+                        moduleName: resolvePackage.moduleName,
+                        inputModuleName: resolvePackage.inputModuleName
                     });
                 }
             } catch (error) {
@@ -247,7 +250,8 @@ For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs
                             rule: ruleModule,
                             options: ruleOptions,
                             filePath: resolvePackage.filePath,
-                            moduleName: resolvePackage.moduleName
+                            moduleName: resolvePackage.moduleName,
+                            inputModuleName: resolvePackage.inputModuleName
                         });
                     }
                 }
@@ -313,7 +317,10 @@ export async function loadPreset({
             rule: preset.rules[ruleKey],
             options: presetRulesOptions[ruleKey] ?? preset.rulesConfig[ruleKey],
             filePath: presetPackageName.filePath,
+            // preset package name
             moduleName: presetPackageName.moduleName,
+            inputModuleName: presetPackageName.inputModuleName,
+            // rule key in preset
             ruleKey
         };
     });

--- a/packages/@textlint/config-loader/src/loader.ts
+++ b/packages/@textlint/config-loader/src/loader.ts
@@ -306,6 +306,7 @@ export async function loadPreset({
       - filePath: path to "textlint-rule-preset-example/index.js"
       - moduleName: "textlint-rule-preset-example"
       - ruleKey: "a",
+      - inputModuleName: "preset-example"
 
      */
     return Object.keys(preset.rules).map((ruleKey) => {

--- a/packages/@textlint/config-loader/src/textlint-module-resolver.ts
+++ b/packages/@textlint/config-loader/src/textlint-module-resolver.ts
@@ -37,29 +37,20 @@ export class TextLintModuleResolver {
          */
         this.baseDirectory = config && config.rulesBaseDirectory ? config.rulesBaseDirectory : "";
     }
-    tryResolveModuleName = (
-        moduleName: string
-    ): {
-        moduleName: string;
-        filePath: string;
-    } | null => {
-        const cachedFilePath = this.moduleCache.get(moduleName);
+
+    tryResolvePackagePath = (modulePath: string): string | null => {
+        const cachedFilePath = this.moduleCache.get(modulePath);
         if (cachedFilePath) {
-            return {
-                moduleName,
-                filePath: cachedFilePath
-            };
+            return cachedFilePath;
         }
-        const ret: string | undefined = tryResolve(moduleName);
+        const ret: string | undefined = tryResolve(modulePath);
         if (ret) {
-            this.moduleCache.set(moduleName, ret);
-            return {
-                moduleName,
-                filePath: ret
-            };
+            this.moduleCache.set(modulePath, ret);
+            return ret;
         }
         return null;
     };
+
     /**
      * Take package name, and return path to module.
      * @param {string} packageName
@@ -72,13 +63,19 @@ export class TextLintModuleResolver {
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.rule, packageName);
         // <rule-name> or textlint-rule-<rule-name>
-        const resultFullPackageName = this.tryResolveModuleName(path.join(baseDir, fullPackageName));
-        if (resultFullPackageName) {
-            return resultFullPackageName;
+        const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
+        if (resultFullPackagePath) {
+            return {
+                moduleName: fullPackageName,
+                filePath: resultFullPackagePath
+            };
         }
-        const resultPackageName = this.tryResolveModuleName(path.join(baseDir, packageName));
-        if (resultPackageName) {
-            return resultPackageName;
+        const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
+        if (resultPackagePath) {
+            return {
+                moduleName: packageName,
+                filePath: resultPackagePath
+            };
         }
         throw new ReferenceError(`Failed to load textlint's rule module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
@@ -97,13 +94,19 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.filterRule, packageName);
         // <rule-name> or textlint-filter-rule-<rule-name> or @scope/<rule-name>
-        const resultFullPackageName = this.tryResolveModuleName(path.join(baseDir, fullPackageName));
-        if (resultFullPackageName) {
-            return resultFullPackageName;
+        const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
+        if (resultFullPackagePath) {
+            return {
+                moduleName: fullPackageName,
+                filePath: resultFullPackagePath
+            };
         }
-        const resultPackageName = this.tryResolveModuleName(path.join(baseDir, packageName));
-        if (resultPackageName) {
-            return resultPackageName;
+        const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
+        if (resultPackagePath) {
+            return {
+                moduleName: packageName,
+                filePath: resultPackagePath
+            };
         }
         throw new ReferenceError(`Failed to load textlint's filter rule module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
@@ -122,13 +125,19 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.plugin, packageName);
         // <plugin-name> or textlint-plugin-<rule-name>
-        const resultFullPackageName = this.tryResolveModuleName(path.join(baseDir, fullPackageName));
-        if (resultFullPackageName) {
-            return resultFullPackageName;
+        const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
+        if (resultFullPackagePath) {
+            return {
+                moduleName: fullPackageName,
+                filePath: resultFullPackagePath
+            };
         }
-        const resultPackageName = this.tryResolveModuleName(path.join(baseDir, packageName));
-        if (resultPackageName) {
-            return resultPackageName;
+        const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
+        if (resultPackagePath) {
+            return {
+                moduleName: packageName,
+                filePath: resultPackagePath
+            };
         }
         throw new ReferenceError(`Failed to load textlint's plugin module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
@@ -167,24 +176,36 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const fullPackageName = createFullPackageName(PREFIX, packageNameWithoutPreset);
         const fullFullPackageName = `${PREFIX}${packageNameWithoutPreset}`;
         // textlint-rule-preset-<preset-name> or @scope/textlint-rule-preset-<preset-name>
-        const resultFullPresetPackageName = this.tryResolveModuleName(path.join(baseDir, fullFullPackageName));
-        if (resultFullPresetPackageName) {
-            return resultFullPresetPackageName;
+        const resultFullPresetPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullFullPackageName));
+        if (resultFullPresetPackagePath) {
+            return {
+                moduleName: fullFullPackageName,
+                filePath: resultFullPresetPackagePath
+            };
         }
         // <preset-name>
-        const resultPresetPackageName = this.tryResolveModuleName(path.join(baseDir, packageNameWithoutPreset));
-        if (resultPresetPackageName) {
-            return resultPresetPackageName;
+        const resultPresetPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageNameWithoutPreset));
+        if (resultPresetPackagePath) {
+            return {
+                moduleName: packageNameWithoutPreset,
+                filePath: resultPresetPackagePath
+            };
         }
         // <rule-name>
-        const resultFullPackageName = this.tryResolveModuleName(path.join(baseDir, fullPackageName));
-        if (resultFullPackageName) {
-            return resultFullPackageName;
+        const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
+        if (resultFullPackagePath) {
+            return {
+                moduleName: fullPackageName,
+                filePath: resultFullPackagePath
+            };
         }
         // <package-name>
-        const resultPackageName = this.tryResolveModuleName(path.join(baseDir, packageName));
-        if (resultPackageName) {
-            return resultPackageName;
+        const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
+        if (resultPackagePath) {
+            return {
+                moduleName: packageName,
+                filePath: resultPackagePath
+            };
         }
         throw new ReferenceError(`Failed to load textlint's preset module: "${packageName}" is not found.
 See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md

--- a/packages/@textlint/config-loader/src/textlint-module-resolver.ts
+++ b/packages/@textlint/config-loader/src/textlint-module-resolver.ts
@@ -12,6 +12,12 @@ export interface ConfigModulePrefix {
     PLUGIN_NAME_PREFIX: string;
 }
 
+export type TextLintModuleResolverResolveResult = {
+    inputModuleName: string;
+    moduleName: string;
+    filePath: string;
+};
+
 /**
  * This class aim to resolve textlint's package name and get the module path.
  *
@@ -56,16 +62,14 @@ export class TextLintModuleResolver {
      * @param {string} packageName
      * @returns {string} return path to module
      */
-    resolveRulePackageName(packageName: string): {
-        moduleName: string;
-        filePath: string;
-    } {
+    resolveRulePackageName(packageName: string): TextLintModuleResolverResolveResult {
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.rule, packageName);
         // <rule-name> or textlint-rule-<rule-name>
         const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
         if (resultFullPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: fullPackageName,
                 filePath: resultFullPackagePath
             };
@@ -73,6 +77,7 @@ export class TextLintModuleResolver {
         const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
         if (resultPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: packageName,
                 filePath: resultPackagePath
             };
@@ -87,16 +92,14 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
      * @param {string} packageName
      * @returns {string} return path to module
      */
-    resolveFilterRulePackageName(packageName: string): {
-        moduleName: string;
-        filePath: string;
-    } {
+    resolveFilterRulePackageName(packageName: string): TextLintModuleResolverResolveResult {
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.filterRule, packageName);
         // <rule-name> or textlint-filter-rule-<rule-name> or @scope/<rule-name>
         const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
         if (resultFullPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: fullPackageName,
                 filePath: resultFullPackagePath
             };
@@ -104,6 +107,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
         if (resultPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: packageName,
                 filePath: resultPackagePath
             };
@@ -118,16 +122,14 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
      * @param {string} packageName
      * @returns {string} return path to module
      */
-    resolvePluginPackageName(packageName: string): {
-        moduleName: string;
-        filePath: string;
-    } {
+    resolvePluginPackageName(packageName: string): TextLintModuleResolverResolveResult {
         const baseDir = this.baseDirectory;
         const fullPackageName = createFullPackageName(PackageNamePrefix.plugin, packageName);
         // <plugin-name> or textlint-plugin-<rule-name>
         const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
         if (resultFullPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: fullPackageName,
                 filePath: resultFullPackagePath
             };
@@ -135,6 +137,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
         if (resultPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: packageName,
                 filePath: resultPackagePath
             };
@@ -149,10 +152,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
      * @param {string} packageName
      * The user must specify preset- prefix to these `packageName`.
      */
-    resolvePresetPackageName(packageName: string): {
-        moduleName: string;
-        filePath: string;
-    } {
+    resolvePresetPackageName(packageName: string): TextLintModuleResolverResolveResult {
         const baseDir = this.baseDirectory;
         const PREFIX = PackageNamePrefix.rulePreset;
         /* Implementation Note
@@ -179,6 +179,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultFullPresetPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullFullPackageName));
         if (resultFullPresetPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: fullFullPackageName,
                 filePath: resultFullPresetPackagePath
             };
@@ -187,6 +188,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultPresetPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageNameWithoutPreset));
         if (resultPresetPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: packageNameWithoutPreset,
                 filePath: resultPresetPackagePath
             };
@@ -195,6 +197,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultFullPackagePath = this.tryResolvePackagePath(path.join(baseDir, fullPackageName));
         if (resultFullPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: fullPackageName,
                 filePath: resultFullPackagePath
             };
@@ -203,6 +206,7 @@ See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-loa
         const resultPackagePath = this.tryResolvePackagePath(path.join(baseDir, packageName));
         if (resultPackagePath) {
             return {
+                inputModuleName: packageName,
                 moduleName: packageName,
                 filePath: resultPackagePath
             };

--- a/packages/@textlint/config-loader/test/snapshots/disable-child-rule-of-preset/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/disable-child-rule-of-preset/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "abc/a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -15,7 +15,7 @@
                 "ruleId": "abc/b",
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -23,7 +23,7 @@
                 "ruleId": "abc/c",
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/disable-child-rule-of-preset/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/disable-child-rule-of-preset/output.json
@@ -8,6 +8,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -16,6 +17,7 @@
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -24,6 +26,7 @@
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/esm/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/esm/output.json
@@ -8,7 +8,7 @@
                 "plugin": {},
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-plugin-esm/index.mjs",
-                "moduleName": "<MODULES_DIR>/textlint-plugin-esm"
+                "moduleName": "textlint-plugin-esm"
             }
         ],
         "filterRules": []

--- a/packages/@textlint/config-loader/test/snapshots/esm/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/esm/output.json
@@ -4,6 +4,7 @@
         "rules": [],
         "plugins": [
             {
+                "type": "Plugin",
                 "pluginId": "esm",
                 "plugin": {},
                 "options": true,

--- a/packages/@textlint/config-loader/test/snapshots/esm/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/esm/output.json
@@ -9,7 +9,8 @@
                 "plugin": {},
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-plugin-esm/index.mjs",
-                "moduleName": "textlint-plugin-esm"
+                "moduleName": "textlint-plugin-esm",
+                "inputModuleName": "esm"
             }
         ],
         "filterRules": []

--- a/packages/@textlint/config-loader/test/snapshots/no-used-rule-will-be-skip-to-load/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/no-used-rule-will-be-skip-to-load/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-a/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-a"
+                "moduleName": "textlint-rule-a"
             },
             {
                 "type": "Rule",
@@ -16,14 +16,14 @@
                     "key": "value"
                 },
                 "filePath": "<MODULES_DIR>/textlint-rule-b/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-b"
+                "moduleName": "textlint-rule-b"
             },
             {
                 "type": "RuleInPreset",
                 "ruleId": "c/c-sub1",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-c/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-c",
+                "moduleName": "textlint-rule-preset-c",
                 "ruleKey": "c-sub1"
             },
             {
@@ -31,7 +31,7 @@
                 "ruleId": "c/c-sub2",
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-c/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-c",
+                "moduleName": "textlint-rule-preset-c",
                 "ruleKey": "c-sub2"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/no-used-rule-will-be-skip-to-load/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/no-used-rule-will-be-skip-to-load/output.json
@@ -7,7 +7,8 @@
                 "ruleId": "a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-a/index.js",
-                "moduleName": "textlint-rule-a"
+                "moduleName": "textlint-rule-a",
+                "inputModuleName": "a"
             },
             {
                 "type": "Rule",
@@ -16,7 +17,8 @@
                     "key": "value"
                 },
                 "filePath": "<MODULES_DIR>/textlint-rule-b/index.js",
-                "moduleName": "textlint-rule-b"
+                "moduleName": "textlint-rule-b",
+                "inputModuleName": "b"
             },
             {
                 "type": "RuleInPreset",
@@ -24,6 +26,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-c/index.js",
                 "moduleName": "textlint-rule-preset-c",
+                "inputModuleName": "preset-c",
                 "ruleKey": "c-sub1"
             },
             {
@@ -32,6 +35,7 @@
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-c/index.js",
                 "moduleName": "textlint-rule-preset-c",
+                "inputModuleName": "preset-c",
                 "ruleKey": "c-sub2"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/plguin/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/plguin/output.json
@@ -12,6 +12,7 @@
         ],
         "plugins": [
             {
+                "type": "Plugin",
                 "pluginId": "custom",
                 "plugin": {},
                 "filePath": "<MODULES_DIR>/textlint-plugin-custom/index.js",

--- a/packages/@textlint/config-loader/test/snapshots/plguin/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/plguin/output.json
@@ -7,7 +7,8 @@
                 "ruleId": "a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-a/index.js",
-                "moduleName": "textlint-rule-a"
+                "moduleName": "textlint-rule-a",
+                "inputModuleName": "a"
             }
         ],
         "plugins": [
@@ -16,7 +17,8 @@
                 "pluginId": "custom",
                 "plugin": {},
                 "filePath": "<MODULES_DIR>/textlint-plugin-custom/index.js",
-                "moduleName": "textlint-plugin-custom"
+                "moduleName": "textlint-plugin-custom",
+                "inputModuleName": "custom"
             }
         ],
         "filterRules": []

--- a/packages/@textlint/config-loader/test/snapshots/plguin/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/plguin/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-a/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-a"
+                "moduleName": "textlint-rule-a"
             }
         ],
         "plugins": [
@@ -15,7 +15,7 @@
                 "pluginId": "custom",
                 "plugin": {},
                 "filePath": "<MODULES_DIR>/textlint-plugin-custom/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-plugin-custom"
+                "moduleName": "textlint-plugin-custom"
             }
         ],
         "filterRules": []

--- a/packages/@textlint/config-loader/test/snapshots/preset/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/preset/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "abc/a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -15,7 +15,7 @@
                 "ruleId": "abc/b",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -23,7 +23,7 @@
                 "ruleId": "abc/c",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/preset/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/preset/output.json
@@ -8,6 +8,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -16,6 +17,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -24,6 +26,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
                 "moduleName": "textlint-rule-preset-abc",
+                "inputModuleName": "preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/ruke-key-should-refer-property-name/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/ruke-key-should-refer-property-name/output.json
@@ -8,6 +8,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
                 "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
+                "inputModuleName": "preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueA"
             },
             {
@@ -16,6 +17,7 @@
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
                 "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
+                "inputModuleName": "preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueB"
             },
             {
@@ -24,6 +26,7 @@
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
                 "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
+                "inputModuleName": "preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueC"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/ruke-key-should-refer-property-name/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/ruke-key-should-refer-property-name/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "abc-but-unique-rule-key/uniqueA",
                 "options": true,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key",
+                "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueA"
             },
             {
@@ -15,7 +15,7 @@
                 "ruleId": "abc-but-unique-rule-key/uniqueB",
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key",
+                "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueB"
             },
             {
@@ -23,7 +23,7 @@
                 "ruleId": "abc-but-unique-rule-key/uniqueC",
                 "options": false,
                 "filePath": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc-but-unique-rule-key",
+                "moduleName": "textlint-rule-preset-abc-but-unique-rule-key",
                 "ruleKey": "uniqueC"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/scoped-rule/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/scoped-rule/output.json
@@ -8,6 +8,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
                 "moduleName": "@scope/textlint-rule-preset-abc",
+                "inputModuleName": "@scope/preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -16,6 +17,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
                 "moduleName": "@scope/textlint-rule-preset-abc",
+                "inputModuleName": "@scope/preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -24,6 +26,7 @@
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
                 "moduleName": "@scope/textlint-rule-preset-abc",
+                "inputModuleName": "@scope/preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/config-loader/test/snapshots/scoped-rule/output.json
+++ b/packages/@textlint/config-loader/test/snapshots/scoped-rule/output.json
@@ -7,7 +7,7 @@
                 "ruleId": "@scope/abc/a",
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/@scope/textlint-rule-preset-abc",
+                "moduleName": "@scope/textlint-rule-preset-abc",
                 "ruleKey": "a"
             },
             {
@@ -15,7 +15,7 @@
                 "ruleId": "@scope/abc/b",
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/@scope/textlint-rule-preset-abc",
+                "moduleName": "@scope/textlint-rule-preset-abc",
                 "ruleKey": "b"
             },
             {
@@ -23,7 +23,7 @@
                 "ruleId": "@scope/abc/c",
                 "options": true,
                 "filePath": "<MODULES_DIR>/@scope/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/@scope/textlint-rule-preset-abc",
+                "moduleName": "@scope/textlint-rule-preset-abc",
                 "ruleKey": "c"
             }
         ],

--- a/packages/@textlint/kernel/src/textlint-kernel-interface.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel-interface.ts
@@ -29,6 +29,8 @@ export interface TextlintKernelPlugin {
 export interface TextlintKernelRule {
     // rule name as key
     // this key should be normalized
+    // For example, `ruleId: "example"`
+    // In Preset rule, `ruleId: "preset-name/example"`
     ruleId: string;
     // rule module
     // For example, `rule: require("textlint-rule-example")`

--- a/packages/@textlint/kernel/src/textlint-kernel-interface.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel-interface.ts
@@ -29,8 +29,8 @@ export interface TextlintKernelPlugin {
 export interface TextlintKernelRule {
     // rule name as key
     // this key should be normalized
-    // For example, `ruleId: "example"`
-    // In Preset rule, `ruleId: "preset-name/example"`
+    // For example, "textlint-rule-example" => "example"
+    // In Preset rule, "rule-name" of "textlint-rule-preset-example" => "example/rule-name"
     ruleId: string;
     // rule module
     // For example, `rule: require("textlint-rule-example")`


### PR DESCRIPTION
This is breaking change, but `@textlint/config-loader` is internal use.

## Changes

### `moduleName` should be package's name

Previously, `moduleName` is a file path.

```diff
            {
                "type": "RuleInPreset",
                "ruleId": "abc/c",
                "options": false,
                "filePath": "<MODULES_DIR>/textlint-rule-preset-abc/index.js",
-                "moduleName": "<MODULES_DIR>/textlint-rule-preset-abc",
+                "moduleName": "textlint-rule-preset-abc",
                "ruleKey": "c"
            }
```

### Add `type: "Plugin"`

```diff
        "plugins": [
            {
+                "type": "Plugin",
                "pluginId": "custom",
                "plugin": {},
                "filePath": "<MODULES_DIR>/textlint-plugin-custom/index.js",
                "moduleName": "textlint-plugin-custom"
            }
        ],
```

### Add `inputModuleName: string`

Previously, the input module name is not defined in results.
In some usecase, a user want to map input to result.

For this usecase, the user can use inputModuleName <-> moduleName

- https://github.com/textlint/editor/issues/87