### PR TITLE
feat: replace Netlify with pr-preview-action

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Build website
         if: github.event.action != 'closed'
         run: |
-          pnpm run build --scope textlint-website
           pnpm run website
 
       - name: Deploy PR preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,48 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'docs/**'
+      - 'website/**'
+      - 'packages/@textlint/website/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        if: github.event.action != 'closed'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        if: github.event.action != 'closed'
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        if: github.event.action != 'closed'
+        with:
+          node-version: 22
+          cache: "pnpm"
+          
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: pnpm install
+
+      - name: Build website
+        if: github.event.action != 'closed'
+        run: |
+          pnpm run build --scope textlint-website
+          pnpm run website
+
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./website/build
+          preview-branch: gh-pages-preview
+          umbrella-dir: pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,4 +1,4 @@
-name: PR Preview
+name: WebSite Preview
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     paths:
       - 'docs/**'
       - 'website/**'
-      - 'packages/@textlint/website/**'
+      - '.github/workflows/pr-preview.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -40,9 +40,11 @@ jobs:
         if: github.event.action != 'closed'
         run: |
           pnpm run website
+        env:
+          DOCUSAURUS_BASE_URL: "/textlint/pr-preview/pr-${{ github.event.number }}/"
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe # v1.6.1
+        uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./website/build
           preview-branch: gh-pages

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -39,11 +39,10 @@ jobs:
       - name: Build website
         if: github.event.action != 'closed'
         run: |
-          pnpm run build --scope textlint-website
           pnpm run website
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe # v1.6.1
         with:
           source-dir: ./website/build
           preview-branch: gh-pages

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'docs/**'
       - 'website/**'
-      - '.github/workflows/pr-preview.yml'
+      - '.github/workflows/website-preview.yml'
 
 permissions:
   contents: read
@@ -45,3 +45,4 @@ jobs:
           source-dir: ./website/build
           preview-branch: gh-pages-preview
           umbrella-dir: pr-preview
+          token: ${{ secrets.ACTIONS_DEPLOY_KEY_WEBSITE }}

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -8,8 +8,10 @@ on:
       - 'website/**'
       - '.github/workflows/website-preview.yml'
 
+concurrency: preview-${{ github.ref }}
+
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -37,12 +39,13 @@ jobs:
       - name: Build website
         if: github.event.action != 'closed'
         run: |
+          pnpm run build --scope textlint-website
           pnpm run website
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe # v1.6.1
+        uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./website/build
-          preview-branch: gh-pages-preview
+          preview-branch: gh-pages
           umbrella-dir: pr-preview
-          token: ${{ secrets.ACTIONS_DEPLOY_KEY_WEBSITE }}
+          action: auto

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -44,7 +44,7 @@ jobs:
           DOCUSAURUS_BASE_URL: "/textlint/pr-preview/pr-${{ github.event.number }}/"
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe # v1.6.1
         with:
           source-dir: ./website/build
           preview-branch: gh-pages

--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -40,7 +40,7 @@ jobs:
           pnpm run website
 
       - name: Deploy PR preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@2fb559e4766555e23d07b73d313fe97c4f8c3cfe # v1.6.1
         with:
           source-dir: ./website/build
           preview-branch: gh-pages-preview

--- a/README.md
+++ b/README.md
@@ -614,8 +614,6 @@ Download from [textlint/media](https://github.com/textlint/media "textlint/media
 
 Thanks to [ESLint](https://eslint.org/ "ESLint").
 
-textlint website is powered by [Netlify](https://www.netlify.com).
-
 <a href="https://www.netlify.com">
   <img src="https://www.netlify.com/img/global/badges/netlify-light.svg"/>
 </a>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,5 +98,5 @@ npx textlint file.md
 - Learn about advanced [configuring](./configuring.md) of textlint.
 - Explore [textlint's rules](https://github.com/textlint/textlint/wiki/Collection-of-textlint-rule)
 - Can't find just the right rule? Make your own [custom rule](./rule.md).
-- Can't handling `.ext` file? Make your own [custom plugin](./plugin.md).
+- Can't handle `.ext` file? Make your own [custom plugin](./plugin.md).
 - Make textlint even better by [contributing](./CONTRIBUTING.md).

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -94,7 +94,7 @@ You should check the AST using [@textlint/ast-tester](https://github.com/textlin
 import { test, isTxtAST } from "@textlint/ast-tester";
 // your implement
 import yourParse from "your-parser";
-// recommenced: test much pattern test
+// recommended: test much pattern test
 const AST = yourParse("This is text");
 
 // Validate AST

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -181,7 +181,7 @@ export default function (context) {
             if (match) {
                 // report error with padding
                 // node's start + padding's range
-                // As a result, report the error that is [node.range[0] + typo.index, node.range[1] + typo.index + type.length]
+                // As a result, report the error that is [node.range[0] + match.index, node.range[1] + match.index + match[0].length]
                 report(
                     node,
                     new RuleError("Found a typo", {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[build]
-  publish = "website/build"
-  command = "pnpm install && pnpm run clean && pnpm run website"
-[build.environment]
-  NODE_VERSION = "22"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,7 +4,7 @@ export default {
     title: "textlint",
     tagline: "The pluggable linting tool for natural language",
     url: "https://textlint.org",
-    baseUrl: "/",
+    baseUrl: process.env.DOCUSAURUS_BASE_URL || "/",
     organizationName: "textlint",
     projectName: "textlint",
     scripts: ["https://buttons.github.io/buttons.js"],


### PR DESCRIPTION
## Changes

This PR replaces Netlify with `pr-preview-action` for PR preview deployments.

### What's changed:

- ✅ Removed `netlify.toml` configuration file
- ✅ Added GitHub Actions workflow for PR previews using `pr-preview-action`
- ✅ Only trigger builds when docs or website files are changed
- ✅ Deploy previews to `gh-pages-preview` branch
- ✅ Automatic cleanup when PR is closed

### Benefits:

- More reliable than Netlify builds
- Maintenance-free configuration
- Automatic preview cleanup
- No external dependencies
- Integrated with GitHub ecosystem

### Configuration:

- Triggers on: `docs/**`, `website/**`, `packages/@textlint/website/**` changes
- Deploy branch: `gh-pages-preview`
- Umbrella directory: `pr-preview`
- Overwrites existing previews (as requested)

Fixes #1579

## Testing

- [ ] Test with a PR that changes docs
- [ ] Test with a PR that changes website
- [ ] Verify preview links work correctly
- [ ] Verify cleanup works when PR is closed