### PR TITLE
feat: add support for JS comment syntax for MDX

### DIFF
--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -47,6 +47,11 @@ export function parse(text: string): TxtDocumentNode {
                 node.loc = positionCompensated;
                 node.range = range;
                 node.raw = textWithoutBOM.slice(range[0], range[1]);
+                // MDX only supports JS comment syntax: `{/* comment */}`
+                // But Markdown parser interprets this as a `Str`.
+                if (node.type === ASTNodeTypes.Str && /({\/\*((?:.|\s)*?)\*\/})/.test(node.raw)) {
+                    node.type = ASTNodeTypes.Html;
+                }
                 // Compatible for https://github.com/syntax-tree/unist, but it is hidden
                 Object.defineProperty(node, "position", {
                     enumerable: false,

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -49,7 +49,7 @@ export function parse(text: string): TxtDocumentNode {
                 node.raw = textWithoutBOM.slice(range[0], range[1]);
                 // MDX only supports JS comment syntax: `{/* comment */}`
                 // But Markdown parser interprets this as a `Str`.
-                if (node.type === ASTNodeTypes.Str && /({\/\*((?:.|\s)*?)\*\/})/.test(node.raw)) {
+                if (node.type === ASTNodeTypes.Str && /^({\/\*(.|\s)*\*\/})$/.test(node.raw)) {
                     node.type = ASTNodeTypes.Html;
                 }
                 // Compatible for https://github.com/syntax-tree/unist, but it is hidden

--- a/packages/@textlint/markdown-to-ast/test/fixtures/mdx-comments.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/mdx-comments.text/input.md
@@ -1,0 +1,7 @@
+Paragraph one.
+
+{/* This is a simple comment */}
+
+{/*
+	This is another comment.
+*/}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/mdx-comments.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/mdx-comments.text/output.json
@@ -1,0 +1,137 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Paragraph one.",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 14
+                        }
+                    },
+                    "range": [
+                        0,
+                        14
+                    ],
+                    "raw": "Paragraph one."
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                0,
+                14
+            ],
+            "raw": "Paragraph one."
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Html",
+                    "value": "{/* This is a simple comment */}",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 32
+                        }
+                    },
+                    "range": [
+                        16,
+                        48
+                    ],
+                    "raw": "{/* This is a simple comment */}"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 32
+                }
+            },
+            "range": [
+                16,
+                48
+            ],
+            "raw": "{/* This is a simple comment */}"
+        },
+        {
+            "type": "Paragraph",
+            "children": [
+                {
+                    "type": "Html",
+                    "value": "{/*\nThis is another comment.\n*/}",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 3
+                        }
+                    },
+                    "range": [
+                        50,
+                        83
+                    ],
+                    "raw": "{/*\n\tThis is another comment.\n*/}"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 3
+                }
+            },
+            "range": [
+                50,
+                83
+            ],
+            "raw": "{/*\n\tThis is another comment.\n*/}"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 8,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        84
+    ],
+    "raw": "Paragraph one.\n\n{/* This is a simple comment */}\n\n{/*\n\tThis is another comment.\n*/}\n"
+}


### PR DESCRIPTION
In preparation for using [textlint-filter-rule-comments](https://github.com/textlint/textlint-filter-rule-comments) with only JS comment syntax in MDX, The interpretation of `Str` containing the JS comment syntax `{/* comment */}` was changed to `Html`.

## References

- https://github.com/textlint/textlint/issues/1368