### PR TITLE
fix(docs): remove Lato from the documentation website

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -26,7 +26,6 @@
 
 /* Header */
 .navigationSlider .slidingNav ul {
-    font-family: Lato, serif;
     font-size: 18px;
     font-weight: bold;
     color: #ffffff;

--- a/website/static/css/index.css
+++ b/website/static/css/index.css
@@ -84,7 +84,6 @@
     line-height: 50px;
     border-radius: 100px;
     background-color: var(--textColor);
-    font-family: Lato, serif;
     font-size: 16px;
     font-weight: bold;
     text-align: center;
@@ -111,14 +110,13 @@
 
 .Playground .Playground-copy,
 .GettingStarted .GettingStarted-copy {
-    font-family: Lato, serif;
     font-size: 18px !important;
     font-weight: 300 !important;
     text-align: center !important;
     color: var(--textColor) !important;
 }
 
-/* Hide Playground on mobile*/
+/* Hide Playground on mobile */
 @media only screen and (max-width: 736px) {
     .Playground-frame {
         display: none;
@@ -144,7 +142,7 @@
         display: none;
     }
 
-    /* Mobile shrink width*/
+    /* Mobile shrink width */
     .GettingStarted ol {
         margin-top: 32px;
         margin-left: 0;


### PR DESCRIPTION
Closes #1403 

<img width="1582" alt="Screenshot 2024-08-09 at 17 16 09" src="https://github.com/user-attachments/assets/414d0886-9908-4e32-8335-6d62064988f4">

<img width="1582" alt="Screenshot 2024-08-09 at 17 17 19" src="https://github.com/user-attachments/assets/9c04c1df-935a-4360-bc5f-fa45671b5150">

<img width="1582" alt="Screenshot 2024-08-09 at 17 18 09" src="https://github.com/user-attachments/assets/9792171b-c39c-4f34-8640-33b8073e7dfa">