### PR TITLE
fix: add type=commonjs

### DIFF
--- a/packages/@textlint/ast-node-types/package.json
+++ b/packages/@textlint/ast-node-types/package.json
@@ -11,6 +11,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "./lib/src/index.js",
     "module": "./module/src/index.js",
     "types": "./lib/src/index.d.ts",

--- a/packages/@textlint/ast-tester/package.json
+++ b/packages/@textlint/ast-tester/package.json
@@ -19,6 +19,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "./module/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/packages/@textlint/ast-traverse/package.json
+++ b/packages/@textlint/ast-traverse/package.json
@@ -16,6 +16,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "./lib/src/index.js",
     "module": "./module/src/index.js",
     "types": "./lib/src/index.d.ts",

--- a/packages/@textlint/config-loader/package.json
+++ b/packages/@textlint/config-loader/package.json
@@ -15,6 +15,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "sideEffects": false,
     "main": "lib/src/index.js",
     "module": "module/src/index.js",

--- a/packages/@textlint/feature-flag/package.json
+++ b/packages/@textlint/feature-flag/package.json
@@ -15,6 +15,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "./lib/src/index.js",
     "types": "./lib/src/index.d.ts",
     "module": "./module/src/index.js",

--- a/packages/@textlint/fixer-formatter/package.json
+++ b/packages/@textlint/fixer-formatter/package.json
@@ -21,6 +21,7 @@
   },
   "license": "MIT",
   "author": "azu",
+  "type": "commonjs",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "files": [

--- a/packages/@textlint/kernel/package.json
+++ b/packages/@textlint/kernel/package.json
@@ -15,6 +15,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "./module/src/index.js",
     "typings": "lib/src/index.d.ts",

--- a/packages/@textlint/legacy-textlint-core/package.json
+++ b/packages/@textlint/legacy-textlint-core/package.json
@@ -18,6 +18,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",
     "directories": {

--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -12,6 +12,7 @@
   },
   "license": "MIT",
   "author": "azu",
+  "type": "commonjs",
   "main": "lib/src/index.js",
   "module": "module/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -12,6 +12,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/packages/@textlint/module-interop/package.json
+++ b/packages/@textlint/module-interop/package.json
@@ -19,6 +19,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/packages/@textlint/source-code-fixer/package.json
+++ b/packages/@textlint/source-code-fixer/package.json
@@ -16,6 +16,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "sideEffects": false,
     "main": "lib/src/index.js",
     "module": "module/src/index.js",

--- a/packages/@textlint/text-to-ast/package.json
+++ b/packages/@textlint/text-to-ast/package.json
@@ -17,6 +17,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/packages/@textlint/textlint-plugin-markdown/package.json
+++ b/packages/@textlint/textlint-plugin-markdown/package.json
@@ -17,6 +17,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "types": "lib/src/index.d.ts",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",

--- a/packages/@textlint/textlint-plugin-text/package.json
+++ b/packages/@textlint/textlint-plugin-text/package.json
@@ -12,6 +12,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "types": "lib/src/index.d.ts",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",

--- a/packages/@textlint/types/package.json
+++ b/packages/@textlint/types/package.json
@@ -18,6 +18,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",
     "directories": {

--- a/packages/@textlint/utils/package.json
+++ b/packages/@textlint/utils/package.json
@@ -16,6 +16,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "main": "lib/src/index.js",
     "module": "module/src/index.js",
     "types": "lib/src/index.d.ts",

--- a/packages/textlint-scripts/package.json
+++ b/packages/textlint-scripts/package.json
@@ -4,6 +4,7 @@
     },
     "author": "azu",
     "license": "MIT",
+    "type": "commonjs",
     "files": [
         "register.js",
         "register-ts.js",

--- a/packages/textlint-tester/package.json
+++ b/packages/textlint-tester/package.json
@@ -13,6 +13,7 @@
     },
     "license": "MIT",
     "author": "azu",
+    "type": "commonjs",
     "files": [
         "bin/",
         "lib/",

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "author": "azu",
+  "type": "commonjs",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "bin": {


### PR DESCRIPTION
`require(esm)` misleading current packages.

- fix #1473 
- ref #1472 