### PR TITLE
feat: add `@textlint/mcp` and add `--mcp` option to textlint CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --mcp                       Start textlint as the Model Context Protocol (MCP) server.
 ```
 
 When running textlint, you can target files to lint using the glob patterns.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,7 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --mcp                       Start textlint as the Model Context Protocol (MCP) server.
 ```
 
 ## Pipe to textlint

--- a/package-lock.json
+++ b/package-lock.json
@@ -8137,6 +8137,311 @@
         "node": ">=12"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@monorepo-utils/package-utils": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@monorepo-utils/package-utils/-/package-utils-2.11.0.tgz",
@@ -9552,6 +9857,10 @@
     },
     "node_modules/@textlint/markdown-to-ast": {
       "resolved": "packages/@textlint/markdown-to-ast",
+      "link": true
+    },
+    "node_modules/@textlint/mcp": {
+      "resolved": "packages/@textlint/mcp",
       "link": true
     },
     "node_modules/@textlint/module-interop": {
@@ -13594,6 +13903,26 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cors/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -15343,6 +15672,25 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -15643,6 +15991,20 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -18735,6 +19097,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -26322,6 +26689,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -30055,6 +30430,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/run-async": {
@@ -35161,6 +35559,22 @@
         "node": "*"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.51",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.51.tgz",
+      "integrity": "sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -36448,6 +36862,136 @@
       }
     },
     "packages/@textlint/markdown-to-ast/node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/@textlint/mcp": {
+      "version": "14.7.1",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "textlint": "^14.7.2",
+        "zod": "^3.25.51"
+      },
+      "devDependencies": {
+        "@textlint/resolver": "^14.7.2",
+        "@types/node": "^18.19.9",
+        "prettier": "^2.7.1",
+        "rimraf": "^6.0.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/glob": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/lru-cache": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/@textlint/mcp/node_modules/rimraf": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
       "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",

--- a/packages/@textlint/mcp/.mocharc.json
+++ b/packages/@textlint/mcp/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "timeout": 5000,
+    "import": "ts-node/esm",
+    "forbidOnly": true,
+    "spec": ["test/**/*.ts"]
+}

--- a/packages/@textlint/mcp/README.md
+++ b/packages/@textlint/mcp/README.md
@@ -1,0 +1,1 @@
+# @textlint/mcp

--- a/packages/@textlint/mcp/README.md
+++ b/packages/@textlint/mcp/README.md
@@ -1,1 +1,51 @@
 # @textlint/mcp
+
+This package is part of the [textlint/textlint](https://github.com/textlint/textlint).
+`@textlint` ecosystem and provides [Model Context Protocol](https://modelcontextprotocol.io) support for `textlint`.
+
+It enables integration with MCP servers to extend the functionality of `textlint` by providing additional tools and resources.
+
+## Installation
+
+```bash
+npm install --save-dev textlint
+```
+
+## Usage
+
+```bash
+npx textlint --mcp
+```
+
+## Example config
+
+A typical configuration looks like this:
+
+```json
+{
+  "servers": {
+    "textlint": {
+      "command": "npx",
+      "args": [
+        "textlint",
+        "--mcp"
+      ]
+    }
+  }
+}
+```
+
+## Tools
+
+- `lintFile`
+- `lintText`
+- `fixFile`
+- `fixText`
+
+## Contributing
+
+Contributions are welcome! Please read the [CONTRIBUTING.md](../../../docs/CONTRIBUTING.md) guide for more information.
+
+## License
+
+This project is licensed under the [MIT License](../../../LICENSE).

--- a/packages/@textlint/mcp/package.json
+++ b/packages/@textlint/mcp/package.json
@@ -35,6 +35,7 @@
         "clean": "rimraf lib/ module/",
         "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
         "prepack": "npm run --if-present build",
+        "test": "mocha",
         "watch": "tsc -b --watch"
     },
     "prettier": {

--- a/packages/@textlint/mcp/package.json
+++ b/packages/@textlint/mcp/package.json
@@ -1,0 +1,61 @@
+{
+    "name": "@textlint/mcp",
+    "version": "14.7.2",
+    "description": "MCP Server for textlint",
+    "keywords": [
+        "textlint",
+        "typescript",
+        "mcp"
+    ],
+    "homepage": "https://github.com/textlint/textlint/tree/master/packages/@textlint/mcp/",
+    "bugs": {
+        "url": "https://github.com/textlint/textlint/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/textlint/textlint.git"
+    },
+    "license": "MIT",
+    "author": "azu",
+    "type": "commonjs",
+    "main": "lib/src/index.js",
+    "types": "lib/src/index.d.ts",
+    "directories": {
+        "lib": "lib",
+        "test": "test"
+    },
+    "files": [
+        "bin/",
+        "lib/",
+        "src/",
+        "!*.tsbuildinfo"
+    ],
+    "scripts": {
+        "build": "tsc -b",
+        "clean": "rimraf lib/ module/",
+        "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
+        "prepack": "npm run --if-present build",
+        "watch": "tsc -b --watch"
+    },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": false,
+        "tabWidth": 4
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "textlint": "^14.7.2",
+        "zod": "^3.25.51"
+    },
+    "devDependencies": {
+        "@textlint/resolver": "^14.7.2",
+        "@types/node": "^18.19.9",
+        "prettier": "^2.7.1",
+        "rimraf": "^6.0.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/@textlint/mcp/src/index.ts
+++ b/packages/@textlint/mcp/src/index.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createLinter, loadTextlintrc, type CreateLinterOptions } from "textlint";
+import { z } from "zod";
+import pkg from "../package.json";
+
+const server = new McpServer({
+    name: "textlint",
+    version: pkg.version,
+});
+
+const makeLinterOptions = async (): Promise<CreateLinterOptions> => {
+    const descriptor = await loadTextlintrc();
+    return {
+        descriptor,
+    };
+};
+
+server.tool(
+    "lintFile",
+    "Lint files using textlint",
+    {
+        filePaths: z.array(z.string().min(1)).nonempty(),
+    },
+    async ({ filePaths }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const results = await linter.lintFiles(filePaths);
+        const content = results.map((result) => ({
+            type: "text" as const,
+            text: JSON.stringify(result),
+        }));
+
+        return { content };
+    }
+);
+
+server.tool(
+    "lintText",
+    "Lint text using textlint",
+    {
+        text: z.string().nonempty(),
+        stdinFilename: z.string().nonempty(),
+    },
+    async ({ text, stdinFilename }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const result = await linter.lintText(text, stdinFilename);
+        const content = [
+            {
+                type: "text" as const,
+                text: JSON.stringify(result),
+            },
+        ];
+
+        return { content };
+    }
+);
+
+server.tool(
+    "fixFile",
+    "Fix files using textlint",
+    {
+        filePaths: z.array(z.string().min(1)).nonempty(),
+    },
+    async ({ filePaths }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const results = await linter.fixFiles(filePaths);
+        const content = results.map((result) => ({
+            type: "text" as const,
+            text: JSON.stringify(result),
+        }));
+
+        return { content };
+    }
+);
+server.tool(
+    "fixText",
+    "Fix text using textlint",
+    {
+        text: z.string().nonempty(),
+        stdinFilename: z.string().nonempty(),
+    },
+    async ({ text, stdinFilename }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const result = await linter.fixText(text, stdinFilename);
+        const content = [
+            {
+                type: "text" as const,
+                text: JSON.stringify(result),
+            },
+        ];
+
+        return { content };
+    }
+);
+
+export { server };

--- a/packages/@textlint/mcp/test/fixtures/ok.md
+++ b/packages/@textlint/mcp/test/fixtures/ok.md
@@ -1,0 +1,1 @@
+This is OK.

--- a/packages/@textlint/mcp/test/index.test.ts
+++ b/packages/@textlint/mcp/test/index.test.ts
@@ -1,0 +1,143 @@
+"use strict";
+
+import assert from "node:assert";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { server } from "../src/index";
+
+const validFilePath = path.join(__dirname, "fixtures", "ok.md");
+const stdinFilename = `textlint.txt`;
+
+function convertRawResultToObject(rawResults: any[]) {
+    return rawResults.map((result) => {
+        return {
+            ...result,
+            text: JSON.parse(result.text),
+        };
+    });
+}
+
+describe("MCP Server", () => {
+    let client: Client, clientTransport, serverTransport;
+
+    beforeEach(async () => {
+        client = new Client({
+            name: "textlint",
+            version: "1.0",
+        });
+
+        [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+        await server.connect(serverTransport);
+        await client.connect(clientTransport);
+    });
+
+    afterEach(async () => {
+        if (client) {
+            await client.close();
+        }
+    });
+
+    describe("Tools", () => {
+        it("should have tools", async () => {
+            const { tools } = await client.listTools();
+            assert.strictEqual(tools.length, 4);
+            assert.strictEqual(tools[0].name, "lintFile");
+        });
+
+        describe("lintFile", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: RawContent } = (await client.callTool({
+                    name: "lintFile",
+                    arguments: {
+                        filePaths: [validFilePath],
+                    },
+                })) as CallToolResult;
+                const results = convertRawResultToObject(RawContent);
+                assert.deepStrictEqual(results, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: validFilePath,
+                        },
+                    },
+                ]);
+            });
+        });
+
+        describe("lintText", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "lintText",
+                    arguments: {
+                        text: "This is a valid text.",
+                        stdinFilename,
+                    },
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: stdinFilename,
+                        },
+                    },
+                ]);
+            });
+        });
+
+        describe("fixFile", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "fixFile",
+                    arguments: {
+                        filePaths: [validFilePath],
+                    },
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: validFilePath,
+                            output: "This is OK.\n",
+                            applyingMessages: [],
+                            remainingMessages: [],
+                        },
+                    },
+                ]);
+            });
+        });
+
+        describe("fixText", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "fixText",
+                    arguments: {
+                        text: "This is a valid text.",
+                        stdinFilename,
+                    },
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: stdinFilename,
+                            output: "This is a valid text.",
+                            applyingMessages: [],
+                            remainingMessages: [],
+                        },
+                    },
+                ]);
+            });
+        });
+    });
+});

--- a/packages/@textlint/mcp/tsconfig.json
+++ b/packages/@textlint/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "lib",
+        "resolveJsonModule": true
+    },
+    "references": [
+        {
+            "path": "../../textlint",
+        },
+        {
+            "path": "../resolver",
+        }
+    ],
+    "include": ["src/**/*", "./package.json"],
+    "exclude": [".git", "node_modules"]
+}

--- a/packages/textlint/src/DEPRECATED/config.ts
+++ b/packages/textlint/src/DEPRECATED/config.ts
@@ -81,7 +81,8 @@ const defaultOptions = Object.freeze({
     // --cache-location: cache file path
     cacheLocation: path.resolve(process.cwd(), ".textlintcache"),
     // --ignore-path: ".textlintignore" file path
-    ignoreFile: path.resolve(process.cwd(), ".textlintignore")
+    ignoreFile: path.resolve(process.cwd(), ".textlintignore"),
+    mcp: false
 });
 
 export interface ConfigStatics {
@@ -204,6 +205,7 @@ export class Config {
             cliOptions.ignorePath !== undefined
                 ? path.resolve(process.cwd(), cliOptions.ignorePath)
                 : defaultOptions.ignoreFile;
+        options.mcp = cliOptions.mcp !== undefined ? cliOptions.mcp : defaultOptions.mcp;
         return this.initWithAutoLoading(options);
     }
 

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -43,6 +43,7 @@ export type CliOptions = {
     version: boolean;
     outputFile: string;
     experimental: boolean;
+    mcp: boolean;
     _: string[];
 };
 export const options = optionator({
@@ -220,6 +221,13 @@ export const options = optionator({
             description:
                 "Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.",
             example: 'textlint --rules-base-directory "/path/to/other/project/node_modules/"'
+        },
+        {
+            option: "mcp",
+            type: "Boolean",
+            default: false,
+            description: "Start textlint as the Model Context Protocol (MCP) server.",
+            example: "--mcp"
         }
     ]
 }) as {

--- a/packages/textlint/test/cli/cli-test.ts
+++ b/packages/textlint/test/cli/cli-test.ts
@@ -510,6 +510,17 @@ describe("cli-test", function () {
             });
         });
     });
+
+    describe("--mcp", function () {
+        it("should output running message", function () {
+            return runWithMockLog(async ({ assertHasLog }) => {
+                const result = await cli.execute("--mcp");
+                assert.strictEqual(result, 0);
+                assertHasLog();
+            });
+        });
+    });
+
     describe("--version", function () {
         it("should output current textlint version", function () {
             const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "../../package.json"), "utf-8"));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,9 @@
       "path": "packages/@textlint/text-to-ast"
     },
     {
+      "path": "packages/@textlint/mcp"
+    },
+    {
       "path": "packages/@textlint/textlint-plugin-markdown"
     },
     {


### PR DESCRIPTION
This PR includes some improvements and verification related to the `mcp` package.  
Ref. #1498

## Verification
I confirmed the behavior with the following steps:

1. Install `textlint` locally:
   ```shell
   cd packages/@textlint/mcp/
   npm install -g .
   ```
1. Run MCP Inspector:
    ```shell
    npx -y @modelcontextprotocol/inspector npx textlint --mcp
    ```
1. Open http://127.0.0.1:6274
1. Click [Connect] and select [LintText]
1. Enter values for text and stdinFilename
1. Click [Run Tool] to execute
   ![127 0 0 1_6274_](https://github.com/user-attachments/assets/4aced32f-8b4e-4ebf-aab6-e339bb449af5)


## Questions
I wasn't sure how to add a test case for invalid files in the mcp server tests.
I'd appreciate any guidance or examples on how to approach this.