### PR TITLE
docs: add note about `LinkReference`, `ImageReference` and `Definition`

### DIFF
--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -195,7 +195,7 @@ These types are defined in [`@textlint/ast-node-types`](https://github.com/textl
 | ASTNodeTypes.TableCell          | TxtTableCellNode                    | Table cell Node. textlint 13+               |
 | ASTNodeTypes.TableCellExit      | TxtTableCellNode                    |                                             |
 
-> [!NOTE]
+> 📝Note
 > `LinkReference`, `ImageReference` and `Definition` are introduced in textlint [v14.5.0](https://github.com/textlint/textlint/releases/tag/v14.5.0).
 
 Some node have additional properties.

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -195,6 +195,9 @@ These types are defined in [`@textlint/ast-node-types`](https://github.com/textl
 | ASTNodeTypes.TableCell          | TxtTableCellNode                    | Table cell Node. textlint 13+               |
 | ASTNodeTypes.TableCellExit      | TxtTableCellNode                    |                                             |
 
+> [!NOTE]
+> `LinkReference`, `ImageReference` and `Definition` are introduced in textlint [v14.5.0](https://github.com/textlint/textlint/releases/tag/v14.5.0).
+
 Some node have additional properties.
 For example, `TxtHeaderNode` has `level` property.
 


### PR DESCRIPTION
Note that if you use this from an earlier version of textlint, it will be `undefined`.

- #1459 
- https://github.com/textlint/textlint/releases/tag/v14.5.0