### PR TITLE
feat(kernel): support multi-part extensions in plugin

### DIFF
--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
@@ -41,7 +41,7 @@ export class TextlintPluginDescriptors {
      */
     findPluginDescriptorWithExt(ext: string) {
         return this.descriptors.find((descriptor) => {
-            return descriptor.availableExtensions.includes(ext);
+            return descriptor.availableExtensions.some((availableExtension) => ext.endsWith(availableExtension));
         });
     }
 

--- a/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts
@@ -108,7 +108,7 @@ describe("TextlintRuleDescriptors", function () {
         });
     });
     describe("#findPluginDescriptorWithExt", function () {
-        it("should return a descriptor that match forward with extension", function () {
+        it("should return the first descriptor that matches the single extension", function () {
             const descriptorA = new TextlintPluginDescriptor({
                 pluginId: "TextPlugin",
                 plugin: createDummyPlugin([".txt"]),
@@ -129,6 +129,33 @@ describe("TextlintRuleDescriptors", function () {
             const textPlugin = ruleDescriptors.findPluginDescriptorWithExt(".txt");
             // save first item
             assert.deepStrictEqual(textPlugin, descriptorA);
+        });
+        it("should return the first descriptor that matches the multi-part extension", function () {
+            const phpDescriptor = new TextlintPluginDescriptor({
+                pluginId: "HtmlPlugin",
+                plugin: createDummyPlugin([".php"]),
+                options: true
+            });
+            const phpDescriptors = new TextlintPluginDescriptors([phpDescriptor]);
+            // `.foo.php` should be matched
+            const fooPhpPlugin = phpDescriptors.findPluginDescriptorWithExt(".foo.php");
+            assert.deepStrictEqual(fooPhpPlugin, phpDescriptor);
+            // `.php.foo` should not be matched
+            const phpFooPlugin = phpDescriptors.findPluginDescriptorWithExt(".php.foo");
+            assert.deepStrictEqual(phpFooPlugin, undefined);
+
+            const bladePhpDescriptor = new TextlintPluginDescriptor({
+                pluginId: "HtmlPlugin",
+                plugin: createDummyPlugin([".blade.php"]),
+                options: true
+            });
+            const bladePhpDescriptors = new TextlintPluginDescriptors([bladePhpDescriptor]);
+            // `.blade.php` should be matched
+            const bladePhpPlugin = bladePhpDescriptors.findPluginDescriptorWithExt(".blade.php");
+            assert.deepStrictEqual(bladePhpPlugin, bladePhpDescriptor);
+            // `.php` should not be matched
+            const phpPlugin = bladePhpDescriptors.findPluginDescriptorWithExt(".php");
+            assert.deepStrictEqual(phpPlugin, undefined);
         });
     });
 });

--- a/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts
@@ -139,10 +139,10 @@ describe("TextlintRuleDescriptors", function () {
             const phpDescriptors = new TextlintPluginDescriptors([phpDescriptor]);
             // `.foo.php` should be matched
             const fooPhpPlugin = phpDescriptors.findPluginDescriptorWithExt(".foo.php");
-            assert.deepStrictEqual(fooPhpPlugin, phpDescriptor);
+            assert.strictEqual(fooPhpPlugin, phpDescriptor);
             // `.php.foo` should not be matched
             const phpFooPlugin = phpDescriptors.findPluginDescriptorWithExt(".php.foo");
-            assert.deepStrictEqual(phpFooPlugin, undefined);
+            assert.strictEqual(phpFooPlugin, undefined);
 
             const bladePhpDescriptor = new TextlintPluginDescriptor({
                 pluginId: "HtmlPlugin",
@@ -152,10 +152,10 @@ describe("TextlintRuleDescriptors", function () {
             const bladePhpDescriptors = new TextlintPluginDescriptors([bladePhpDescriptor]);
             // `.blade.php` should be matched
             const bladePhpPlugin = bladePhpDescriptors.findPluginDescriptorWithExt(".blade.php");
-            assert.deepStrictEqual(bladePhpPlugin, bladePhpDescriptor);
+            assert.strictEqual(bladePhpPlugin, bladePhpDescriptor);
             // `.php` should not be matched
             const phpPlugin = bladePhpDescriptors.findPluginDescriptorWithExt(".php");
-            assert.deepStrictEqual(phpPlugin, undefined);
+            assert.strictEqual(phpPlugin, undefined);
         });
     });
 });


### PR DESCRIPTION
close https://github.com/textlint/textlint/issues/623

This pull request updates the logic for matching plugin descriptors by file extensions in the `TextlintPluginDescriptors` class and adds new test cases to validate the changes.

### Updates to extension matching logic:

* [`packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts`](diffhunk://#diff-bfd47c42eb24e8d66c3053c502812a3ae7d20eea2a1475a49affc61161348436L44-R44): Updated the `findPluginDescriptorWithExt` method to use `.some()` for matching extensions, allowing support for multi-part extensions (e.g., `.blade.php`).

### Enhancements to test coverage:

* [`packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts`](diffhunk://#diff-03e0bc4bf98fefc88bd9dd92e004bf13d0152ac26e22266237faef97e3cf89a2L111-R111): Updated the test description for single extension matching to clarify behavior.
* [`packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors-test.ts`](diffhunk://#diff-03e0bc4bf98fefc88bd9dd92e004bf13d0152ac26e22266237faef97e3cf89a2R133-R159): Added a new test case to validate matching behavior for multi-part extensions, ensuring that descriptors correctly match or reject extensions like `.foo.php` and `.blade.php`.