### PR TITLE
refactor(textlint): use "read-package-up"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
   publish = "website/build"
-  command = "pnpm run website --verbose"
+  command = "pnpm install && pnpm run website --verbose"
 [build.environment]
   NODE_VERSION = "22"

--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -69,8 +69,7 @@
     "optionator": "^0.9.4",
     "path-to-glob-pattern": "^2.0.1",
     "rc-config-loader": "^4.1.3",
-    "read-pkg": "^1.1.0",
-    "read-pkg-up": "^3.0.0",
+    "read-package-up": "^11.0.0",
     "structured-source": "^4.0.0",
     "unique-concat": "^0.2.2",
     "zod": "^3.25.64"
@@ -81,7 +80,6 @@
     "@types/debug": "^4.1.12",
     "@types/glob": "^8.1.0",
     "@types/node": "^18.19.111",
-    "@types/read-pkg-up": "^3.0.1",
     "@types/shelljs": "^0.8.16",
     "clone": "^2.1.2",
     "rimraf": "^6.0.1",

--- a/packages/textlint/src/DEPRECATED/config.ts
+++ b/packages/textlint/src/DEPRECATED/config.ts
@@ -13,14 +13,11 @@ import {
     normalizeTextlintRulePresetKey
 } from "@textlint/utils";
 import { Logger } from "../util/logger.js";
-// @ts-expect-error no types. it will be removed
-import md5 from "md5";
 import fs from "node:fs";
 import assert from "node:assert";
 // @ts-expect-error no types. it will be removed
 import concat from "unique-concat";
 import path from "node:path";
-import pkgConf from "read-pkg-up";
 
 function applyNormalizerToList(normalizer: (name: string) => string, names: string[]) {
     return names.map((name) => {
@@ -295,16 +292,10 @@ export class Config {
      * @returns {string}
      */
     get hash() {
-        try {
-            const version = pkgConf.sync({ cwd: __dirname }).pkg.version;
-            const toString = JSON.stringify(this.toJSON());
-            return md5(`${version}-${toString}`);
-        } catch (error) {
-            // Fallback for some env
-            // https://github.com/textlint/textlint/issues/597
-            Logger.warn("Use random value as hash because calculating hash value throw error", error);
-            return crypto.randomBytes(20).toString("hex");
-        }
+        // Fallback for some env
+        // https://github.com/textlint/textlint/issues/597
+        Logger.warn("Use random value as hash because deprecated config.hash");
+        return crypto.randomBytes(20).toString("hex");
     }
 
     /**

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -56,8 +56,8 @@ export const cli = {
     async execute(args: string | Array<string>, text?: string): Promise<number> {
         let currentOptions;
         // version from package.json
-        const pkgConf = await import("read-pkg-up");
-        const version = pkgConf.sync({ cwd: __dirname }).pkg.version;
+        const { readPackageUpSync } = await import("read-package-up");
+        const version = readPackageUpSync({ cwd: __dirname })?.packageJson.version ?? "unknown";
         try {
             currentOptions = options.parse(args);
         } catch (error) {

--- a/packages/textlint/src/config/config-initializer.ts
+++ b/packages/textlint/src/config/config-initializer.ts
@@ -4,8 +4,6 @@ import { TextlintPackageNamePrefix } from "@textlint/utils";
 
 import fs from "node:fs";
 import path from "node:path";
-// @ts-ignore - read-pkg v1.1.0 doesn't have type definitions
-import readPkg from "read-pkg";
 import { Logger } from "../util/logger.js";
 
 const isFile = (filePath: string) => {
@@ -21,8 +19,11 @@ const isFile = (filePath: string) => {
  * @param {string} dir
  * @returns {Promise.<Array.<String>>}
  */
-const getTextlintDependencyNames = (dir: string): Promise<Array<string>> => {
-    return readPkg(dir)
+const getTextlintDependencyNames = async (dir: string): Promise<Array<string>> => {
+    const { readPackageUp } = await import("read-package-up");
+    return readPackageUp({
+        cwd: dir
+    })
         .then((pkg: any) => {
             const dependencies = pkg.dependencies || {};
             const devDependencies = pkg.devDependencies || {};
@@ -70,7 +71,7 @@ export interface CreateConfigFileOption {
  * @params {string} dir The directory of .textlintrc file
  * @returns {Promise.<number>} The exit code for the operation.
  */
-export const createConfigFile = (options: CreateConfigFileOption) => {
+export const createConfigFile = async (options: CreateConfigFileOption) => {
     const dir = options.dir;
     return getTextlintDependencyNames(dir).then((pkgNames) => {
         const rcFile = `.textlintrc.json`;

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -6,7 +6,6 @@ import { ExecuteFileBackerManager } from "./engine/execute-file-backer-manager.j
 import { CacheBacker } from "./engine/execute-file-backers/cache-backer.js";
 import path from "node:path";
 import crypto from "node:crypto";
-import pkgConf from "read-pkg-up";
 import fs from "node:fs/promises";
 import { Logger } from "./util/logger.js";
 import { TextlintFixResult } from "@textlint/types";
@@ -27,9 +26,10 @@ export type CreateLinterOptions = {
      */
     cwd?: string;
 };
-const createHashForDescriptor = (descriptor: TextlintKernelDescriptor): string => {
+const createHashForDescriptor = async (descriptor: TextlintKernelDescriptor): Promise<string> => {
     try {
-        const version = pkgConf.sync({ cwd: __dirname }).pkg.version;
+        const { readPackageUpSync } = await import("read-package-up");
+        const version = readPackageUpSync({ cwd: __dirname })?.packageJson.version ?? "unknown";
         const toString = JSON.stringify(descriptor.toJSON());
         const md5 = crypto.createHash("md5");
         return md5.update(`${version}-${toString}`, "utf8").digest("hex");
@@ -40,19 +40,22 @@ const createHashForDescriptor = (descriptor: TextlintKernelDescriptor): string =
         return crypto.randomBytes(20).toString("hex");
     }
 };
+
+const createExecutor = async (options: CreateLinterOptions): Promise<ExecuteFileBackerManager> => {
+    const executeFileBackerManger = new ExecuteFileBackerManager();
+    if (options.cache) {
+        const cacheBaker = new CacheBacker({
+            cache: options.cache ?? false,
+            cacheLocation: options.cacheLocation ?? path.resolve(process.cwd(), ".textlintcache"),
+            hash: await createHashForDescriptor(options.descriptor)
+        });
+        executeFileBackerManger.add(cacheBaker);
+    }
+    return executeFileBackerManger;
+};
+
 export const createLinter = (options: CreateLinterOptions) => {
     const cwd = options.cwd ?? process.cwd();
-    const executeFileBackerManger = new ExecuteFileBackerManager();
-    const cacheBaker = new CacheBacker({
-        cache: options.cache ?? false,
-        cacheLocation: options.cacheLocation ?? path.resolve(process.cwd(), ".textlintcache"),
-        hash: createHashForDescriptor(options.descriptor)
-    });
-    if (options.cache) {
-        executeFileBackerManger.add(cacheBaker);
-    } else {
-        cacheBaker.destroyCache();
-    }
     const kernel = new TextlintKernel({
         quiet: options.quiet
     });
@@ -65,6 +68,7 @@ export const createLinter = (options: CreateLinterOptions) => {
          * @returns {Promise<TextlintResult[]>} The results for all files that were linted.
          */
         async lintFiles(filesOrGlobs: string[]): Promise<TextlintResult[]> {
+            const executeFileBackerManger = await createExecutor(options);
             const patterns = pathsToGlobPatterns(filesOrGlobs, {
                 extensions: options.descriptor.availableExtensions
             });
@@ -77,7 +81,7 @@ export const createLinter = (options: CreateLinterOptions) => {
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
             debug("No Process files that are un-support extensions: %j", unAvailableFiles);
-            return executeFileBackerManger.process(availableFiles, async (filePath) => {
+            return executeFileBackerManger.process(availableFiles, async (filePath: string) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");
                 const kernelOptions = {
@@ -110,6 +114,7 @@ export const createLinter = (options: CreateLinterOptions) => {
          * @returns {Promise<TextlintFixResult[]>} The results for all files that were linted and fixed.
          */
         async fixFiles(fileOrGlobs: string[]): Promise<TextlintFixResult[]> {
+            const executeFileBackerManger = await createExecutor(options);
             const patterns = pathsToGlobPatterns(fileOrGlobs, {
                 extensions: options.descriptor.availableExtensions
             });
@@ -122,7 +127,7 @@ export const createLinter = (options: CreateLinterOptions) => {
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
             debug("No Process files that are un-support extensions: %j", unAvailableFiles);
-            return executeFileBackerManger.process(availableFiles, async (filePath) => {
+            return executeFileBackerManger.process(availableFiles, async (filePath: string) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");
                 const kernelOptions = {

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -42,16 +42,16 @@ const createHashForDescriptor = async (descriptor: TextlintKernelDescriptor): Pr
 };
 
 const createExecutor = async (options: CreateLinterOptions): Promise<ExecuteFileBackerManager> => {
-    const executeFileBackerManger = new ExecuteFileBackerManager();
+    const executeFileBackerManager = new ExecuteFileBackerManager();
     if (options.cache) {
         const cacheBaker = new CacheBacker({
             cache: options.cache ?? false,
             cacheLocation: options.cacheLocation ?? path.resolve(process.cwd(), ".textlintcache"),
             hash: await createHashForDescriptor(options.descriptor)
         });
-        executeFileBackerManger.add(cacheBaker);
+        executeFileBackerManager.add(cacheBaker);
     }
-    return executeFileBackerManger;
+    return executeFileBackerManager;
 };
 
 export const createLinter = (options: CreateLinterOptions) => {
@@ -68,7 +68,7 @@ export const createLinter = (options: CreateLinterOptions) => {
          * @returns {Promise<TextlintResult[]>} The results for all files that were linted.
          */
         async lintFiles(filesOrGlobs: string[]): Promise<TextlintResult[]> {
-            const executeFileBackerManger = await createExecutor(options);
+            const executeFileBackerManager = await createExecutor(options);
             const patterns = pathsToGlobPatterns(filesOrGlobs, {
                 extensions: options.descriptor.availableExtensions
             });
@@ -81,7 +81,7 @@ export const createLinter = (options: CreateLinterOptions) => {
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
             debug("No Process files that are un-support extensions: %j", unAvailableFiles);
-            return executeFileBackerManger.process(availableFiles, async (filePath: string) => {
+            return executeFileBackerManager.process(availableFiles, async (filePath: string) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");
                 const kernelOptions = {
@@ -114,7 +114,7 @@ export const createLinter = (options: CreateLinterOptions) => {
          * @returns {Promise<TextlintFixResult[]>} The results for all files that were linted and fixed.
          */
         async fixFiles(fileOrGlobs: string[]): Promise<TextlintFixResult[]> {
-            const executeFileBackerManger = await createExecutor(options);
+            const executeFileBackerManager = await createExecutor(options);
             const patterns = pathsToGlobPatterns(fileOrGlobs, {
                 extensions: options.descriptor.availableExtensions
             });
@@ -127,7 +127,7 @@ export const createLinter = (options: CreateLinterOptions) => {
             debug("Available extensions: %j", options.descriptor.availableExtensions);
             debug("Process files: %j", availableFiles);
             debug("No Process files that are un-support extensions: %j", unAvailableFiles);
-            return executeFileBackerManger.process(availableFiles, async (filePath: string) => {
+            return executeFileBackerManager.process(availableFiles, async (filePath: string) => {
                 const absoluteFilePath = path.resolve(process.cwd(), filePath);
                 const fileContent = await fs.readFile(filePath, "utf-8");
                 const kernelOptions = {

--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -1,15 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import pkgConf from "read-pkg-up";
 import { createLinter, loadTextlintrc, type CreateLinterOptions } from "../index.js";
 import { existsSync } from "node:fs";
-
-const version = pkgConf.sync({ cwd: __dirname }).pkg.version;
-const server = new McpServer({
-    name: "textlint",
-    version
-});
 
 const makeLinterOptions = async (): Promise<CreateLinterOptions> => {
     const descriptor = await loadTextlintrc();
@@ -70,250 +63,262 @@ const validateInputAndReturnError = (value: string, fieldName: string, errorType
     return null;
 };
 
-server.registerTool(
-    "lintFile",
-    {
-        description: "Lint files using textlint",
-        inputSchema: {
-            filePaths: z.array(z.string().min(1)).nonempty()
+export const setupServer = async (): Promise<McpServer> => {
+    const { readPackageUpSync } = await import("read-package-up");
+    const version = readPackageUpSync({ cwd: __dirname })?.packageJson.version ?? "unknown";
+    const server = new McpServer({
+        name: "textlint",
+        version
+    });
+
+    // ツール登録
+    server.registerTool(
+        "lintFile",
+        {
+            description: "Lint files using textlint",
+            inputSchema: {
+                filePaths: z.array(z.string().min(1)).nonempty()
+            },
+            outputSchema: {
+                results: z.array(
+                    z.object({
+                        filePath: z.string(),
+                        messages: z.array(
+                            z.object({
+                                ruleId: z.string().optional(),
+                                message: z.string(),
+                                line: z.number(),
+                                column: z.number(),
+                                severity: z.number(),
+                                fix: z
+                                    .object({
+                                        range: z.array(z.number()),
+                                        text: z.string()
+                                    })
+                                    .optional()
+                            })
+                        ),
+                        output: z.string().optional()
+                    })
+                ),
+                isError: z.boolean(),
+                timestamp: z.string().optional(),
+                error: z.string().optional(),
+                type: z.string().optional()
+            }
         },
-        outputSchema: {
-            results: z.array(
-                z.object({
-                    filePath: z.string(),
-                    messages: z.array(
-                        z.object({
-                            ruleId: z.string().optional(),
-                            message: z.string(),
-                            line: z.number(),
-                            column: z.number(),
-                            severity: z.number(),
-                            fix: z
-                                .object({
-                                    range: z.array(z.number()),
-                                    text: z.string()
-                                })
-                                .optional()
-                        })
-                    ),
-                    output: z.string().optional()
-                })
-            ),
-            isError: z.boolean(),
-            timestamp: z.string().optional(),
-            error: z.string().optional(),
-            type: z.string().optional()
-        }
-    },
-    async ({ filePaths }) => {
-        try {
-            // Check if files exist before processing
-            const nonExistentFiles = checkFilesExist(filePaths);
-            if (nonExistentFiles.length > 0) {
+        async ({ filePaths }) => {
+            try {
+                // Check if files exist before processing
+                const nonExistentFiles = checkFilesExist(filePaths);
+                if (nonExistentFiles.length > 0) {
+                    return createStructuredErrorResponse(
+                        `File(s) not found: ${nonExistentFiles.join(", ")}`,
+                        "lintFile_error"
+                    );
+                }
+
+                const linterOptions = await makeLinterOptions();
+                const linter = createLinter(linterOptions);
+
+                const results = await linter.lintFiles(filePaths);
+
+                // Return structured content as per MCP 2025-06-18 specification
+                // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+                return createStructuredSuccessResponse({ results });
+            } catch (error) {
+                // Handle errors with isError flag for MCP compliance
                 return createStructuredErrorResponse(
-                    `File(s) not found: ${nonExistentFiles.join(", ")}`,
+                    error instanceof Error ? error.message : "Unknown error occurred",
                     "lintFile_error"
                 );
             }
-
-            const linterOptions = await makeLinterOptions();
-            const linter = createLinter(linterOptions);
-
-            const results = await linter.lintFiles(filePaths);
-
-            // Return structured content as per MCP 2025-06-18 specification
-            // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-            return createStructuredSuccessResponse({ results });
-        } catch (error) {
-            // Handle errors with isError flag for MCP compliance
-            return createStructuredErrorResponse(
-                error instanceof Error ? error.message : "Unknown error occurred",
-                "lintFile_error"
-            );
         }
-    }
-);
+    );
 
-server.registerTool(
-    "lintText",
-    {
-        description: "Lint text using textlint",
-        inputSchema: {
-            text: z.string().nonempty(),
-            stdinFilename: z.string().nonempty()
-        },
-        outputSchema: {
-            filePath: z.string(),
-            messages: z.array(
-                z.object({
-                    ruleId: z.string().optional(),
-                    message: z.string(),
-                    line: z.number(),
-                    column: z.number(),
-                    severity: z.number(),
-                    fix: z
-                        .object({
-                            range: z.array(z.number()),
-                            text: z.string()
-                        })
-                        .optional()
-                })
-            ),
-            output: z.string().optional(),
-            isError: z.boolean(),
-            timestamp: z.string().optional(),
-            error: z.string().optional(),
-            type: z.string().optional()
-        }
-    },
-    async ({ text, stdinFilename }) => {
-        try {
-            // Validate input parameters
-            const validationError = validateInputAndReturnError(stdinFilename, "stdinFilename", "lintText_error");
-            if (validationError) {
-                return validationError;
+    server.registerTool(
+        "lintText",
+        {
+            description: "Lint text using textlint",
+            inputSchema: {
+                text: z.string().nonempty(),
+                stdinFilename: z.string().nonempty()
+            },
+            outputSchema: {
+                filePath: z.string(),
+                messages: z.array(
+                    z.object({
+                        ruleId: z.string().optional(),
+                        message: z.string(),
+                        line: z.number(),
+                        column: z.number(),
+                        severity: z.number(),
+                        fix: z
+                            .object({
+                                range: z.array(z.number()),
+                                text: z.string()
+                            })
+                            .optional()
+                    })
+                ),
+                output: z.string().optional(),
+                isError: z.boolean(),
+                timestamp: z.string().optional(),
+                error: z.string().optional(),
+                type: z.string().optional()
             }
-
-            const linterOptions = await makeLinterOptions();
-            const linter = createLinter(linterOptions);
-
-            const result = await linter.lintText(text, stdinFilename);
-
-            // Return structured content as per MCP 2025-06-18 specification
-            // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-            return createStructuredSuccessResponse(result);
-        } catch (error) {
-            return createStructuredErrorResponse(
-                error instanceof Error ? error.message : "Unknown error occurred",
-                "lintText_error"
-            );
-        }
-    }
-);
-
-server.registerTool(
-    "getLintFixedFileContent",
-    {
-        description: "Get lint-fixed content of files using textlint",
-        inputSchema: {
-            filePaths: z.array(z.string().min(1)).nonempty()
         },
-        outputSchema: {
-            results: z.array(
-                z.object({
-                    filePath: z.string(),
-                    messages: z.array(
-                        z.object({
-                            ruleId: z.string().optional(),
-                            message: z.string(),
-                            line: z.number(),
-                            column: z.number(),
-                            severity: z.number(),
-                            fix: z
-                                .object({
-                                    range: z.array(z.number()),
-                                    text: z.string()
-                                })
-                                .optional()
-                        })
-                    ),
-                    output: z.string().optional()
-                })
-            ),
-            isError: z.boolean(),
-            timestamp: z.string().optional(),
-            error: z.string().optional(),
-            type: z.string().optional()
-        }
-    },
-    async ({ filePaths }) => {
-        try {
-            // Check if files exist before processing
-            const nonExistentFiles = checkFilesExist(filePaths);
-            if (nonExistentFiles.length > 0) {
+        async ({ text, stdinFilename }) => {
+            try {
+                // Validate input parameters
+                const validationError = validateInputAndReturnError(stdinFilename, "stdinFilename", "lintText_error");
+                if (validationError) {
+                    return validationError;
+                }
+
+                const linterOptions = await makeLinterOptions();
+                const linter = createLinter(linterOptions);
+
+                const result = await linter.lintText(text, stdinFilename);
+
+                // Return structured content as per MCP 2025-06-18 specification
+                // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+                return createStructuredSuccessResponse(result);
+            } catch (error) {
                 return createStructuredErrorResponse(
-                    `File(s) not found: ${nonExistentFiles.join(", ")}`,
+                    error instanceof Error ? error.message : "Unknown error occurred",
+                    "lintText_error"
+                );
+            }
+        }
+    );
+
+    server.registerTool(
+        "getLintFixedFileContent",
+        {
+            description: "Get lint-fixed content of files using textlint",
+            inputSchema: {
+                filePaths: z.array(z.string().min(1)).nonempty()
+            },
+            outputSchema: {
+                results: z.array(
+                    z.object({
+                        filePath: z.string(),
+                        messages: z.array(
+                            z.object({
+                                ruleId: z.string().optional(),
+                                message: z.string(),
+                                line: z.number(),
+                                column: z.number(),
+                                severity: z.number(),
+                                fix: z
+                                    .object({
+                                        range: z.array(z.number()),
+                                        text: z.string()
+                                    })
+                                    .optional()
+                            })
+                        ),
+                        output: z.string().optional()
+                    })
+                ),
+                isError: z.boolean(),
+                timestamp: z.string().optional(),
+                error: z.string().optional(),
+                type: z.string().optional()
+            }
+        },
+        async ({ filePaths }) => {
+            try {
+                // Check if files exist before processing
+                const nonExistentFiles = checkFilesExist(filePaths);
+                if (nonExistentFiles.length > 0) {
+                    return createStructuredErrorResponse(
+                        `File(s) not found: ${nonExistentFiles.join(", ")}`,
+                        "fixFiles_error"
+                    );
+                }
+
+                const linterOptions = await makeLinterOptions();
+                const linter = createLinter(linterOptions);
+
+                const results = await linter.fixFiles(filePaths);
+
+                // Return structured content as per MCP 2025-06-18 specification
+                // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+                return createStructuredSuccessResponse({ results });
+            } catch (error) {
+                // Handle errors with isError flag for MCP compliance
+                return createStructuredErrorResponse(
+                    error instanceof Error ? error.message : "Unknown error occurred",
                     "fixFiles_error"
                 );
             }
-
-            const linterOptions = await makeLinterOptions();
-            const linter = createLinter(linterOptions);
-
-            const results = await linter.fixFiles(filePaths);
-
-            // Return structured content as per MCP 2025-06-18 specification
-            // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-            return createStructuredSuccessResponse({ results });
-        } catch (error) {
-            // Handle errors with isError flag for MCP compliance
-            return createStructuredErrorResponse(
-                error instanceof Error ? error.message : "Unknown error occurred",
-                "fixFiles_error"
-            );
         }
-    }
-);
-server.registerTool(
-    "getLintFixedTextContent",
-    {
-        description: "Get lint-fixed content of text using textlint",
-        inputSchema: {
-            text: z.string().nonempty(),
-            stdinFilename: z.string().nonempty()
+    );
+
+    server.registerTool(
+        "getLintFixedTextContent",
+        {
+            description: "Get lint-fixed content of text using textlint",
+            inputSchema: {
+                text: z.string().nonempty(),
+                stdinFilename: z.string().nonempty()
+            },
+            outputSchema: {
+                filePath: z.string(),
+                messages: z.array(
+                    z.object({
+                        ruleId: z.string().optional(),
+                        message: z.string(),
+                        line: z.number(),
+                        column: z.number(),
+                        severity: z.number(),
+                        fix: z
+                            .object({
+                                range: z.array(z.number()),
+                                text: z.string()
+                            })
+                            .optional()
+                    })
+                ),
+                output: z.string().optional(),
+                isError: z.boolean(),
+                timestamp: z.string().optional(),
+                error: z.string().optional(),
+                type: z.string().optional()
+            }
         },
-        outputSchema: {
-            filePath: z.string(),
-            messages: z.array(
-                z.object({
-                    ruleId: z.string().optional(),
-                    message: z.string(),
-                    line: z.number(),
-                    column: z.number(),
-                    severity: z.number(),
-                    fix: z
-                        .object({
-                            range: z.array(z.number()),
-                            text: z.string()
-                        })
-                        .optional()
-                })
-            ),
-            output: z.string().optional(),
-            isError: z.boolean(),
-            timestamp: z.string().optional(),
-            error: z.string().optional(),
-            type: z.string().optional()
+        async ({ text, stdinFilename }) => {
+            try {
+                // Validate input parameters
+                const validationError = validateInputAndReturnError(stdinFilename, "stdinFilename", "fixText_error");
+                if (validationError) return validationError;
+
+                const linterOptions = await makeLinterOptions();
+                const linter = createLinter(linterOptions);
+
+                const result = await linter.fixText(text, stdinFilename);
+
+                // Return structured content as per MCP 2025-06-18 specification
+                // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
+                return createStructuredSuccessResponse(result);
+            } catch (error) {
+                // Handle errors with isError flag for MCP compliance
+                return createStructuredErrorResponse(
+                    error instanceof Error ? error.message : "Unknown error occurred",
+                    "fixText_error"
+                );
+            }
         }
-    },
-    async ({ text, stdinFilename }) => {
-        try {
-            // Validate input parameters
-            const validationError = validateInputAndReturnError(stdinFilename, "stdinFilename", "fixText_error");
-            if (validationError) return validationError;
+    );
 
-            const linterOptions = await makeLinterOptions();
-            const linter = createLinter(linterOptions);
+    return server;
+};
 
-            const result = await linter.fixText(text, stdinFilename);
-
-            // Return structured content as per MCP 2025-06-18 specification
-            // https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content
-            return createStructuredSuccessResponse(result);
-        } catch (error) {
-            // Handle errors with isError flag for MCP compliance
-            return createStructuredErrorResponse(
-                error instanceof Error ? error.message : "Unknown error occurred",
-                "fixText_error"
-            );
-        }
-    }
-);
-
-const connectStdioMcpServer = async () => {
+export const connectStdioMcpServer = async () => {
+    const server = await setupServer();
     const transport = new StdioServerTransport();
     await server.connect(transport);
     return server;
 };
-
-export { connectStdioMcpServer, server };

--- a/packages/textlint/test/mcp/server.test.ts
+++ b/packages/textlint/test/mcp/server.test.ts
@@ -5,23 +5,23 @@ import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import { server } from "../../src/mcp/server.js";
+import { setupServer } from "../../src/mcp/server.js";
 
 const validFilePath = path.join(__dirname, "fixtures", "ok.md");
 const stdinFilename = `textlint.txt`;
 
 describe("MCP Server", () => {
-    let client: Client, clientTransport, serverTransport;
+    let client: Client, server: McpServer, clientTransport, serverTransport;
 
     beforeEach(async () => {
         client = new Client({
             name: "textlint",
             version: "1.0"
         });
-
+        server = await setupServer();
         [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
         await server.connect(serverTransport);
         await client.connect(clientTransport);
     });
@@ -29,6 +29,9 @@ describe("MCP Server", () => {
     afterEach(async () => {
         if (client) {
             await client.close();
+        }
+        if (server) {
+            await server.close();
         }
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,12 +853,9 @@ importers:
       rc-config-loader:
         specifier: ^4.1.3
         version: 4.1.3
-      read-pkg:
-        specifier: ^1.1.0
-        version: 1.1.0
-      read-pkg-up:
-        specifier: ^3.0.0
-        version: 3.0.0
+      read-package-up:
+        specifier: ^11.0.0
+        version: 11.0.0
       structured-source:
         specifier: ^4.0.0
         version: 4.0.0
@@ -884,9 +881,6 @@ importers:
       '@types/node':
         specifier: ^18.19.111
         version: 18.19.111
-      '@types/read-pkg-up':
-        specifier: ^3.0.1
-        version: 3.0.1
       '@types/shelljs':
         specifier: ^0.8.16
         version: 0.8.16
@@ -3305,9 +3299,6 @@ packages:
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
-
-  '@types/read-pkg-up@3.0.1':
-    resolution: {integrity: sha512-rMD+eDN93H/f6UGe6HJjJ08L+Vro+LN0bfCdYxsSb3Np13s75Lv+E/XBgw14kjz83Pfi82fb5z3/jtw1S3DvgA==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -13206,10 +13197,6 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@types/read-pkg-up@3.0.1':
-    dependencies:
-      '@types/normalize-package-data': 2.4.4
-
   '@types/retry@0.12.0': {}
 
   '@types/sax@1.2.7':
@@ -13355,6 +13342,22 @@ snapshots:
       '@vitest/utils': 3.2.3
       chai: 5.2.0
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.3(vite@5.4.19(@types/node@18.19.111)(terser@5.42.0))':
+    dependencies:
+      '@vitest/spy': 3.2.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@18.19.111)(terser@5.42.0)
+
+  '@vitest/mocker@3.2.3(vite@5.4.19(@types/node@20.19.0)(terser@5.42.0))':
+    dependencies:
+      '@vitest/spy': 3.2.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.19(@types/node@20.19.0)(terser@5.42.0)
 
   '@vitest/mocker@3.2.3(vite@5.4.19(@types/node@22.15.31)(terser@5.42.0))':
     dependencies:
@@ -21048,7 +21051,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@5.4.19(@types/node@22.15.31)(terser@5.42.0))
+      '@vitest/mocker': 3.2.3(vite@5.4.19(@types/node@18.19.111)(terser@5.42.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
@@ -21087,7 +21090,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@5.4.19(@types/node@22.15.31)(terser@5.42.0))
+      '@vitest/mocker': 3.2.3(vite@5.4.19(@types/node@20.19.0)(terser@5.42.0))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3


### PR DESCRIPTION
## Migration: Upgrade from read-pkg-up to read-package-up v11

This PR migrates textlint from the deprecated `read-pkg-up` v3 to the modern `read-package-up` v11, while maintaining CommonJS compatibility.

### Changes

- **Package Migration**: `read-pkg-up` v3 → `read-package-up` v11
  - Updated API usage: `pkg` → `packageJson`, `readPkgUpSync` → `readPackageUpSync`
  - Used dynamic imports to maintain CJS compatibility

- **MCP Server Refactoring**: Added `setupServer()` function for better test isolation
  - Removed global server instance
  - Tests can now create/teardown their own server instances

- **Enhanced MCP Compliance**: Improved structured content support (MCP 2025-06-18 specification)
  - All tools return both `content` and `structuredContent`
  - Proper `isError` flags and enhanced error handling

- **Code Quality**: Made `createLinter` synchronous, moved async cache setup to `lintFiles`/`fixFiles`

### Benefits

- Future-proof dependencies using actively maintained packages
- Better testability with proper server isolation
- Enhanced MCP specification compliance
- No breaking changes for users

fix #1565 
closes https://github.com/textlint/textlint/pull/1566