### PR TITLE
feat(website): make the entire sidebar hideable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -181,6 +181,11 @@ export default {
         prism: {
             theme: prismThemes.github,
             darkTheme: prismThemes.dracula
+        },
+        docs : {
+            sidebar: {
+                hideable: true
+            }
         }
     }
 };


### PR DESCRIPTION
## Summary

New Features:
- Allow the documentation sidebar to be hideable by setting hideable: true in the Docusaurus config

## Appearance

| Before | After |
|--------|--------|
| <img width="2792" height="1738" alt="before" src="https://github.com/user-attachments/assets/cae9fd87-2595-4d65-b1f6-3c9c51349e36" /> | ![after](https://github.com/user-attachments/assets/66eb369b-4c5f-4db3-9bc2-ef462f61a852) | 