### PR TITLE
feat(config-loader): validate UTF-8 encoding for configuration file

### DIFF
--- a/packages/@textlint/config-loader/src/config-loader.ts
+++ b/packages/@textlint/config-loader/src/config-loader.ts
@@ -203,13 +203,6 @@ export const loadConfig = async (options: TextlintConfigLoaderOptions): Promise<
  */
 export const loadRawConfig = async (options: TextlintConfigLoaderOptions): Promise<TextlintConfigLoaderRawResult> => {
     try {
-        if (
-            options.configFilePath &&
-            fs.existsSync(options.configFilePath) &&
-            !isUtf8(fs.readFileSync(options.configFilePath))
-        ) {
-            throw new Error("textlint configuration file must be encoded in UTF-8");
-        }
         const results = rcFile<TextlintRcConfig>("textlint", {
             cwd: options.cwd,
             configFileName: options.configFilePath,
@@ -231,6 +224,9 @@ The config file define the use of rules.`)
                     ]
                 }
             };
+        }
+        if (results.filePath && fs.existsSync(results.filePath) && !isUtf8(fs.readFileSync(results.filePath))) {
+            throw new Error("textlint configuration file must be encoded in UTF-8");
         }
         return {
             ok: true,

--- a/packages/@textlint/config-loader/src/config-loader.ts
+++ b/packages/@textlint/config-loader/src/config-loader.ts
@@ -3,6 +3,8 @@ import { TextLintModuleResolver } from "./textlint-module-resolver";
 import { loadFilterRules, loadPlugins, loadRules } from "./loader";
 import { TextlintRcConfig } from "./TextlintRcConfig";
 import type { TextlintConfigDescriptor } from "./TextlintConfigDescriptor";
+import { isUtf8 } from "node:buffer";
+import fs from "node:fs";
 
 export type TextlintConfigLoaderOptions = {
     cwd?: string;
@@ -201,6 +203,13 @@ export const loadConfig = async (options: TextlintConfigLoaderOptions): Promise<
  */
 export const loadRawConfig = async (options: TextlintConfigLoaderOptions): Promise<TextlintConfigLoaderRawResult> => {
     try {
+        if (
+            options.configFilePath &&
+            fs.existsSync(options.configFilePath) &&
+            !isUtf8(fs.readFileSync(options.configFilePath))
+        ) {
+            throw new Error("textlint configuration file must be encoded in UTF-8");
+        }
         const results = rcFile<TextlintRcConfig>("textlint", {
             cwd: options.cwd,
             configFileName: options.configFilePath,
@@ -216,7 +225,7 @@ export const loadRawConfig = async (options: TextlintConfigLoaderOptions): Promi
                     message: "textlint config is not found",
                     errors: [
                         new Error(`textlint config is not found
-                
+
 textlint require .textlintrc config file.
 The config file define the use of rules.`)
                     ]

--- a/packages/@textlint/config-loader/test/fixtures/euc-jp.json
+++ b/packages/@textlint/config-loader/test/fixtures/euc-jp.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "no-todo": {
+      "EUC-JPのテキスト": true
+    }
+  }
+}

--- a/packages/@textlint/config-loader/test/fixtures/shift-jis.json
+++ b/packages/@textlint/config-loader/test/fixtures/shift-jis.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "no-todo": {
+      "SHift_JISのテキスト": true
+    }
+  }
+}

--- a/packages/@textlint/config-loader/test/index.test.ts
+++ b/packages/@textlint/config-loader/test/index.test.ts
@@ -55,4 +55,28 @@ describe("@textlint/config-loader", () => {
             );
         });
     });
+    context("when config file is not encoded in UTF-8", () => {
+        it("should validate UTF-8 encoding and reject non-UTF-8 files", () => {
+            const notUTF8Files = ["shift-jis.json", "euc-jp.json"];
+            notUTF8Files.forEach(async (notUTF8File) => {
+                const configFile = path.join(__dirname, "fixtures", notUTF8File);
+                const result = await loadRawConfig({
+                    configFilePath: configFile,
+                    node_modulesDir: modulesDir
+                });
+                assert.strictEqual(result.ok, false, "Result should be not ok for non-UTF-8 file");
+
+                if (!result.ok) {
+                    assert.strictEqual(
+                        result.error.message,
+                        "textlint configuration file must be encoded in UTF-8",
+                        "Error message should indicate UTF-8 encoding issue"
+                    );
+
+                    const errorDetail = result.error.errors[0].message;
+                    assert.ok(errorDetail.includes("UTF-8"), "Error details should mention UTF-8 encoding");
+                }
+            });
+        });
+    });
 });

--- a/packages/@textlint/config-loader/test/index.test.ts
+++ b/packages/@textlint/config-loader/test/index.test.ts
@@ -74,7 +74,7 @@ describe("@textlint/config-loader", () => {
                     );
 
                     const errorDetail = result.error.errors[0].message;
-                    assert.ok(errorDetail.includes("UTF-8"), "Error details should mention UTF-8 encoding");
+                    assert.match(errorDetail, /UTF-8/, "Error details should mention UTF-8 encoding");
                 }
             });
         });


### PR DESCRIPTION
close https://github.com/textlint/textlint/issues/298

This pull request introduces changes to the `@textlint/config-loader` package to enforce UTF-8 encoding for configuration files.

### UTF-8 Encoding Validation:

* [`packages/@textlint/config-loader/src/config-loader.ts`](diffhunk://#diff-ad9621f1e6319b5812853449bf45c8bdc5ba98dd16809a6b2b6777becb88e59bR6-R7): Added UTF-8 encoding validation to ensure that configuration files are encoded in UTF-8 and throw an error if they are not. [[1]](diffhunk://#diff-ad9621f1e6319b5812853449bf45c8bdc5ba98dd16809a6b2b6777becb88e59bR6-R7) [[2]](diffhunk://#diff-ad9621f1e6319b5812853449bf45c8bdc5ba98dd16809a6b2b6777becb88e59bR206-R212)

### Test Updates:

* [`packages/@textlint/config-loader/test/index.test.ts`](diffhunk://#diff-6ffb1fa27de25171d0c069abd8d9240858eee355ee4ec4715a0e63805feb9a74R58-R81): Added a new test context to validate that non-UTF-8 encoded configuration files are correctly rejected with an appropriate error message.

### Test Fixtures:

* [`packages/@textlint/config-loader/test/fixtures/euc-jp.json`](diffhunk://#diff-c5c5b836518c466948b3601c70fc81c98b366a2c78f3aa3e270743db782c9a65R1-R7): Added a new test fixture file encoded in EUC-JP for testing purposes.
* [`packages/@textlint/config-loader/test/fixtures/shift-jis.json`](diffhunk://#diff-b6026162fc260ae834bf19bbfe64d571ee97fe06a07a0b7d96dbda46b76a79d8R1-R7): Added a new test fixture file encoded in Shift-JIS for testing purposes.