### PR TITLE
refactor: replace get-stdin with built-in stream consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14907,14 +14907,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/get-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
@@ -36638,7 +36630,6 @@
         "@textlint/utils": "^14.7.1",
         "debug": "^4.4.0",
         "file-entry-cache": "^10.0.5",
-        "get-stdin": "^5.0.1",
         "glob": "^10.4.5",
         "md5": "^2.3.0",
         "mkdirp": "^0.5.6",

--- a/packages/textlint/bin/textlint.js
+++ b/packages/textlint/bin/textlint.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 "use strict";
-const getStdin = require("get-stdin");
+const streamConsumers = require("node:stream/consumers");
 const useStdIn = process.argv.indexOf("--stdin") > -1;
 const isDebug = process.argv.indexOf("--debug") > -1;
 if (isDebug) {
@@ -42,7 +42,7 @@ function showError(error) {
 Promise.resolve()
     .then(function () {
         if (useStdIn) {
-            return getStdin().then(function (text) {
+            return streamConsumers.text(process.stdin).then(function (text) {
                 return cli.execute(process.argv, text);
             });
         }

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -61,7 +61,6 @@
     "@textlint/utils": "^14.7.1",
     "debug": "^4.4.0",
     "file-entry-cache": "^10.0.5",
-    "get-stdin": "^5.0.1",
     "glob": "^10.4.5",
     "md5": "^2.3.0",
     "mkdirp": "^0.5.6",


### PR DESCRIPTION
This small PR removes `get-stdin` in favor of built-in `streamConsumers`.

textlint targets Node 18+, stream consumers are available since Node 16.

From `get-stdin` README:


>You can now accomplish this natively in Node.js using [`streamConsumers.text()`](https://nodejs.org/api/>webstreams.html#streamconsumerstextstream) or [`streamConsumers.buffer()`](https://nodejs.org/api/>webstreams.html#streamconsumersbufferstream)

I've run the tests locally, they pass. I used `text()` consumer because `cli.execute` expects a string.