### PR TITLE
docs: clarify JSON comment support in configuration files

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -9,11 +9,13 @@ You can use following file as configuration file:
 
 - `.textlintrc` – try parse it as JSON, YAML or JS
 - `.textlintrc.js` – parse it as JavaScript
-- `.textlintrc.json` – parse it as JSON
+- `.textlintrc.json` – parse it as JSON (with comment support)
 - `.textlintrc.yml` – parse it as YAML
 - `.textlintrc.yaml` – parse it as YAML
 
 `.textlintrc` is a config file which is loaded as JSON, YAML or JS via [azu/rc-config-loader](https://github.com/azu/rc-config-loader).
+
+**Note:** JSON configuration files (`.textlintrc.json` and `.textlintrc` with JSON format) support JavaScript-style comments (`//`) for better documentation of your configuration.
 
 You can put the config of rules into `.textlintrc`
 
@@ -31,6 +33,20 @@ Add rule name to `rules` field.
 {
   "rules": {
     "no-todo": true
+  }
+}
+```
+
+You can also add comments to your configuration:
+
+```json
+{
+  // Enable rules for checking text quality
+  "rules": {
+    "no-todo": true,  // Disallow TODO comments in text
+    "max-comma": {
+      "max": 3  // Maximum commas allowed in a sentence
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Added documentation explaining that `.textlintrc.json` and `.textlintrc` files support JavaScript-style comments
- Included example showing both single-line (`//`) comment syntax
- Addresses user confusion about whether comments are allowed in configuration files

## Context
As discussed in #1689, textlint already supports comments in JSON configuration files through the [rc-config-loader](https://github.com/azu/rc-config-loader) library. This PR updates the documentation to make this feature more discoverable.

## Changes
- Updated `docs/configuring.md` to note comment support in the file list
- Added a clear note explaining JavaScript-style comment support
- Provided a practical example showing how to use comments in configuration

Fixes #1689

## Test plan
- [x] Documentation change only - no code changes required
- [x] Verified markdown formatting is correct
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)