### PR TITLE
Refactor textlint configuration and update dependencies

### DIFF
--- a/examples/perf/.textlintrc
+++ b/examples/perf/.textlintrc
@@ -1,8 +1,6 @@
 {
-  "plugins": [
-    "jtf-style"
-  ],
   "rules": {
+    "preset-jtf-style": true,
     "max-ten": {
       "max": 3
     },

--- a/examples/perf/package.json
+++ b/examples/perf/package.json
@@ -10,7 +10,7 @@
     "devDependencies": {
         "shelljs": "^0.8.5",
         "textlint": "^14.8.1",
-        "textlint-plugin-jtf-style": "^1.0.1",
+        "textlint-rule-preset-jtf-style": "^3.0.2",
         "textlint-rule-max-ten": "^2.0.3",
         "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",
         "textlint-rule-no-start-duplicated-conjunction": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,12 +120,41 @@
       "devDependencies": {
         "shelljs": "^0.8.5",
         "textlint": "^14.8.1",
-        "textlint-plugin-jtf-style": "^1.0.1",
         "textlint-rule-max-ten": "^2.0.3",
         "textlint-rule-no-mix-dearu-desumasu": "^3.0.3",
         "textlint-rule-no-start-duplicated-conjunction": "^2.0.2",
+        "textlint-rule-preset-jtf-style": "^3.0.2",
         "textlint-rule-prh": "^5.2.0",
         "textlint-rule-spellcheck-tech-word": "^5.0.0"
+      }
+    },
+    "examples/perf/node_modules/textlint-rule-preset-jtf-style": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-jtf-style/-/textlint-rule-preset-jtf-style-3.0.2.tgz",
+      "integrity": "sha512-rpB1OCIK4KZqZOnM+vVxDCBkgzDH3XINCRiHQ+gV8SRydtfppPWx9WAoxCvq8lm7YuRdGiFU6XartIix2Fc2kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "analyze-desumasu-dearu": "^2.1.2",
+        "japanese-numerals-to-number": "^1.0.2",
+        "match-index": "^1.0.3",
+        "moji": "^0.5.1",
+        "regexp.prototype.flags": "^1.5.3",
+        "regx": "^1.0.4",
+        "textlint-rule-helper": "^2.3.1",
+        "textlint-rule-prh": "^6.0.0"
+      }
+    },
+    "examples/perf/node_modules/textlint-rule-preset-jtf-style/node_modules/textlint-rule-prh": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-6.1.0.tgz",
+      "integrity": "sha512-KrchADHw1/LZ/tAQ2XwL/XdUhunKCvlNmwgp+6hdyzuWX7uojOkDdJWWV0KAN4XWsK6Te5w/SZcYwQ7X6i3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.0",
+        "prh": "^5.4.4",
+        "textlint-rule-helper": "^2.3.1"
       }
     },
     "examples/plugin-extensions-option": {
@@ -11063,60 +11092,6 @@
         "@algolia/requester-common": "4.24.0"
       }
     },
-    "node_modules/amp-create-callback": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-create-callback/-/amp-create-callback-1.0.1.tgz",
-      "integrity": "sha512-6VunSFZ+GbIDWi/Vdeb1dgToRmbKfrfi3mzjC1c8QDUTgk7tx8JpUz5yJL8r/Jhgg5bH0eOCkQWCTQ++ipVcrw==",
-      "dev": true
-    },
-    "node_modules/amp-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-each/-/amp-each-1.0.1.tgz",
-      "integrity": "sha512-FdRP/SerovbQc91xmpF2Ud0CTKQ8QW89wvPf5hQ/JnndUicfx9PrGYuxRvzckeoRhC/38XEoLC6XYNVdFpJm0Q==",
-      "dev": true,
-      "dependencies": {
-        "amp-create-callback": "^1.0.0",
-        "amp-keys": "^1.0.0"
-      }
-    },
-    "node_modules/amp-has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-has/-/amp-has-1.0.1.tgz",
-      "integrity": "sha512-KcFsv9i9VVyc9VvMT30Fr0SnJQbOFrtCHMDAGjkD2dvYcygxUviEoUH7pWvpnoonrSeWcj7WS/NuO3gx/vyyUw==",
-      "dev": true
-    },
-    "node_modules/amp-index-of": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/amp-index-of/-/amp-index-of-1.1.0.tgz",
-      "integrity": "sha512-8ZVB+BOAe1cPSOU2MvPiaSzGD71T8tuY6cf+JTZRA4F7oZFSYvjyhNGYTvrpRcmFaFmapqM8f0dmLLfm2HcjjA==",
-      "dev": true,
-      "dependencies": {
-        "amp-is-number": "^1.0.0"
-      }
-    },
-    "node_modules/amp-is-number": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-is-number/-/amp-is-number-1.0.1.tgz",
-      "integrity": "sha512-qfMX1U6Z126J6mn3Sq3olrD73As8FSHEW3+d5mR6PIht9m/AeFelcmUw5Fk0EqBxzYVEjA5t0wAQRhGjnXGbfQ==",
-      "dev": true
-    },
-    "node_modules/amp-is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-is-object/-/amp-is-object-1.0.1.tgz",
-      "integrity": "sha512-oZ6BelObhLMcbk2+Qho1qIMWcsBfAf+BMsqusOWyWVDB4rtq4ERx85wZBYIFiaKjrMOH0BKfjJHim0h+XlEd3g==",
-      "dev": true
-    },
-    "node_modules/amp-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amp-keys/-/amp-keys-1.0.1.tgz",
-      "integrity": "sha512-2oFXnlyfOzNY1AMfQdzwolYfCKDeK2YF9zPEfUGCswGC29sa7jQJ6alZpKoPzIpvLcd/JH6LKrSjzFbDAxYtaw==",
-      "dev": true,
-      "dependencies": {
-        "amp-has": "^1.0.0",
-        "amp-index-of": "^1.0.0",
-        "amp-is-object": "^1.0.0"
-      }
-    },
     "node_modules/analyze-desumasu-dearu": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/analyze-desumasu-dearu/-/analyze-desumasu-dearu-2.1.5.tgz",
@@ -12677,12 +12652,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
       "integrity": "sha512-CQsjCRiNObI8AtTsNIBDRMQ4oMR83CzEswHYahClvul7gKk+lDQiOKv+5qh7LQWf5sh6jkZNispz/QlsZxyNgA==",
-      "dev": true
-    },
-    "node_modules/code-point": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point/-/code-point-1.1.0.tgz",
-      "integrity": "sha512-L9JOfOolA/Y/YKVO+WUscMXuYUcHmkleTJkvl1G0XaGFj5JDXl02BobH8avoI/pjWvgOLivs2bizA0N6g8gM9Q==",
       "dev": true
     },
     "node_modules/collapse-white-space": {
@@ -19457,12 +19426,6 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "node_modules/joyo-kanji": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/joyo-kanji/-/joyo-kanji-0.2.1.tgz",
-      "integrity": "sha512-bRx8wMjrZQDfAQIQXVDYRcznafdmB/0uIy+/PORguEO1vkV5GJVEWLZDPAHL5eM8liCIYDVAdNURV7WEjzMvUw==",
-      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -31390,25 +31353,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/sorted-array": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sorted-array/-/sorted-array-2.0.4.tgz",
-      "integrity": "sha512-58INzrX0rL6ttCfsGoFmOuQY5AjR6A5E/MmGKJ5JvWHOey6gOEOC6vO8K6C0Y2bQR6KJ8o8aFwHjp/mJ/HcYsQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true
-    },
-    "node_modules/sorted-joyo-kanji": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sorted-joyo-kanji/-/sorted-joyo-kanji-0.2.0.tgz",
-      "integrity": "sha512-zTEYyDjGqVBdotkM9ElCglxtiji6tqxLAHQinTm3+SZaMvvHjGdeVVopfra99IbZbeH++t0vii8IxbE8qW34zg==",
-      "dev": true,
-      "dependencies": {
-        "amp-each": "^1.0.1",
-        "code-point": "^1.0.1",
-        "joyo-kanji": "^0.2.1",
-        "sorted-array": "^2.0.1"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -32233,129 +32177,6 @@
       "dev": true,
       "dependencies": {
         "boundary": "^1.0.1"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/textlint-plugin-jtf-style/-/textlint-plugin-jtf-style-1.0.1.tgz",
-      "integrity": "sha512-1hFUWDaPWdG9LSnT8VV/SuMaeLm3dVU5E0RCB5jcUnaPwAoTUHxQC8/pO+eOVEJDLhSzv6KULfGjtVbBzBVFbQ==",
-      "deprecated": "Use textlint-rule-preset-jtf-style. See https://github.com/azu/textlint-rule-preset-JTF-style/releases/tag/2.0.0",
-      "dev": true,
-      "dependencies": {
-        "analyze-desumasu-dearu": "^2.1.2",
-        "sorted-joyo-kanji": "^0.2.0",
-        "textlint-rule-helper": "^1.1.3",
-        "textlint-rule-prh": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/commandpost": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.0.0.tgz",
-      "integrity": "sha512-x7kVnys+Mv4l8NBpeusP1fgOqZ04zfpsDY9ThHLi98jqFqCAWTfFqj+gBl9ZDcgf+MatsYVkoG23RQgRWcp2Ew==",
-      "dev": true
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha512-OarPfz0lFCiW4/AV2Oy1Rp9qu0iusTKqykwTspGCZtPxmF81JR4MmIebvF1F9+UOKth2ZubLQ4XGGaU+hSn99A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/js-yaml": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
-      "integrity": "sha512-x4x00j/71mI2/g/dm6DSs3tnPwkJBNae8DAKAjHZ+ywVwsgElxWzXS66ltRSYORwCeTgiicxflaaL2MrALjH7Q==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/prh": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/prh/-/prh-0.9.0.tgz",
-      "integrity": "sha512-jMvYgs4L4++q/+hQ9G7JTQZM/J7KDGm6Z71VjQ30rN9jLjnYk5l6tGyKPjV/3128Y+VU7lZmaT41+rC5rU+SwA==",
-      "dev": true,
-      "dependencies": {
-        "commandpost": "1.0.0",
-        "js-yaml": "3.4.3"
-      },
-      "bin": {
-        "prh": "bin/prh"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/structured-source": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
-      "integrity": "sha512-Ap7JHfKgmH40SUjumqyKTHYHNZ8GvGQskP34ks0ElHCDEig+bYGpmXVksxPSrgcY9rkJqhVMzfeg5GIpZelfpQ==",
-      "dev": true,
-      "dependencies": {
-        "boundary": "^1.0.1"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha512-yJmVbmyuUPOndKsxOijpx/G7mwybXXf4M10U2up0BeIZSN+6drUl+aSKAoC+RUHY7bG4ogLwRcmWoNG1lSrRIQ==",
-      "dev": true,
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/textlint-rule-prh": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/textlint-rule-prh/-/textlint-rule-prh-2.4.1.tgz",
-      "integrity": "sha512-iVWJUvLl1eVBeSiZOYo/CMcBVaTeHyIkmW5oKpn3YB8y2zZNtaM4HEAGwg82WnYhk5O2RWEY14Cv7ssF/8QkSQ==",
-      "dev": true,
-      "dependencies": {
-        "prh": "^0.9.0",
-        "structured-source": "^3.0.2",
-        "textlint-rule-helper": "^1.1.3"
-      },
-      "peerDependencies": {
-        "textlint": ">= 5.5.0"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-      "dev": true
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-      "dev": true,
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/textlint-plugin-jtf-style/node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-      "dev": true,
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "node_modules/textlint-rule-eslint": {
@@ -33590,72 +33411,18 @@
       "resolved": "website",
       "link": true
     },
-    "node_modules/textlintrc-to-pacakge-list": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/textlintrc-to-pacakge-list/-/textlintrc-to-pacakge-list-1.2.1.tgz",
-      "integrity": "sha512-dGdqSLN1VlBxin4imSiIUEfyq3FLnw4F/eeiINwKQpff+ym3tDqenamAwnp9utlSnwOBSRCiO6Q3E+WTqq/FYg==",
-      "deprecated": "This package is typo. Please use textlintrc-to-package-list",
+    "node_modules/textlintrc-to-package-list": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/textlintrc-to-package-list/-/textlintrc-to-package-list-3.0.1.tgz",
+      "integrity": "sha512-jlTIB9WN/Aqozgmx25lW7eYP6HOwcjU3eQFNcxfah0fQnWo0V0mvGveM00L/ewPmK5BgRbzZkwg7P9ov4as4zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "concat-stream": "^1.5.1",
-        "strip-json-comments": "^2.0.1"
+        "concat-stream": "^2.0.0",
+        "strip-json-comments": "^3.1.1"
       },
       "bin": {
-        "textlintrc-to-pacakge-list": "bin/cmd.js"
-      }
-    },
-    "node_modules/textlintrc-to-pacakge-list/node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/textlintrc-to-pacakge-list/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/textlintrc-to-pacakge-list/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
-    "node_modules/textlintrc-to-pacakge-list/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/textlintrc-to-pacakge-list/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "textlintrc-to-package-list": "bin/cmd.js"
       }
     },
     "node_modules/through": {
@@ -38338,7 +38105,7 @@
         "json5": "^2.1.1",
         "shelljs": "^0.8.3",
         "textlint": "^14.8.1",
-        "textlintrc-to-pacakge-list": "^1.2.0"
+        "textlintrc-to-package-list": "^3.0.1"
       }
     },
     "test/integration-test/node_modules/semver": {

--- a/test/integration-test/package.json
+++ b/test/integration-test/package.json
@@ -37,7 +37,7 @@
         "json5": "^2.1.1",
         "shelljs": "^0.8.3",
         "textlint": "^14.8.1",
-        "textlintrc-to-pacakge-list": "^1.2.0"
+        "textlintrc-to-package-list": "^3.0.1"
     },
     "email": "azuciao@gmail.com"
 }


### PR DESCRIPTION
Replace `textlint-plugin-jtf-style` with `textlint-rule-preset-jtf-style` and update relevant package versions to improve compatibility and maintainability.