### PR TITLE
chore: do not format .nx and docusaurus files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ module/
 node_modules/
 test/integration-test/
 packages/textlint-scripts/examples/
+.nx/
+website/build/
+website/.docusaurus/


### PR DESCRIPTION
When `npm run format`, unnecessary files are formatted.
