### PR TITLE
docs: add filterRules parameter to TextlintKernelDescriptor

### DIFF
--- a/docs/use-as-modules.md
+++ b/docs/use-as-modules.md
@@ -96,7 +96,8 @@ const customDescriptor = new TextlintKernelDescriptor({
             pluginId: "custom-plugin",
             plugin: moduleInterop((await import("./custom-plugin")).default)
         }
-    ]
+    ],
+    filterRules: []
 });
 const textlintrcDescriptor = await loadTextlintrc();
 const linter = createLinter({


### PR DESCRIPTION
Updated documentation to include `filterRules` parameter, which is required for `TextlintKernelDescriptor` constructor.

References
- https://github.com/textlint/textlint/blob/3f0423bdfbf136caab71b76d7c0c0e496a03d49e/packages/%40textlint/kernel/src/descriptor/TextlintKernelDescriptor.ts#L17-L23
- https://github.com/textlint/textlint/blob/3f0423bdfbf136caab71b76d7c0c0e496a03d49e/packages/%40textlint/kernel/src/descriptor/README.md?plain=1#L18-L36

