### PR TITLE
fix(kernel): add browser compatibility for timing utility

### DIFF
--- a/packages/@textlint/kernel/src/util/timing.ts
+++ b/packages/@textlint/kernel/src/util/timing.ts
@@ -118,7 +118,7 @@ export default (function () {
         fn: (...args: T) => void | Promise<void>
     ): (...args: T) => void | Promise<void> {
         if (isBrowser) {
-            // ブラウザ環境では時間測定せずにそのまま関数を返す
+            // In browser environment, return function as-is without timing measurement
             return fn;
         }
 

--- a/packages/@textlint/kernel/src/util/timing.ts
+++ b/packages/@textlint/kernel/src/util/timing.ts
@@ -32,7 +32,8 @@ function alignRight(str: string, len: number, ch?: string) {
     return new Array(len - str.length + 1).join(ch || " ") + str;
 }
 
-const enabled = Boolean(process.env.TIMING);
+const isBrowser = typeof process === "undefined";
+const enabled = isBrowser ? false : Boolean(process.env.TIMING);
 
 const HEADERS = ["Rule", "Time (ms)", "Relative"];
 const ALIGN = [alignLeft, alignRight, alignRight];
@@ -56,7 +57,7 @@ function display(data: Record<string, number>) {
             return b[1] - a[1];
         })
         .slice(0, 10);
-    
+
     const rows: (string | number)[][] = [...sortedData];
 
     rows.forEach(function (row: (string | number)[]) {
@@ -112,7 +113,15 @@ export default (function () {
      * @returns {(...args: any[]) => any} function to be executed
      * @private
      */
-    function time<T extends unknown[]>(key: string, fn: (...args: T) => unknown) {
+    function time<T extends unknown[]>(
+        key: string,
+        fn: (...args: T) => void | Promise<void>
+    ): (...args: T) => void | Promise<void> {
+        if (isBrowser) {
+            // ブラウザ環境では時間測定せずにそのまま関数を返す
+            return fn;
+        }
+
         if (typeof data[key] === "undefined") {
             data[key] = 0;
         }
@@ -125,7 +134,7 @@ export default (function () {
         };
     }
 
-    if (enabled) {
+    if (enabled && !isBrowser) {
         process.on("exit", function () {
             display(data);
         });


### PR DESCRIPTION
## Summary
- Fix `process is not defined` error when building @textlint/kernel with Vite
- Add browser environment detection to timing utility
- Disable timing functionality in browser environments while preserving Node.js compatibility

## Problem
When building @textlint/kernel with Vite for browser environments, it throws `Uncaught ReferenceError: process is not defined` at runtime because the timing utility uses Node.js-specific `process` object.

## Solution
- Added browser environment detection using `typeof process === "undefined"`
- Modified timing functions to return original functions unchanged in browser environments
- Preserved full timing functionality in Node.js environments
- Updated TypeScript types for better compatibility

## Test plan
- [x] Build @textlint/kernel successfully with TypeScript
- [x] Verify timing functionality still works in Node.js environments
- [x] Test that browser builds no longer throw process-related errors

🤖 Generated with [Claude Code](https://claude.ai/code)