### PR TITLE
perf(textlint): use glob.stream instead of glob.sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       }
     },
     "examples/cli": {
+      "name": "textlint-example-cli",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -36,6 +37,7 @@
       }
     },
     "examples/config-file": {
+      "name": "textlint-example-config-file",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -44,6 +46,7 @@
       }
     },
     "examples/config-in-package-json": {
+      "name": "textlint-example-config-in-package-json",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -52,6 +55,7 @@
       }
     },
     "examples/filter": {
+      "name": "textlint-example-filter",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -61,6 +65,7 @@
       }
     },
     "examples/fix": {
+      "name": "textlint-example-fix",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -69,6 +74,7 @@
       }
     },
     "examples/fix-dry-run": {
+      "name": "textlint-example-fix-dry-run",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -77,6 +83,7 @@
       }
     },
     "examples/html-plugin": {
+      "name": "textlint-example-html-plugin",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -106,6 +113,7 @@
       }
     },
     "examples/perf": {
+      "name": "textlint-perf-test",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -120,6 +128,7 @@
       }
     },
     "examples/plugin-extensions-option": {
+      "name": "textlint-example-plugin-extensions-option",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -129,6 +138,7 @@
       }
     },
     "examples/preset": {
+      "name": "textlint-example-preset",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -137,6 +147,7 @@
       }
     },
     "examples/rulesdir": {
+      "name": "textlint-example-rulesdir",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -144,6 +155,7 @@
       }
     },
     "examples/use-as-module": {
+      "name": "textlint-example-use-as-module",
       "version": "13.4.1",
       "license": "MIT",
       "dependencies": {
@@ -152,6 +164,7 @@
       }
     },
     "examples/use-as-ts-module": {
+      "name": "textlint-example-use-as-ts-module",
       "version": "13.4.1",
       "license": "MIT",
       "dependencies": {
@@ -2397,7 +2410,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -2414,7 +2426,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -2426,7 +2437,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -2437,14 +2447,12 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -2461,7 +2469,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -2476,7 +2483,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -3434,7 +3440,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -9950,8 +9955,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -11914,7 +11918,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -11930,7 +11933,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -15451,7 +15453,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -20390,7 +20391,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
       "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -20406,7 +20406,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
-      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -20415,7 +20414,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
       "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -24703,7 +24701,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -24717,7 +24714,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -24791,7 +24787,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -28526,7 +28521,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -29255,7 +29249,7 @@
         "debug": "^4.3.4",
         "file-entry-cache": "^5.0.1",
         "get-stdin": "^5.0.1",
-        "glob": "^7.2.3",
+        "glob": "^10.3.10",
         "md5": "^2.3.0",
         "mkdirp": "^0.5.6",
         "optionator": "^0.9.3",
@@ -29335,6 +29329,7 @@
       }
     },
     "packages/textlint-scripts/examples/example": {
+      "name": "textlint-scripts-example",
       "version": "13.4.1",
       "dependencies": {
         "prh": "^5.4.4"
@@ -29344,12 +29339,14 @@
       }
     },
     "packages/textlint-scripts/examples/example-dynamic-import": {
+      "name": "textlint-scripts-example-dynamic-import",
       "version": "13.4.1",
       "devDependencies": {
         "textlint-scripts": "^13.4.1"
       }
     },
     "packages/textlint-scripts/examples/example-ts": {
+      "name": "textlint-scripts-example-ts",
       "version": "13.4.1",
       "dependencies": {
         "prh": "^5.4.4"
@@ -29393,6 +29390,14 @@
         "kuromojin": "^2.0.0"
       }
     },
+    "packages/textlint/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "packages/textlint/node_modules/file-entry-cache": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -29417,6 +29422,45 @@
         "node": ">=4"
       }
     },
+    "packages/textlint/node_modules/flat-cache/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/textlint/node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/textlint/node_modules/flat-cache/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/textlint/node_modules/flat-cache/node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -29433,7 +29477,51 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
+    "packages/textlint/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/textlint/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/textlint/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "test/benchmark": {
+      "name": "@textlint/benchmark",
       "version": "13.4.1",
       "license": "MIT",
       "devDependencies": {
@@ -29464,6 +29552,7 @@
       }
     },
     "website": {
+      "name": "textlint-website",
       "version": "13.4.1",
       "devDependencies": {
         "conventional-changelog-angular-all": "^1.7.0",

--- a/packages/@textlint/kernel/src/textlint-kernel.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel.ts
@@ -77,18 +77,16 @@ export class TextlintKernel {
      * @param {Object} options linting options
      * @returns {Promise.<TextlintResult>}
      */
-    lintText(text: string, options: TextlintKernelOptions): Promise<TextlintResult> {
-        return Promise.resolve().then(() => {
-            const descriptor = new TextlintKernelDescriptor({
-                rules: options.rules || [],
-                filterRules: options.filterRules || [],
-                plugins: options.plugins || []
-            });
-            return this._parallelProcess({
-                descriptor,
-                text,
-                options
-            });
+    async lintText(text: string, options: TextlintKernelOptions): Promise<TextlintResult> {
+        const descriptor = new TextlintKernelDescriptor({
+            rules: options.rules || [],
+            filterRules: options.filterRules || [],
+            plugins: options.plugins || []
+        });
+        return this._parallelProcess({
+            descriptor,
+            text,
+            options
         });
     }
 
@@ -98,18 +96,16 @@ export class TextlintKernel {
      * @param {Object} options lint options
      * @returns {Promise.<TextlintFixResult>}
      */
-    fixText(text: string, options: TextlintKernelOptions): Promise<TextlintFixResult> {
-        return Promise.resolve().then(() => {
-            const descriptor = new TextlintKernelDescriptor({
-                rules: options.rules || [],
-                filterRules: options.filterRules || [],
-                plugins: options.plugins || []
-            });
-            return this._sequenceProcess({
-                descriptor,
-                options,
-                text
-            });
+    async fixText(text: string, options: TextlintKernelOptions): Promise<TextlintFixResult> {
+        const descriptor = new TextlintKernelDescriptor({
+            rules: options.rules || [],
+            filterRules: options.filterRules || [],
+            plugins: options.plugins || []
+        });
+        return this._sequenceProcess({
+            descriptor,
+            options,
+            text
         });
     }
 

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -60,7 +60,7 @@
     "debug": "^4.3.4",
     "file-entry-cache": "^5.0.1",
     "get-stdin": "^5.0.1",
-    "glob": "^7.2.3",
+    "glob": "^10.3.10",
     "md5": "^2.3.0",
     "mkdirp": "^0.5.6",
     "optionator": "^0.9.3",

--- a/packages/textlint/src/DEPRECATED/engine/textlint-engine-core.ts
+++ b/packages/textlint/src/DEPRECATED/engine/textlint-engine-core.ts
@@ -226,12 +226,12 @@ new TextLintEngine({
      * @param {String[]}  files An array of file and directory names.
      * @returns {Promise<TextlintResult[]>} The results for all files that were linted.
      */
-    executeOnFiles(files: string[]): Promise<LintResult[]> {
+    async executeOnFiles(files: string[]): Promise<LintResult[]> {
         const execFile = this.onFile(this.textlint);
         const patterns = pathsToGlobPatterns(files, {
             extensions: this.textlintrcDescriptor.availableExtensions
         });
-        const targetFiles = findFiles(patterns, { ignoreFilePath: this.config.ignoreFile });
+        const targetFiles = await findFiles(patterns, { ignoreFilePath: this.config.ignoreFile });
         // Maybe, unAvailableFilePath should be warning.
         // But, The user can use glob pattern like `src/**/*` as arguments.
         // pathsToGlobPatterns not modified that pattern.

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -66,12 +66,6 @@ export const createLinter = (options: CreateLinterOptions) => {
             const { availableFiles, unAvailableFiles } = separateByAvailability(targetFiles, {
                 extensions: options.descriptor.availableExtensions
             });
-            console.log({
-                patterns,
-                targetFiles,
-                availableFiles,
-                unAvailableFiles
-            });
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
             debug("No Process files that are un-support extensions: %j", unAvailableFiles);

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -60,11 +60,17 @@ export const createLinter = (options: CreateLinterOptions) => {
             const patterns = pathsToGlobPatterns(files, {
                 extensions: options.descriptor.availableExtensions
             });
-            const targetFiles = findFiles(patterns, {
+            const targetFiles = await findFiles(patterns, {
                 ignoreFilePath: options.ignoreFilePath
             });
             const { availableFiles, unAvailableFiles } = separateByAvailability(targetFiles, {
                 extensions: options.descriptor.availableExtensions
+            });
+            console.log({
+                patterns,
+                targetFiles,
+                availableFiles,
+                unAvailableFiles
             });
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
@@ -93,7 +99,7 @@ export const createLinter = (options: CreateLinterOptions) => {
             const patterns = pathsToGlobPatterns(files, {
                 extensions: options.descriptor.availableExtensions
             });
-            const targetFiles = findFiles(patterns, {
+            const targetFiles = await findFiles(patterns, {
                 ignoreFilePath: options.ignoreFilePath
             });
             const { availableFiles, unAvailableFiles } = separateByAvailability(targetFiles, {

--- a/packages/textlint/test/cli/cli-test.ts
+++ b/packages/textlint/test/cli/cli-test.ts
@@ -492,4 +492,13 @@ describe("cli-test", function () {
             });
         });
     });
+    describe("when pass non-supported file extension", function () {
+        it("should show warning", function () {
+            return runWithMockLog(async ({ getLogs }) => {
+                const result = await cli.execute("--rule textlint-rule-no-todo /path/to/not-supported-file");
+                console.log(getLogs());
+                assert.strictEqual(result, 1);
+            });
+        });
+    });
 });

--- a/packages/textlint/test/cli/cli-test.ts
+++ b/packages/textlint/test/cli/cli-test.ts
@@ -492,13 +492,4 @@ describe("cli-test", function () {
             });
         });
     });
-    describe("when pass non-supported file extension", function () {
-        it("should show warning", function () {
-            return runWithMockLog(async ({ getLogs }) => {
-                const result = await cli.execute("--rule textlint-rule-no-todo /path/to/not-supported-file");
-                console.log(getLogs());
-                assert.strictEqual(result, 1);
-            });
-        });
-    });
 });

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -4,7 +4,7 @@ import { findFiles, separateByAvailability } from "../../src/util/find-util";
 
 describe("find-util", () => {
     describe("findFiles", () => {
-        const cwd = path.resolve(__dirname, "fixtures/find-util");
+        const cwd = path.posix.resolve(__dirname, "fixtures/find-util");
         it("should find files with relative path pattern", async () => {
             const patterns = ["dir/**/*.md"];
             const files = await findFiles(patterns, { cwd });

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -6,7 +6,7 @@ describe("find-util", () => {
     describe("findFiles", () => {
         const cwd = path.resolve(__dirname, "fixtures/find-util");
         // for glob
-        const posixCwd = path.posix.resolve(__dirname, "fixtures/find-util");
+        const posixCwd = path.posix.resolve(__dirname.replaceAll(path.sep, "/"), "fixtures/find-util");
         it("should find files with relative path pattern", async () => {
             const patterns = ["dir/**/*.md"];
             const files = await findFiles(patterns, { cwd });

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -16,7 +16,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with absolute path pattern", async () => {
-            const patterns = [path.resolve(cwd, "dir/**/*.md")];
+            const patterns = [path.posix.resolve(cwd, "dir/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -26,7 +26,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find dot files", async () => {
-            const patterns = [path.resolve(cwd, "dir/**/*.md")];
+            const patterns = [path.posix.resolve(cwd, "dir/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -36,7 +36,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with multiple path patterns", async () => {
-            const patterns = ["dir/**/*.md", path.resolve(cwd, "ignored/**/*.md")];
+            const patterns = ["dir/**/*.md", path.posix.resolve(cwd, "ignored/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -61,7 +61,7 @@ describe("find-util", () => {
                 ]);
             });
             it("should find files with absolute path patterns", async () => {
-                const patterns = [path.resolve(cwd, "**/*.md")];
+                const patterns = [path.posix.resolve(cwd, "**/*.md")];
                 const files = await findFiles(patterns, {
                     cwd,
                     ignoreFilePath: ".textlintignore"

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -4,7 +4,9 @@ import { findFiles, separateByAvailability } from "../../src/util/find-util";
 
 describe("find-util", () => {
     describe("findFiles", () => {
-        const cwd = path.posix.resolve(__dirname, "fixtures/find-util");
+        const cwd = path.resolve(__dirname, "fixtures/find-util");
+        // for glob
+        const posixCwd = path.posix.resolve(__dirname, "fixtures/find-util");
         it("should find files with relative path pattern", async () => {
             const patterns = ["dir/**/*.md"];
             const files = await findFiles(patterns, { cwd });
@@ -16,7 +18,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with absolute path pattern", async () => {
-            const patterns = [path.posix.resolve(cwd, "./dir/**/*.md")];
+            const patterns = [path.posix.resolve(posixCwd, "./dir/**/*.md")];
             console.log("p@patterns", patterns);
             const files = await findFiles(patterns, { cwd });
             files.sort();
@@ -27,7 +29,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find dot files", async () => {
-            const patterns = [path.posix.resolve(cwd, "./dir/**/*.md")];
+            const patterns = [path.posix.resolve(posixCwd, "./dir/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -37,7 +39,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with multiple path patterns", async () => {
-            const patterns = ["dir/**/*.md", path.posix.resolve(cwd, "ignored/**/*.md")];
+            const patterns = ["dir/**/*.md", path.posix.resolve(posixCwd, "ignored/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -62,7 +64,7 @@ describe("find-util", () => {
                 ]);
             });
             it("should find files with absolute path patterns", async () => {
-                const patterns = [path.posix.resolve(cwd, "**/*.md")];
+                const patterns = [path.posix.resolve(posixCwd, "**/*.md")];
                 const files = await findFiles(patterns, {
                     cwd,
                     ignoreFilePath: ".textlintignore"

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -16,7 +16,8 @@ describe("find-util", () => {
             ]);
         });
         it("should find files with absolute path pattern", async () => {
-            const patterns = [path.posix.resolve(cwd, "dir/**/*.md")];
+            const patterns = [path.posix.resolve(cwd, "./dir/**/*.md")];
+            console.log("p@patterns", patterns);
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
@@ -26,7 +27,7 @@ describe("find-util", () => {
             ]);
         });
         it("should find dot files", async () => {
-            const patterns = [path.posix.resolve(cwd, "dir/**/*.md")];
+            const patterns = [path.posix.resolve(cwd, "./dir/**/*.md")];
             const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [

--- a/packages/textlint/test/util/find-util-test.ts
+++ b/packages/textlint/test/util/find-util-test.ts
@@ -5,9 +5,9 @@ import { findFiles, separateByAvailability } from "../../src/util/find-util";
 describe("find-util", () => {
     describe("findFiles", () => {
         const cwd = path.resolve(__dirname, "fixtures/find-util");
-        it("should find files with relative path pattern", () => {
+        it("should find files with relative path pattern", async () => {
             const patterns = ["dir/**/*.md"];
-            const files = findFiles(patterns, { cwd });
+            const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
                 path.resolve(cwd, "dir/ignored.md"),
@@ -15,9 +15,9 @@ describe("find-util", () => {
                 path.resolve(cwd, "dir/test.md")
             ]);
         });
-        it("should find files with absolute path pattern", () => {
+        it("should find files with absolute path pattern", async () => {
             const patterns = [path.resolve(cwd, "dir/**/*.md")];
-            const files = findFiles(patterns, { cwd });
+            const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
                 path.resolve(cwd, "dir/ignored.md"),
@@ -25,9 +25,9 @@ describe("find-util", () => {
                 path.resolve(cwd, "dir/test.md")
             ]);
         });
-        it("should find dot files", () => {
+        it("should find dot files", async () => {
             const patterns = [path.resolve(cwd, "dir/**/*.md")];
-            const files = findFiles(patterns, { cwd });
+            const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
                 path.resolve(cwd, "dir/ignored.md"),
@@ -35,9 +35,9 @@ describe("find-util", () => {
                 path.resolve(cwd, "dir/test.md")
             ]);
         });
-        it("should find files with multiple path patterns", () => {
+        it("should find files with multiple path patterns", async () => {
             const patterns = ["dir/**/*.md", path.resolve(cwd, "ignored/**/*.md")];
-            const files = findFiles(patterns, { cwd });
+            const files = await findFiles(patterns, { cwd });
             files.sort();
             assert.deepStrictEqual(files, [
                 path.resolve(cwd, "dir/ignored.md"),
@@ -48,9 +48,9 @@ describe("find-util", () => {
             ]);
         });
         context("when specify `ignoreFilePath` option", () => {
-            it("should find files with relative path patterns", () => {
+            it("should find files with relative path patterns", async () => {
                 const patterns = ["**/*.md"];
-                const files = findFiles(patterns, {
+                const files = await findFiles(patterns, {
                     cwd,
                     ignoreFilePath: ".textlintignore"
                 });
@@ -60,9 +60,9 @@ describe("find-util", () => {
                     path.resolve(cwd, "dir/test.md")
                 ]);
             });
-            it("should find files with absolute path patterns", () => {
+            it("should find files with absolute path patterns", async () => {
                 const patterns = [path.resolve(cwd, "**/*.md")];
-                const files = findFiles(patterns, {
+                const files = await findFiles(patterns, {
                     cwd,
                     ignoreFilePath: ".textlintignore"
                 });


### PR DESCRIPTION
According to the benchmark[^1], Glovestream should be faster than Glovesync.

Also, it seems that the bug in the path in Windows is fixed.

- refs https://github.com/isaacs/node-glob/issues/74#issuecomment-31548810

[^1]: https://github.com/isaacs/node-glob/tree/97611cd366e5906a4c58df3f5214af843b0a5e63#benchmark-results
