### PR TITLE
docs: replace vscode-textlint link

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ For more details, see [integrations document](./docs/integrations.md).
   - [scrooloose/syntastic](https://github.com/vim-syntastic/syntastic "scrooloose/syntastic")
     - See [Markdown](https://github.com/vim-syntastic/syntastic/wiki/Markdown "Markdown"), [Text](https://github.com/vim-syntastic/syntastic/wiki/Text "Text") and [HTML](https://github.com/vim-syntastic/syntastic/wiki/HTML "HTML") of [scrooloose/syntastic Wiki](https://github.com/vim-syntastic/syntastic/wiki/Syntax-Checkers "Syntax Checkers · scrooloose/syntastic Wiki")
 - VS Code
-  - [taichi/vscode-textlint](https://github.com/taichi/vscode-textlint)
+  - [textlint/vscode-textlint](https://github.com/textlint/vscode-textlint)
 - [micro](https://github.com/zyedidia/micro "micro")
   - [hidaruma/micro-textlint-plugin](https://github.com/hidaruma/micro-textlint-plugin "hidaruma/micro-textlint-plugin: textlint plugin for micro-editor")
 - NetBeans


### PR DESCRIPTION
https://github.com/taichi/vscode-textlint is deprecated.
Instead of it, change the link to official fork: https://github.com/textlint/vscode-textlint

Thanks to @taichi!

cc @3w36zj6 