### PR TITLE
chore(deps): remove unused mkdirp dependency

### DIFF
--- a/packages/textlint/package.json
+++ b/packages/textlint/package.json
@@ -66,7 +66,6 @@
     "file-entry-cache": "^10.1.3",
     "glob": "^10.4.5",
     "md5": "^2.3.0",
-    "mkdirp": "^0.5.6",
     "optionator": "^0.9.4",
     "path-to-glob-pattern": "^2.0.1",
     "rc-config-loader": "^4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,9 +838,6 @@ importers:
       md5:
         specifier: ^2.3.0
         version: 2.3.0
-      mkdirp:
-        specifier: ^0.5.6
-        version: 0.5.6
       optionator:
         specifier: ^0.9.4
         version: 0.9.4
@@ -949,7 +946,7 @@ importers:
         version: link:../textlint-tester
       ts-node:
         specifier: '*'
-        version: 10.9.2(@types/node@22.17.0)(typescript@5.6.3)
+        version: 10.9.2(@types/node@24.2.1)(typescript@5.6.3)
       typescript:
         specifier: '*'
         version: 5.6.3
@@ -3281,9 +3278,6 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
-
-  '@types/node@22.17.0':
-    resolution: {integrity: sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==}
 
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
@@ -9311,9 +9305,6 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
@@ -13118,10 +13109,6 @@ snapshots:
       '@types/node': 24.2.1
 
   '@types/node@17.0.45': {}
-
-  '@types/node@22.17.0':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@24.2.1':
     dependencies:
@@ -20430,14 +20417,14 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  ts-node@10.9.2(@types/node@22.17.0)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@24.2.1)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.17.0
+      '@types/node': 24.2.1
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -20580,8 +20567,6 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  undici-types@6.21.0: {}
 
   undici-types@7.10.0: {}
 


### PR DESCRIPTION
## Summary
- Remove the `mkdirp` dependency from the textlint package as it is not being used anywhere in the codebase

## Changes
- Removed `mkdirp` from `packages/textlint/package.json`
- Updated `pnpm-lock.yaml` to reflect the dependency removal

## Test plan
- [x] Build all packages successfully (`pnpm run build`)
- [x] Linting passes (`pnpm run lint`)
- [x] CLI functionality verified (`textlint --version`)

Fixes #1686

🤖 Generated with [Claude Code](https://claude.ai/code)