### PR TITLE
docs: deprecated `--parallel` and `--max-concurrency` in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
-  --parallel                  Lint files in parallel
-  --max-concurrency Number    maxConcurrency for --parallel
 ```
 
 When running textlint, you can target files to lint using the glob patterns.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,8 +72,6 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
-  --parallel                  Lint files in parallel
-  --max-concurrency Number    maxConcurrency for --parallel
 ```
 
 ## Pipe to textlint


### PR DESCRIPTION
Related: https://github.com/textlint/textlint/pull/1338