### PR TITLE
test(mcp): add comprehensive tests for createStructuredErrorResponse

### DIFF
--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -5,6 +5,9 @@ import { createLinter, loadTextlintrc, type CreateLinterOptions } from "../index
 import { existsSync } from "node:fs";
 import { TextlintMessageSchema } from "./schemas.js";
 
+// Define error types as a union type
+type TextlintMcpErrorType = "lintFile_error" | "lintText_error" | "fixFiles_error" | "fixText_error";
+
 const makeLinterOptions = async (
     options: { configFilePath?: string; node_modulesDir?: string } = {}
 ): Promise<CreateLinterOptions> => {
@@ -18,7 +21,7 @@ const makeLinterOptions = async (
 };
 
 // Helper functions for common MCP operations
-const createStructuredErrorResponse = (error: string, type: string, isError = true) => {
+const createStructuredErrorResponse = (error: string, type: TextlintMcpErrorType, isError = true) => {
     const structuredContent = {
         results: [],
         error,
@@ -62,7 +65,7 @@ const checkFilesExist = (filePaths: string[]) => {
     return filePaths.filter((filePath) => !existsSync(filePath));
 };
 
-const validateInputAndReturnError = (value: string, fieldName: string, errorType: string) => {
+const validateInputAndReturnError = (value: string, fieldName: string, errorType: TextlintMcpErrorType) => {
     if (!value.trim()) {
         return createStructuredErrorResponse(`${fieldName} cannot be empty`, errorType);
     }

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-empty-stdin-filename/input.ts
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-empty-stdin-filename/input.ts
@@ -1,0 +1,19 @@
+import type { SnapshotInputFactory } from "../../types.js";
+
+/**
+ * Error case: lintText with empty stdinFilename
+ */
+const inputFactory: SnapshotInputFactory = (context) => {
+    return {
+        description: "Error case: lintText with empty stdinFilename",
+        request: {
+            name: "lintText",
+            arguments: {
+                text: "This is test content",
+                stdinFilename: "   " // Only whitespace
+            }
+        }
+    };
+};
+
+export default inputFactory;

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-empty-stdin-filename/output.json
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-empty-stdin-filename/output.json
@@ -1,0 +1,16 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\n  \"results\": [],\n  \"error\": \"stdinFilename cannot be empty\",\n  \"type\": \"lintText_error\",\n  \"timestamp\": \"<timestamp>\",\n  \"isError\": true\n}"
+    }
+  ],
+  "structuredContent": {
+    "results": [],
+    "error": "stdinFilename cannot be empty",
+    "type": "lintText_error",
+    "timestamp": "<timestamp>",
+    "isError": true
+  },
+  "isError": true
+}

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-file-not-found/input.ts
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-file-not-found/input.ts
@@ -1,0 +1,18 @@
+import type { SnapshotInputFactory } from "../../types.js";
+
+/**
+ * Error case: lintFile with non-existent file
+ */
+const inputFactory: SnapshotInputFactory = (context) => {
+    return {
+        description: "Error case: lintFile with non-existent file",
+        request: {
+            name: "lintFile",
+            arguments: {
+                filePaths: ["./non-existent-file.md", "./another-missing-file.txt"]
+            }
+        }
+    };
+};
+
+export default inputFactory;

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-file-not-found/output.json
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-file-not-found/output.json
@@ -1,0 +1,16 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\n  \"results\": [],\n  \"error\": \"File(s) not found: <error-file-not-found>/non-existent-file.md, <error-file-not-found>/another-missing-file.txt\",\n  \"type\": \"lintFile_error\",\n  \"timestamp\": \"<timestamp>\",\n  \"isError\": true\n}"
+    }
+  ],
+  "structuredContent": {
+    "results": [],
+    "error": "File(s) not found: <error-file-not-found>/non-existent-file.md, <error-file-not-found>/another-missing-file.txt",
+    "type": "lintFile_error",
+    "timestamp": "<timestamp>",
+    "isError": true
+  },
+  "isError": true
+}

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-file-not-found/input.ts
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-file-not-found/input.ts
@@ -1,0 +1,18 @@
+import type { SnapshotInputFactory } from "../../types.js";
+
+/**
+ * Error case: getLintFixedFileContent with non-existent file
+ */
+const inputFactory: SnapshotInputFactory = (context) => {
+    return {
+        description: "Error case: getLintFixedFileContent with non-existent file",
+        request: {
+            name: "getLintFixedFileContent",
+            arguments: {
+                filePaths: ["./missing-file-to-fix.md"]
+            }
+        }
+    };
+};
+
+export default inputFactory;

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-file-not-found/output.json
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-file-not-found/output.json
@@ -1,0 +1,16 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\n  \"results\": [],\n  \"error\": \"File(s) not found: <error-fix-file-not-found>/missing-file-to-fix.md\",\n  \"type\": \"fixFiles_error\",\n  \"timestamp\": \"<timestamp>\",\n  \"isError\": true\n}"
+    }
+  ],
+  "structuredContent": {
+    "results": [],
+    "error": "File(s) not found: <error-fix-file-not-found>/missing-file-to-fix.md",
+    "type": "fixFiles_error",
+    "timestamp": "<timestamp>",
+    "isError": true
+  },
+  "isError": true
+}

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-text-empty-filename/input.ts
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-text-empty-filename/input.ts
@@ -1,0 +1,19 @@
+import type { SnapshotInputFactory } from "../../types.js";
+
+/**
+ * Error case: getLintFixedTextContent with whitespace-only stdinFilename
+ */
+const inputFactory: SnapshotInputFactory = (context) => {
+    return {
+        description: "Error case: getLintFixedTextContent with whitespace-only stdinFilename",
+        request: {
+            name: "getLintFixedTextContent",
+            arguments: {
+                text: "Some text content to fix",
+                stdinFilename: "   " // Only whitespace
+            }
+        }
+    };
+};
+
+export default inputFactory;

--- a/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-text-empty-filename/output.json
+++ b/packages/textlint/test/mcp-snapshot-test/snapshots/error-fix-text-empty-filename/output.json
@@ -1,0 +1,16 @@
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\n  \"results\": [],\n  \"error\": \"stdinFilename cannot be empty\",\n  \"type\": \"fixText_error\",\n  \"timestamp\": \"<timestamp>\",\n  \"isError\": true\n}"
+    }
+  ],
+  "structuredContent": {
+    "results": [],
+    "error": "stdinFilename cannot be empty",
+    "type": "fixText_error",
+    "timestamp": "<timestamp>",
+    "isError": true
+  },
+  "isError": true
+}


### PR DESCRIPTION
## Summary
- Add snapshot tests for error handling in MCP server
- Improve test coverage for `createStructuredErrorResponse` function
- Ensure proper error responses for various error conditions

## Test plan
- [x] Add test for file not found errors in `lintFile`
- [x] Add test for empty stdinFilename validation in `lintText` 
- [x] Add test for file not found errors in `getLintFixedFileContent`
- [x] Add test for empty stdinFilename validation in `getLintFixedTextContent`
- [x] Verify all tests pass locally
- [x] Ensure tests follow existing snapshot test patterns

fix #1625 

🤖 Generated with [Claude Code](https://claude.ai/code)