### PR TITLE
fix(docs): update links from textlint.github.io to textlint.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Output Step Summary
         run: |
           cat ./test/benchmark/result.md > $GITHUB_STEP_SUMMARY
-          echo "- <https://textlint.github.io/textlint/benchmarks/>" >> $GITHUB_STEP_SUMMARY
+          echo "- <https://textlint.org/textlint/benchmarks/>" >> $GITHUB_STEP_SUMMARY
   e2e:
     name: E2E
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://textlint.github.io/media/banner/banner_710x256.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://textlint.github.io/media/logo/spaced/textlint-logo.png">
-  <img alt="textlint log" src="https://textlint.github.io/media/logo/spaced/textlint-logo.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://textlint.org/media/banner/banner_710x256.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://textlint.org/media/logo/spaced/textlint-logo.png">
+  <img alt="textlint log" src="https://textlint.org/media/logo/spaced/textlint-logo.png">
 </picture>
 
 > The pluggable linting tool for text and markdown.
@@ -23,7 +23,7 @@ textlint is similar to [ESLint](http://eslint.org/ "ESLint"), but it's for use w
 - Searchable documents
 - Release blog
 
-Visit [https://textlint.github.io/](https://textlint.github.io/).
+Visit [https://textlint.org/](https://textlint.org/).
 
 ## Features
 
@@ -303,7 +303,7 @@ If you create a new rule, and add it to the wiki :)
 
 ### Fixable
 
-[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.org/)
 
 Some rules are fixable using the `--fix` command line flag.
 
@@ -324,7 +324,7 @@ $ npx textlint --fix --dry-run --format diff README.md
 You can copy and paste to your README.
 
 ```markdown
-[![textlint fixable rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/)
+[![textlint fixable rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.org/)
 ```
 
 ### Built-in formatters
@@ -436,7 +436,7 @@ Please see docs/
 
 You can use filter rule like [textlint-filter-rule-comments](https://github.com/textlint/textlint-filter-rule-comments "textlint-filter-rule-comments").
 
-Please see [Ignoring Text · textlint](https://textlint.github.io/docs/ignore.html) for more details.
+Please see [Ignoring Text · textlint](https://textlint.org/docs/ignore.html) for more details.
 
 ## Integrations
 

--- a/docs/rule-fixable.md
+++ b/docs/rule-fixable.md
@@ -122,10 +122,10 @@ If your textlint's rule is *fixable*, display "this rule is fixable!".
 
 We have *fixable* rule badge and use it!
 
-[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/) 
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.org/) 
 
 ```markdown
-[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/) 
+[![textlint rule](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.org/) 
 ```
 
 ## Terms

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -81,9 +81,9 @@ In textlint@11.1.0<=, you had to write `[Syntax.Document + ":exit"]`.
 
 [![gif visualize-txt-traverse](https://gyazo.com/155c68f0f9ff35e0a549d655a787c01e.gif)](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse")
 
-[AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") help you better understand [TxtAST](./txtnode.md).
+[AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint") help you better understand [TxtAST](./txtnode.md).
 
-[![ast-explorer fork](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
+[![ast-explorer fork](assets/ast-explorer.png)](https://textlint.org/astexplorer/)
 
 
 **Related information:**

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -14,9 +14,9 @@ Each node has common properties like `type`, `raw`, `loc`, `range` and `parent` 
 
 Each node has own properties that is defined in each node type.
 
-[![textlint ast-explorer](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
+[![textlint ast-explorer](assets/ast-explorer.png)](https://textlint.org/astexplorer/)
 
-[AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") is useful for understanding AST.
+[AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint") is useful for understanding AST.
 
 ### `TxtNode`
 
@@ -264,9 +264,9 @@ If you want to use this interface from TypeScript, [packages/ast-node-types](htt
 
 ## Online Parsing Demo
 
-[![ast-explorer fork](assets/ast-explorer.png)](https://textlint.github.io/astexplorer/)
+[![ast-explorer fork](assets/ast-explorer.png)](https://textlint.org/astexplorer/)
 
-[AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") is useful for understanding AST.
+[AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint") is useful for understanding AST.
 
 Minimum(recommended) rules is following code:
 
@@ -326,7 +326,7 @@ In other word, textlint's rule handle `TxtNode`, but [formatter](./formatter.md 
 
 Input: `*text*`
 
-Output: The AST by [AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint") + Markdown
+Output: The AST by [AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint") + Markdown
 
 ```json
 {

--- a/examples/config-in-package-json/README.md
+++ b/examples/config-in-package-json/README.md
@@ -2,7 +2,7 @@
 
 `package.json`'s `"textlint"` field can be used for configuration.
 
-- https://textlint.github.io/docs/configuring.html
+- https://textlint.org/docs/configuring.html
 
 ## Usage
 

--- a/packages/@textlint/kernel/src/textlint-kernel.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel.ts
@@ -172,7 +172,7 @@ ${preProcessResult.stack}
             
 You can check the validation result with "DEBUG=textlint*" env
 
-See https://textlint.github.io/docs/plugin.html`
+See https://textlint.org/docs/plugin.html`
             );
         }
         const sourceCode = new TextlintSourceCodeImpl({
@@ -241,7 +241,7 @@ See https://textlint.github.io/docs/plugin.html`
             
 You can check the validation result with "DEBUG=textlint*" env
 
-See https://textlint.github.io/docs/plugin.html`
+See https://textlint.org/docs/plugin.html`
             );
         }
         const sourceCode = new TextlintSourceCodeImpl({

--- a/packages/@textlint/legacy-textlint-core/README.md
+++ b/packages/@textlint/legacy-textlint-core/README.md
@@ -9,7 +9,7 @@ This package provides legacy `TextLintCore` compatible API.
 
 This compat package is deprecated. You should use `@textlint/kernel` or new APIs instead of it.
 
-- [Use as Node Modules · textlint](https://textlint.github.io/docs/use-as-modules.html)
+- [Use as Node Modules · textlint](https://textlint.org/docs/use-as-modules.html)
 
 ## Install
 

--- a/packages/@textlint/markdown-to-ast/README.md
+++ b/packages/@textlint/markdown-to-ast/README.md
@@ -22,7 +22,7 @@ This library is a part of [textlint/textlint](https://github.com/textlint/textli
 
 ## DEMO
 
-- [textlint AST explorer](https://textlint.github.io/astexplorer/ "textlint AST explorer")
+- [textlint AST explorer](https://textlint.org/astexplorer/ "textlint AST explorer")
 
 ## Installation
 

--- a/packages/@textlint/text-to-ast/README.md
+++ b/packages/@textlint/text-to-ast/README.md
@@ -26,7 +26,7 @@ npm install @textlint/text-to-ast
 
 ## DEMO
 
-- [AST explorer for textlint](https://textlint.github.io/astexplorer/ "AST explorer for textlint")
+- [AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint")
 
 ## Usage
 

--- a/packages/textlint-scripts/README.md
+++ b/packages/textlint-scripts/README.md
@@ -4,7 +4,7 @@ textlint scripts help you to create textlint rule.
 
 Documentation of creating a textlint rule:
 
-- [Creating Rules · textlint](https://textlint.github.io/docs/rule.html)
+- [Creating Rules · textlint](https://textlint.org/docs/rule.html)
 
 ## Install
 

--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -1,7 +1,7 @@
 # textlint-tester
 
 [Mocha](http://mochajs.org/ "Mocha") test helper library
-for [textlint](https://github.com/textlint/textlint "textlint") [rule](https://textlint.github.io/docs/rule.html).
+for [textlint](https://github.com/textlint/textlint "textlint") [rule](https://textlint.org/docs/rule.html).
 
 ## Installation
 

--- a/packages/textlint/README.md
+++ b/packages/textlint/README.md
@@ -2,5 +2,5 @@
 
 The pluggable linting tool for text.  
 
-- Website: <https://textlint.github.io/>
+- Website: <https://textlint.org/>
 - Repository: <https://github.com/textlint/textlint>

--- a/packages/textlint/src/DEPRECATED/textfix-engine.ts
+++ b/packages/textlint/src/DEPRECATED/textfix-engine.ts
@@ -9,7 +9,7 @@ import { Logger } from "../util/logger";
 /**
  * TextFixEngine a adapter for TextLintEngineCore.
  * It aim to pull the whole look together. (TextLintEngine and TextFixEngine)
- * @deprecated use new APIs https://textlint.github.io/docs/use-as-modules.html#new-apis
+ * @deprecated use new APIs https://textlint.org/docs/use-as-modules.html#new-apis
  */
 export class TextFixEngine extends AbstractTextLintEngine<TextlintFixResult> {
     constructor(...args: any[]) {

--- a/packages/textlint/src/DEPRECATED/textlint-core.ts
+++ b/packages/textlint/src/DEPRECATED/textlint-core.ts
@@ -32,7 +32,7 @@ import { Logger } from "../util/logger";
 
 /**
  * @class {TextLintCore}
- * @deprecated use new APIs https://textlint.github.io/docs/use-as-modules.html#new-apis
+ * @deprecated use new APIs https://textlint.org/docs/use-as-modules.html#new-apis
  */
 export class TextLintCore {
     private kernel: TextlintKernel;

--- a/packages/textlint/src/DEPRECATED/textlint-engine.ts
+++ b/packages/textlint/src/DEPRECATED/textlint-engine.ts
@@ -9,7 +9,7 @@ import { Logger } from "../util/logger";
 /**
  * TextLintEngine a adapter for TextLintEngineCore.
  * It aim to pull the whole look together. (TextLintEngine and TextFixEngine)
- * @deprecated use new APIs https://textlint.github.io/docs/use-as-modules.html#new-apis
+ * @deprecated use new APIs https://textlint.org/docs/use-as-modules.html#new-apis
  */
 export class TextLintEngine extends AbstractTextLintEngine<TextlintResult> {
     constructor(...args: any[]) {

--- a/packages/textlint/src/index.ts
+++ b/packages/textlint/src/index.ts
@@ -34,7 +34,7 @@ export { TextLintCore } from "./DEPRECATED/textlint-core";
 
 /* = New APIs */
 /**
- * @see {https://textlint.github.io/docs/use-as-modules.html#new-apis}
+ * @see {https://textlint.org/docs/use-as-modules.html#new-apis}
  * @example
  *
  * ```js

--- a/packages/textlint/src/textlint.ts
+++ b/packages/textlint/src/textlint.ts
@@ -37,6 +37,6 @@
 import { TextLintCore } from "./DEPRECATED/textlint-core";
 /**
  * singleton instance
- * @deprecated use new APIs https://textlint.github.io/docs/use-as-modules.html#new-apis
+ * @deprecated use new APIs https://textlint.org/docs/use-as-modules.html#new-apis
  */
 export const textlint = new TextLintCore();

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -14,4 +14,4 @@ npm bench
 
 ## Continuous Benchmark
 
-- https://textlint.github.io/textlint/benchmarks/
+- https://textlint.org/textlint/benchmarks/

--- a/website/blog/2018-05-22-new-website.md
+++ b/website/blog/2018-05-22-new-website.md
@@ -13,9 +13,9 @@ textlint get a new website!
 - [@azu](https://github.com/azu) implement the design and deploy.
 
 
-If you have used textlint in your project or your office, please pull request to add your project to [Users](https://textlint.github.io/users.html)!
+If you have used textlint in your project or your office, please pull request to add your project to [Users](https://textlint.org/users.html)!
 
-- [textlint · users](https://textlint.github.io/users.html)
+- [textlint · users](https://textlint.org/users.html)
 
 ## Related Issues
 

--- a/website/blog/2018-07-22-textlint-11.md
+++ b/website/blog/2018-07-22-textlint-11.md
@@ -33,7 +33,7 @@ For more details, please see [custom extension example](https://github.com/textl
 
 For developer:
 
-if you want to support `extensions` options, see [Plugin · textlint](https://textlint.github.io/docs/plugin.html).
+if you want to support `extensions` options, see [Plugin · textlint](https://textlint.org/docs/plugin.html).
 
 ### Show message if `textlint --init` is success [#529](https://github.com/textlint/textlint/issues/529)
 

--- a/website/blog/2023-01-27-textlint-13.md
+++ b/website/blog/2023-01-27-textlint-13.md
@@ -105,7 +105,7 @@ console.log(output);
 
 For more details, please read next document.
 
-- [Use as Node Modules · textlint](https://textlint.github.io/docs/use-as-modules.html)
+- [Use as Node Modules · textlint](https://textlint.org/docs/use-as-modules.html)
 
 If you have any questions, please ask us via GitHub Discussion.
 
@@ -121,10 +121,10 @@ If you have any questions, please ask us via GitHub Discussion.
 - Improve `@textlint/ast-node-types` types
   - Now, All node types are defined!
   - It changes the existing node type and it is a breaking change
-  - If you want to know TxtAST, please read [TxtAST Interface](https://textlint.github.io/docs/txtnode.html)
+  - If you want to know TxtAST, please read [TxtAST Interface](https://textlint.org/docs/txtnode.html)
 - Use New-CLI instead of Old-CLI
   - textlint has introduced New-CLI and New-APIs in [v12.3.0](https://github.com/textlint/textlint/releases/tag/v12.3.0)
-  - New-CLI uses new APIs: `createLinter`/`loadTextlintrc`/`loadLinterFormatter`/`loadFixerFormatter`( If you want to know new APIs, please read [Use as Node Modules](https://textlint.github.io/docs/use-as-modules.html))
+  - New-CLI uses new APIs: `createLinter`/`loadTextlintrc`/`loadLinterFormatter`/`loadFixerFormatter`( If you want to know new APIs, please read [Use as Node Modules](https://textlint.org/docs/use-as-modules.html))
   - It means that textlint support rules/plugins that are written by ESM 🎉
   - Remove Old-CLI
 

--- a/website/blog/2024-02-03-textlint-14.md
+++ b/website/blog/2024-02-03-textlint-14.md
@@ -76,7 +76,7 @@ Old APIs are `textlint`, `TextLintCore`, `TextLintEngine`, and `TextFixEngine` o
 
 There are replaced by `createLinter` and `loadTextlintrc`, and `loadLinerFormatter` since v13.0.0.
 
-- [textlint v13.0.0 · textlint](https://textlint.github.io/blog/2023/01/27/textlint-13.html)
+- [textlint v13.0.0 · textlint](https://textlint.org/blog/2023/01/27/textlint-13.html)
 
 #### Depretead old APIs
 
@@ -105,7 +105,7 @@ For more details, see [process.emitWarning(warning[, options])](https://nodejs.o
 
 #### Documentaion for New APIs
 
-- [Use as Node Modules · textlint](https://textlint.github.io/docs/use-as-modules.html)
+- [Use as Node Modules · textlint](https://textlint.org/docs/use-as-modules.html)
 
 #### Migration Guide
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -260,20 +260,20 @@ const Playground = (props) => {
                 <p className="Playground-copy">
                     Take textlint for a spin, start typing below.
                     <br />
-                    Want to try more? Go to <a href="https://textlint.github.io/playground">playground</a>.
+                    Want to try more? Go to <a href="https://textlint.org/playground">playground</a>.
                 </p>
             </div>
             <iframe
                 className={"Playground-frame"}
                 sandbox={"allow-scripts"}
-                src="https://textlint.github.io/playground?embed"
+                src="https://textlint.org/playground?embed"
                 title="online demo"
                 width="100%"
                 height="500"
             >
                 <p>
                     Your browser does not support iframes. Please visit{" "}
-                    <a href="https://textlint.github.io/playground">online demo</a>.
+                    <a href="https://textlint.org/playground">online demo</a>.
                 </p>
             </iframe>
         </Container>


### PR DESCRIPTION
fix #1482 