### PR TITLE
feat(textlint): add `--mcp` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --mcp                       Start textlint as the Model Context Protocol (MCP) server.
 ```
 
 When running textlint, you can target files to lint using the glob patterns.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,7 @@ Caching:
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
   --rules-base-directory path::String  Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.
+  --mcp                       Start textlint as the Model Context Protocol (MCP) server.
 ```
 
 ## Pipe to textlint

--- a/package-lock.json
+++ b/package-lock.json
@@ -37835,7 +37835,8 @@
         "read-pkg": "^1.1.0",
         "read-pkg-up": "^3.0.0",
         "structured-source": "^4.0.0",
-        "unique-concat": "^0.2.2"
+        "unique-concat": "^0.2.2",
+        "zod": "^3.25.56"
       },
       "bin": {
         "textlint": "bin/textlint.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8137,6 +8137,311 @@
         "node": ">=12"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@monorepo-utils/package-utils": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@monorepo-utils/package-utils/-/package-utils-2.11.0.tgz",
@@ -13594,6 +13899,26 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cors/node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -15343,6 +15668,25 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
+      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
@@ -15643,6 +15987,20 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -18735,6 +19093,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -26322,6 +26685,14 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -30055,6 +30426,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/run-async": {
@@ -35161,6 +35555,22 @@
         "node": "*"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -37400,6 +37810,7 @@
       "version": "14.7.2",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
         "@textlint/ast-node-types": "^14.7.2",
         "@textlint/ast-traverse": "^14.7.2",
         "@textlint/config-loader": "^14.7.2",

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -46,6 +46,7 @@
     "watch": "tsc -b --watch"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
     "@textlint/ast-node-types": "^14.7.2",
     "@textlint/ast-traverse": "^14.7.2",
     "@textlint/config-loader": "^14.7.2",

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -71,7 +71,8 @@
     "read-pkg": "^1.1.0",
     "read-pkg-up": "^3.0.0",
     "structured-source": "^4.0.0",
-    "unique-concat": "^0.2.2"
+    "unique-concat": "^0.2.2",
+    "zod": "^3.25.56"
   },
   "devDependencies": {
     "@textlint/legacy-textlint-core": "^14.7.2",

--- a/packages/textlint/src/DEPRECATED/config.ts
+++ b/packages/textlint/src/DEPRECATED/config.ts
@@ -81,7 +81,9 @@ const defaultOptions = Object.freeze({
     // --cache-location: cache file path
     cacheLocation: path.resolve(process.cwd(), ".textlintcache"),
     // --ignore-path: ".textlintignore" file path
-    ignoreFile: path.resolve(process.cwd(), ".textlintignore")
+    ignoreFile: path.resolve(process.cwd(), ".textlintignore"),
+    // --mcp
+    mcp: false
 });
 
 export interface ConfigStatics {
@@ -204,6 +206,8 @@ export class Config {
             cliOptions.ignorePath !== undefined
                 ? path.resolve(process.cwd(), cliOptions.ignorePath)
                 : defaultOptions.ignoreFile;
+        // --mcp
+        options.mcp = cliOptions.mcp !== undefined ? cliOptions.mcp : defaultOptions.mcp;
         return this.initWithAutoLoading(options);
     }
 

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -10,6 +10,7 @@ import { createLinter } from "./createLinter";
 import { SeverityLevel } from "./shared/type/SeverityLevel";
 import { printResults, showEmptyRuleWarning } from "./cli-util";
 import { loadFixerFormatter, loadLinterFormatter } from "./formatter";
+import { connectStdioMcpServer } from "./mcp/server";
 
 const debug = debug0("textlint:cli");
 type StdinExecuteOption = {
@@ -76,6 +77,13 @@ export const cli = {
             const descriptor = await loadDescriptor(currentOptions);
             Logger.log(JSON.stringify(descriptor, null, 4));
             return Promise.resolve(0);
+        } else if (currentOptions.mcp) {
+            const mcpServer = await connectStdioMcpServer();
+            process.on("SIGINT", () => {
+                mcpServer.close();
+                process.exitCode = 0;
+            });
+            return 0;
         } else if (currentOptions.help || (!files.length && !text)) {
             Logger.log(options.generateHelp());
         } else {

--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -1,0 +1,111 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import pkgConf from "read-pkg-up";
+import { createLinter, loadTextlintrc, type CreateLinterOptions } from "../";
+
+const version = pkgConf.sync({ cwd: __dirname }).pkg.version;
+const server = new McpServer({
+    name: "textlint",
+    version
+});
+
+const makeLinterOptions = async (): Promise<CreateLinterOptions> => {
+    const descriptor = await loadTextlintrc();
+    return {
+        descriptor
+    };
+};
+
+server.tool(
+    "lintFile",
+    "Lint files using textlint",
+    {
+        filePaths: z.array(z.string().min(1)).nonempty()
+    },
+    async ({ filePaths }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const results = await linter.lintFiles(filePaths);
+        const content = results.map((result) => ({
+            type: "text" as const,
+            text: JSON.stringify(result)
+        }));
+
+        return { content };
+    }
+);
+
+server.tool(
+    "lintText",
+    "Lint text using textlint",
+    {
+        text: z.string().nonempty(),
+        stdinFilename: z.string().nonempty()
+    },
+    async ({ text, stdinFilename }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const result = await linter.lintText(text, stdinFilename);
+        const content = [
+            {
+                type: "text" as const,
+                text: JSON.stringify(result)
+            }
+        ];
+
+        return { content };
+    }
+);
+
+server.tool(
+    "fixFile",
+    "Fix files using textlint",
+    {
+        filePaths: z.array(z.string().min(1)).nonempty()
+    },
+    async ({ filePaths }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const results = await linter.fixFiles(filePaths);
+        const content = results.map((result) => ({
+            type: "text" as const,
+            text: JSON.stringify(result)
+        }));
+
+        return { content };
+    }
+);
+server.tool(
+    "fixText",
+    "Fix text using textlint",
+    {
+        text: z.string().nonempty(),
+        stdinFilename: z.string().nonempty()
+    },
+    async ({ text, stdinFilename }) => {
+        const linterOptions = await makeLinterOptions();
+        const linter = createLinter(linterOptions);
+
+        const result = await linter.fixText(text, stdinFilename);
+        const content = [
+            {
+                type: "text" as const,
+                text: JSON.stringify(result)
+            }
+        ];
+
+        return { content };
+    }
+);
+
+const connectStdioMcpServer = async () => {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    return server;
+};
+
+export { connectStdioMcpServer, server };

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -43,6 +43,7 @@ export type CliOptions = {
     version: boolean;
     outputFile: string;
     experimental: boolean;
+    mcp: boolean;
     _: string[];
 };
 export const options = optionator({
@@ -220,6 +221,13 @@ export const options = optionator({
             description:
                 "Set module base directory. textlint load modules(rules/presets/plugins) from the base directory.",
             example: 'textlint --rules-base-directory "/path/to/other/project/node_modules/"'
+        },
+        {
+            option: "mcp",
+            type: "Boolean",
+            default: false,
+            description: "Start textlint as the Model Context Protocol (MCP) server.",
+            example: "--mcp"
         }
     ]
 }) as {

--- a/packages/textlint/test/cli/cli-test.ts
+++ b/packages/textlint/test/cli/cli-test.ts
@@ -510,6 +510,12 @@ describe("cli-test", function () {
             });
         });
     });
+    describe("--mcp", function () {
+        it("should have --mcp option", async function () {
+            const result = await cli.execute("--mcp");
+            assert.strictEqual(result, 0);
+        });
+    });
     describe("--version", function () {
         it("should output current textlint version", function () {
             const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "../../package.json"), "utf-8"));

--- a/packages/textlint/test/mcp/fixtures/ok.md
+++ b/packages/textlint/test/mcp/fixtures/ok.md
@@ -1,0 +1,1 @@
+This is OK.

--- a/packages/textlint/test/mcp/server.test.ts
+++ b/packages/textlint/test/mcp/server.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { server } from "../../src/mcp/server";
+
+const validFilePath = path.join(__dirname, "fixtures", "ok.md");
+const stdinFilename = `textlint.txt`;
+
+function convertRawResultToObject(rawResults: any[]) {
+    return rawResults.map((result) => {
+        return {
+            ...result,
+            text: JSON.parse(result.text)
+        };
+    });
+}
+
+describe("MCP Server", () => {
+    let client: Client, clientTransport, serverTransport;
+
+    beforeEach(async () => {
+        client = new Client({
+            name: "textlint",
+            version: "1.0"
+        });
+
+        [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+        await server.connect(serverTransport);
+        await client.connect(clientTransport);
+    });
+
+    afterEach(async () => {
+        if (client) {
+            await client.close();
+        }
+    });
+
+    describe("Tools", () => {
+        it("should have tools", async () => {
+            const { tools } = await client.listTools();
+            assert.strictEqual(tools.length, 4);
+            assert.strictEqual(tools[0].name, "lintFile");
+        });
+
+        describe("lintFile", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: RawContent } = (await client.callTool({
+                    name: "lintFile",
+                    arguments: {
+                        filePaths: [validFilePath]
+                    }
+                })) as CallToolResult;
+                const results = convertRawResultToObject(RawContent);
+                assert.deepStrictEqual(results, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: validFilePath
+                        }
+                    }
+                ]);
+            });
+        });
+
+        describe("lintText", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "lintText",
+                    arguments: {
+                        text: "This is a valid text.",
+                        stdinFilename
+                    }
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: stdinFilename
+                        }
+                    }
+                ]);
+            });
+        });
+
+        describe("fixFile", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "fixFile",
+                    arguments: {
+                        filePaths: [validFilePath]
+                    }
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: validFilePath,
+                            output: "This is OK.\n",
+                            applyingMessages: [],
+                            remainingMessages: []
+                        }
+                    }
+                ]);
+            });
+        });
+
+        describe("fixText", () => {
+            it("should return zero lint messages for a valid file", async () => {
+                const { content: rawContent } = (await client.callTool({
+                    name: "fixText",
+                    arguments: {
+                        text: "This is a valid text.",
+                        stdinFilename
+                    }
+                })) as CallToolResult;
+                const content = convertRawResultToObject(rawContent);
+                assert.deepStrictEqual(content, [
+                    {
+                        type: "text",
+                        text: {
+                            messages: [],
+                            filePath: stdinFilename,
+                            output: "This is a valid text.",
+                            applyingMessages: [],
+                            remainingMessages: []
+                        }
+                    }
+                ]);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR is adding `--mcp` option for textlint CLI.
Ref. #1498

## Verification
I confirmed the behavior with the following steps:

1. Build packages
   ```
    npm run build
   ```
1. Install `textlint` locally:
   ```shell
   cd packages/textlint/
   npm install -g .
   ```
1. Run MCP Inspector:
    ```shell
    npx -y @modelcontextprotocol/inspector npx textlint --mcp
    ```
1. Open http://127.0.0.1:6274
1. Click [Connect] and select [LintText]
1. Enter values for text and stdinFilename
1. Click [Run Tool] to execute
   ![127 0 0 1_6274_](https://github.com/user-attachments/assets/64458922-aee8-4aab-9147-561887963155)
