### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Experimental:
   --max-concurrency Number    maxConcurrency for --parallel
 ```
 
-When running texlint, you can target files to lint using the glob patterns.
+When running textlint, you can target files to lint using the glob patterns.
 Make sure that you enclose any glob parameter you pass in quotes.
 
 ```sh


### PR DESCRIPTION
## Feature Description

- fix typo in README (`texlint` -> `textlint`)