### PR TITLE
fix(legacy-textlint-core): add `resetRules()`

### DIFF
--- a/packages/@textlint/legacy-textlint-core/README.md
+++ b/packages/@textlint/legacy-textlint-core/README.md
@@ -19,16 +19,20 @@ Install with [npm](https://www.npmjs.com/):
 
 ## Usage
 
+This package provided a procedural API.
+
 ```ts
 import { TextLintCore } from "@textlint/legacy-textlint-core";
 // example packages
 import rule from "textlint-rule-example";
 import plugin from "textlint-plugin-example";
+import { text } from "node:stream/consumers";
 
 const textlintCore = new TextLintCore();
 textlintCore.setupRules({ "example-rule": rule });
 textlintCore.setupPlugins({ "example-plugin": rule });
 const results = await textlintCore.lintText("test", ".example");
+textlintCore.resetRules(); // reset setup
 ```
 
 ## FAQ

--- a/packages/@textlint/legacy-textlint-core/README.md
+++ b/packages/@textlint/legacy-textlint-core/README.md
@@ -9,7 +9,7 @@ This package provides legacy `TextLintCore` compatible API.
 
 This compat package is deprecated. You should use `@textlint/kernel` or new APIs instead of it.
 
-- [Use as Node Modules · textlint](https://textlint.github.io/docs/use-as-modules.html)a
+- [Use as Node Modules · textlint](https://textlint.github.io/docs/use-as-modules.html)
 
 ## Install
 

--- a/packages/@textlint/legacy-textlint-core/README.md
+++ b/packages/@textlint/legacy-textlint-core/README.md
@@ -35,8 +35,6 @@ const results = await textlintCore.lintText("test", ".example");
 textlintCore.resetRules(); // reset setup
 ```
 
-## FAQ
-
 ## Changelog
 
 See [Releases page](https://github.com/textlint/textlint/releases).

--- a/packages/@textlint/legacy-textlint-core/src/index.ts
+++ b/packages/@textlint/legacy-textlint-core/src/index.ts
@@ -121,6 +121,18 @@ export class TextLintCore {
         );
     }
 
+    /**
+     * reset defined rules
+     * reset to initial state
+     */
+    resetRules() {
+        this.kernelDescriptor = new TextlintKernelDescriptor({
+            rules: [],
+            filterRules: [],
+            plugins: builtInPlugins,
+        });
+    }
+
     setupPlugins(plugins = {}, pluginsConfig = {}) {
         this.kernelDescriptor = this.kernelDescriptor.concat(
             new TextlintKernelDescriptor({

--- a/packages/@textlint/legacy-textlint-core/src/index.ts
+++ b/packages/@textlint/legacy-textlint-core/src/index.ts
@@ -36,7 +36,7 @@ const builtInPlugins = [
  *
  * => TextlintKernelRule
  */
-export const rulesObjectToKernelRule: (
+const rulesObjectToKernelRule: (
     rules: { [p: string]: TextlintRuleModule },
     rulesOption: { [p: string]: TextlintKernelRule["options"] }
 ) => TextlintKernelRule[] = (rules, rulesOption) => {
@@ -49,7 +49,7 @@ export const rulesObjectToKernelRule: (
     });
 };
 
-export const filterRulesObjectToKernelRule: (
+const filterRulesObjectToKernelRule: (
     rules: { [p: string]: TextlintFilterRuleReporter },
     rulesOption: { [p: string]: TextlintKernelFilterRule["options"] }
 ) => TextlintKernelFilterRule[] = (rules, rulesOption): TextlintKernelFilterRule[] => {
@@ -101,6 +101,11 @@ export class TextLintCore {
         // noop
     }
 
+    /**
+     * setup rules
+     * @param rules
+     * @param rulesOption
+     */
     setupRules(rules = {}, rulesOption = {}) {
         this.kernelDescriptor = this.kernelDescriptor.concat(
             new TextlintKernelDescriptor({
@@ -111,6 +116,11 @@ export class TextLintCore {
         );
     }
 
+    /**
+     * setup filter rules
+     * @param filterRules
+     * @param filterRulesConfig
+     */
     setupFilterRules(filterRules = {}, filterRulesConfig = {}) {
         this.kernelDescriptor = this.kernelDescriptor.concat(
             new TextlintKernelDescriptor({
@@ -133,6 +143,11 @@ export class TextLintCore {
         });
     }
 
+    /**
+     * setup plugins
+     * @param plugins
+     * @param pluginsConfig
+     */
     setupPlugins(plugins = {}, pluginsConfig = {}) {
         this.kernelDescriptor = this.kernelDescriptor.concat(
             new TextlintKernelDescriptor({
@@ -143,6 +158,12 @@ export class TextLintCore {
         );
     }
 
+    /**
+     * lint text and return results
+     * default ext is ".txt"
+     * @param text
+     * @param ext
+     */
     async lintText(text: string, ext = ".txt") {
         const kernel = new TextlintKernel();
         return kernel.lintText(text, {
@@ -151,6 +172,10 @@ export class TextLintCore {
         });
     }
 
+    /**
+     * lint text as markdown and return results
+     * @param text
+     */
     async lintMarkdown(text: string) {
         const kernel = new TextlintKernel();
         return kernel.lintText(text, {
@@ -159,6 +184,10 @@ export class TextLintCore {
         });
     }
 
+    /**
+     * lint file and return results
+     * @param filePath
+     */
     async lintFile(filePath: string) {
         const content = await fs.readFile(filePath, "utf-8");
         const kernel = new TextlintKernel();
@@ -169,6 +198,12 @@ export class TextLintCore {
         });
     }
 
+    /**
+     * fix text and return results
+     * default ext is ".txt"
+     * @param text
+     * @param ext
+     */
     async fixText(text: string, ext = ".txt") {
         const kernel = new TextlintKernel();
         return kernel.fixText(text, {


### PR DESCRIPTION
- `textlint.resetRules()` to initilize setup

Original `TextLintCore` has this one.