### PR TITLE
Rename MCP fix tools to clarify non-destructive behavior

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -113,27 +113,27 @@ Lint raw text content using textlint configuration.
 "Check this text for writing issues: 'This is a sample text.'"
 ```
 
-### `fixFile`
-Automatically fix issues in one or more files using textlint's auto-fix capability.
+### `getLintFixedFileContent`
+Get lint-fixed content of files using textlint's auto-fix capability. This tool returns the corrected content without modifying the original files.
 
 **Parameters:**
-- `filePaths` (Array): File paths to fix
+- `filePaths` (Array): File paths to get fixed content for
 
 **Example usage:**
 ```
-"Fix all textlint issues in the current file"
+"Get the textlint auto-fixed version of the current file"
 ```
 
-### `fixText`
-Automatically fix issues in raw text content.
+### `getLintFixedTextContent`
+Get lint-fixed content of raw text using textlint's auto-fix capability.
 
 **Parameters:**
-- `text` (String): Text content to fix
+- `text` (String): Text content to get fixed version of
 - `stdinFilename` (String): Filename to use for the text
 
 **Example usage:**
 ```
-"Fix the writing issues in this text and show me the corrected version"
+"Get the auto-fixed version of this text and show me the corrected content"
 ```
 
 ## Configuration
@@ -163,11 +163,11 @@ Here are some example prompts you can use with AI assistants:
 ```
 Lint the current file with textlint MCP and explain any text issues found
 
-Fix all textlint issues in src/README.md
+Get the auto-fixed content for src/README.md using textlint
 
-Check this markdown text for writing problems and suggest improvements
+Check this markdown text for writing problems and show me the corrected version
 
-Apply textlint auto-fixes to all files in the docs/ directory
+Get textlint auto-fixed content for all files in the docs/ directory
 ```
 
 ## Troubleshooting

--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -61,8 +61,8 @@ server.tool(
 );
 
 server.tool(
-    "fixFile",
-    "Fix files using textlint",
+    "getLintFixedFileContent",
+    "Get lint-fixed content of files using textlint",
     {
         filePaths: z.array(z.string().min(1)).nonempty()
     },
@@ -80,8 +80,8 @@ server.tool(
     }
 );
 server.tool(
-    "fixText",
-    "Fix text using textlint",
+    "getLintFixedTextContent",
+    "Get lint-fixed content of text using textlint",
     {
         text: z.string().nonempty(),
         stdinFilename: z.string().nonempty()

--- a/packages/textlint/test/mcp/server.test.ts
+++ b/packages/textlint/test/mcp/server.test.ts
@@ -89,10 +89,10 @@ describe("MCP Server", () => {
             });
         });
 
-        describe("fixFile", () => {
+        describe("getLintFixedFileContent", () => {
             it("should return zero lint messages for a valid file", async () => {
                 const { content: rawContent } = (await client.callTool({
-                    name: "fixFile",
+                    name: "getLintFixedFileContent",
                     arguments: {
                         filePaths: [validFilePath]
                     }
@@ -113,10 +113,10 @@ describe("MCP Server", () => {
             });
         });
 
-        describe("fixText", () => {
+        describe("getLintFixedTextContent", () => {
             it("should return zero lint messages for a valid file", async () => {
                 const { content: rawContent } = (await client.callTool({
-                    name: "fixText",
+                    name: "getLintFixedTextContent",
                     arguments: {
                         text: "This is a valid text.",
                         stdinFilename


### PR DESCRIPTION
## Summary

This PR resolves the issue where AI Agents misunderstand the MCP `fixFile` and `fixText` tools, thinking they directly modify files when they actually only return fixed content.

## Changes

### Tool Renaming
- **`fixFile`** → **`getLintFixedFileContent`**
- **`fixText`** → **`getLintFixedTextContent`**

### Updated Descriptions
- Changed from "Fix files/text using textlint" to "Get lint-fixed content of files/text using textlint"
- Emphasizes that these tools return corrected content without modifying original files

### Files Modified
- `packages/textlint/src/mcp/server.ts` - Updated tool definitions and descriptions
- `packages/textlint/test/mcp/server.test.ts` - Updated test cases to use new tool names
- `docs/mcp.md` - Updated documentation and example prompts

## Benefits

1. **Eliminates AI Agent confusion** - Clear naming prevents misunderstanding about file modification
2. **Better user experience** - AI Agents will be more willing to use these "safe" tools
3. **Maintains backward compatibility** - Only affects MCP tool names, not core functionality
4. **Improved documentation** - Examples now clearly show content retrieval use cases

## Testing

- ✅ All existing tests pass with updated tool names
- ✅ MCP server correctly registers new tool names
- ✅ Tool descriptions accurately reflect non-destructive behavior

## Related Issues

Fixes #1527

## Breaking Changes

This is a **breaking change** for MCP clients that use the old tool names (`fixFile`, `fixText`). However, MCP is experimental feature.

Users will need to update their MCP configurations and prompts to use the new tool names.