### PR TITLE
refactor(formatter): import formatter as static

### DIFF
--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -81,6 +81,11 @@ ${ex}`);
 export function createFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
+    if (builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
+        return function (results: TextlintFixResult[]) {
+            return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
+        };
+    }
     let formatter: (results: TextlintFixResult[], formatterConfig: FormatterConfig) => string;
     let formatterPath;
     if (fs.existsSync(formatterName)) {

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -9,12 +9,14 @@ import debug0 from "debug";
 import tryResolve from "try-resolve";
 import { pathToFileURL } from "node:url";
 // formatters
+import compatsFormatter from "./formatters/compats";
 import diffFormatter from "./formatters/diff";
 import fixedResultFormatter from "./formatters/fixed-result";
 import jsonFormatter from "./formatters/json";
 import stylishFormatter from "./formatters/stylish";
 
 const builtinFormatterList = {
+    compats: compatsFormatter,
     diff: diffFormatter,
     "fixed-result": fixedResultFormatter,
     json: jsonFormatter,

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -8,12 +8,7 @@ import debug0 from "debug";
 // @ts-expect-error
 import tryResolve from "try-resolve";
 import { pathToFileURL } from "node:url";
-
-// compats.ts
-// diff.ts
-// fixed-result.ts
-// json.ts
-// stylish.ts
+// formatters
 import diffFormatter from "./formatters/diff";
 import fixedResultFormatter from "./formatters/fixed-result";
 import jsonFormatter from "./formatters/json";

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -93,6 +93,11 @@ ${ex}`);
 export function createFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
+    if (builtinFormatterNames.includes(formatterName)) {
+        return function (results: TextlintResult[]) {
+            return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
+        };
+    }
     let formatter: (results: TextlintResult[], formatterConfig: FormatterConfig) => string;
     let formatterPath;
     if (fs.existsSync(formatterName)) {

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -10,14 +10,32 @@ import path from "path";
 import tryResolve from "try-resolve";
 import debug0 from "debug";
 import { pathToFileURL } from "node:url";
+// formatter
+import checkstyleFormatter from "./formatters/checkstyle";
+import compactFormatter from "./formatters/compact";
+import jslintXMLFormatter from "./formatters/jslint-xml";
+import jsonFormatter from "./formatters/json";
+import junitFormatter from "./formatters/junit";
+import prettyErrorFormatter from "./formatters/pretty-error";
+import stylishFormatter from "./formatters/stylish";
+import tableFormatter from "./formatters/table";
+import tapFormatter from "./formatters/tap";
+import unixFormatter from "./formatters/unix";
 
-const isFile = (filePath: string) => {
-    try {
-        return fs.statSync(filePath).isFile();
-    } catch {
-        return false;
-    }
-};
+const builtinFormatterList = {
+    checkstyle: checkstyleFormatter,
+    compact: compactFormatter,
+    "jslint-xml": jslintXMLFormatter,
+    json: jsonFormatter,
+    junit: junitFormatter,
+    "pretty-error": prettyErrorFormatter,
+    stylish: stylishFormatter,
+    table: tableFormatter,
+    tap: tapFormatter,
+    unix: unixFormatter
+} as const;
+type BuiltInFormatterName = keyof typeof builtinFormatterList;
+const builtinFormatterNames = Object.keys(builtinFormatterList);
 // import() can not load Window file path
 // convert file path to file URL before import()
 // https://github.com/nodejs/node/issues/31710
@@ -36,6 +54,13 @@ export interface FormatterConfig {
 export async function loadFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
+    if (builtinFormatterNames.includes(formatterName)) {
+        return {
+            format(results: TextlintResult[]) {
+                return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
+            }
+        };
+    }
     let formatter: (results: TextlintResult[], formatterConfig: FormatterConfig) => string;
     let formatterPath;
     if (fs.existsSync(formatterName)) {
@@ -43,15 +68,9 @@ export async function loadFormatter(formatterConfig: FormatterConfig) {
     } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
         formatterPath = path.resolve(process.cwd(), formatterName);
     } else {
-        if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.js`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.js`;
-        } else if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.ts`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.ts`;
-        } else {
-            const pkgPath = tryResolve(`textlint-formatter-${formatterName}`) || tryResolve(formatterName);
-            if (pkgPath) {
-                formatterPath = pkgPath;
-            }
+        const pkgPath = tryResolve(`textlint-formatter-${formatterName}`) || tryResolve(formatterName);
+        if (pkgPath) {
+            formatterPath = pkgPath;
         }
     }
     try {
@@ -81,15 +100,9 @@ export function createFormatter(formatterConfig: FormatterConfig) {
     } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
         formatterPath = path.resolve(process.cwd(), formatterName);
     } else {
-        if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.js`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.js`;
-        } else if (isFile(`${path.join(__dirname, "formatters/", formatterName)}.ts`)) {
-            formatterPath = `${path.join(__dirname, "formatters/", formatterName)}.ts`;
-        } else {
-            const pkgPath = tryResolve(`textlint-formatter-${formatterName}`) || tryResolve(formatterName);
-            if (pkgPath) {
-                formatterPath = pkgPath;
-            }
+        const pkgPath = tryResolve(`textlint-formatter-${formatterName}`) || tryResolve(formatterName);
+        if (pkgPath) {
+            formatterPath = pkgPath;
         }
     }
     try {
@@ -108,12 +121,9 @@ export interface FormatterDetail {
 }
 
 export function getFormatterList(): FormatterDetail[] {
-    return fs
-        .readdirSync(path.join(__dirname, "formatters"))
-        .filter((file: string) => {
-            return path.extname(file) === ".js";
-        })
-        .map((file: string) => {
-            return { name: path.basename(file, ".js") };
-        });
+    return builtinFormatterNames.map((name) => {
+        return {
+            name
+        };
+    });
 }


### PR DESCRIPTION
If textlint is to become a single executable binary in the future, it is important to make it a static import.

- dynamic load is hard to build binary
