### PR TITLE
refactor(kernel): improve plugin preProcess results

### DIFF
--- a/packages/@textlint/kernel/src/descriptor/README.md
+++ b/packages/@textlint/kernel/src/descriptor/README.md
@@ -14,6 +14,8 @@ The Descriptor is a structure object of rules, filter rules, and plugins.
 
 ## Usage
 
+### Create a Descriptor from textlintrc object
+
 ```js
 const descriptors = new TextlintKernelDescriptor({
     plugins: [
@@ -42,4 +44,37 @@ assert.ok(markdownProcessor !== undefined);
 // rules
 assert.strictEqual(descriptors.rule.descriptors.length, 1);
 ```
+### Parse with descriptor
 
+```js
+import { TextlintKernelDescriptor } from "@textlint/kernel";
+import { exampleRule } from "textlint-rule-example";
+import { createDummyPlugin } from "./util/create-dummy-plugin.js";
+const descriptors = new TextlintKernelDescriptor({
+    plugins: [
+        {
+            pluginId: "text",
+            plugin: createDummyPlugin([".txt"])
+        },
+        {
+            pluginId: "markdown",
+            plugin: createDummyPlugin([".md"])
+        }
+    ],
+    rules: [
+        {
+            ruleId: "example",
+            rule: exampleRule
+        }
+    ],
+    filterRules: []
+});
+// get plugin instance
+const markdownProcessor = descriptors.findPluginDescriptorWithExt(".md");
+assert.ok(markdownProcessor !== undefined);
+const markdownPlugin = markdownProcessor.processor.processor(".md");
+const result = await markdownPlugin.preProcess("# Hello World");
+// TxtAST check
+assert.ok(isTxtAST(result));
+assert.strictEqual(result.type, "Document");
+```

--- a/packages/@textlint/kernel/src/descriptor/TextlintKernelDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintKernelDescriptor.ts
@@ -38,7 +38,7 @@ export class TextlintKernelDescriptor {
     /**
      * Return available extensions of plugins
      */
-    get availableExtensions() {
+    get availableExtensions(): string[] {
         return this.plugin.availableExtensions;
     }
 
@@ -47,7 +47,7 @@ export class TextlintKernelDescriptor {
      * It shallow merge partialArgs.
      * It means that overwrite own properties by partialArgs.
      */
-    shallowMerge(partialArgs: Partial<TextlintKernelDescriptorArgs>) {
+    shallowMerge(partialArgs: Partial<TextlintKernelDescriptorArgs>): TextlintKernelDescriptor {
         return new TextlintKernelDescriptor({
             ...this.args,
             ...partialArgs
@@ -60,7 +60,7 @@ export class TextlintKernelDescriptor {
      * Note: withoutDuplicated pick A from [A, B] If A and B have same ruleId.
      * @param other
      */
-    concat(other: TextlintKernelDescriptor) {
+    concat(other: TextlintKernelDescriptor): TextlintKernelDescriptor {
         return new TextlintKernelDescriptor({
             configBaseDir: other.configBaseDir ?? this.configBaseDir,
             rules: this.rule.toKernelRulesFormat().concat(other.rule.toKernelRulesFormat()),
@@ -80,9 +80,11 @@ export class TextlintKernelDescriptor {
      * {
      *     "plugins": [MarkdownA, MarkdownB]
      * }
+     *
+     * @param extension file extension (e.g. ".md", ".txt")
      */
-    findPluginDescriptorWithExt(ext: string): TextlintPluginDescriptor | undefined {
-        return this.plugin.findPluginDescriptorWithExt(ext);
+    findPluginDescriptorWithExt(extension: string): TextlintPluginDescriptor | undefined {
+        return this.plugin.findPluginDescriptorWithExt(extension);
     }
 
     /**

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
@@ -38,10 +38,11 @@ export class TextlintPluginDescriptors {
     /**
      * find PluginDescriptor with extension.
      * This is forward match.
+     * @param {string} extension - file extension (ex. ".md", ".txt")
      */
-    findPluginDescriptorWithExt(ext: string) {
+    findPluginDescriptorWithExt(extension: string) {
         return this.descriptors.find((descriptor) => {
-            return descriptor.availableExtensions.some((availableExtension) => ext.endsWith(availableExtension));
+            return descriptor.availableExtensions.some((availableExtension) => extension.endsWith(availableExtension));
         });
     }
 

--- a/packages/@textlint/kernel/src/index.ts
+++ b/packages/@textlint/kernel/src/index.ts
@@ -1,7 +1,16 @@
 // Kernel
 export { TextlintKernel } from "./textlint-kernel.js";
 // Kernel Descriptor
-export * from "./descriptor/index.js";
+export {
+    TextlintKernelDescriptor,
+    TextlintRuleDescriptors,
+    TextlintLintableRuleDescriptor,
+    TextlintFixableRuleDescriptor,
+    TextlintFilterRuleDescriptors,
+    TextlintFilterRuleDescriptor,
+    TextlintPluginDescriptors,
+    TextlintPluginDescriptor
+} from "./descriptor/index.js";
 // Kernel rule/filter/plugin format
 export {
     TextlintKernelRule,

--- a/packages/@textlint/kernel/test/descriptor/helper/dummy-plugin.ts
+++ b/packages/@textlint/kernel/test/descriptor/helper/dummy-plugin.ts
@@ -1,5 +1,6 @@
 import { TextlintPluginCreator } from "../../../src/index.js";
-import type { TextlintPluginPreProcessResult, TextlintMessage, TextlintPluginPostProcessResult } from "@textlint/types";
+import type { TextlintMessage, TextlintPluginPostProcessResult } from "@textlint/types";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 
 export const createDummyPlugin = (extensions: string[] = [".dummy"]): TextlintPluginCreator => {
     return {
@@ -11,10 +12,22 @@ export const createDummyPlugin = (extensions: string[] = [".dummy"]): TextlintPl
             processor() {
                 return {
                     preProcess(_: string) {
-                        return {} as TextlintPluginPreProcessResult;
+                        return {
+                            type: "Document",
+                            children: [],
+                            raw: "",
+                            loc: {
+                                start: { line: 1, column: 1 },
+                                end: { line: 1, column: 1 }
+                            },
+                            range: [0, 0]
+                        } as TxtDocumentNode;
                     },
-                    postProcess(_messages: Array<TextlintMessage>, _filePath?: string) {
-                        return {} as TextlintPluginPostProcessResult;
+                    postProcess(messages: Array<TextlintMessage>, _filePath?: string) {
+                        return {
+                            messages,
+                            filePath: "<dummy>"
+                        } as TextlintPluginPostProcessResult;
                     }
                 };
             }

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -10,7 +10,19 @@ export declare type TextlintPluginOptions = {
     [index: string]: unknown;
 };
 
-export type TextlintPluginPreProcessResult = TxtDocumentNode | { text: string; ast: TxtDocumentNode };
+/**
+ * Result with transformed text that differs from the input.
+ * Used when the plugin handles binary or other intermediate formats.
+ * The text property contains the transformed text, and ast corresponds to that transformed text.
+ * @see https://github.com/textlint/textlint/issues/649
+ */
+export type TextlintPluginPreProcessWithTransformedText = { text: string; ast: TxtDocumentNode };
+/**
+ * PreProcess result.
+ * Usually returns TxtDocumentNode as the parsed result where the AST corresponds to the input text.
+ * For special cases (binary or intermediate formats), returns TextlintPluginPreProcessWithTransformedText.
+ */
+export type TextlintPluginPreProcessResult = TxtDocumentNode | TextlintPluginPreProcessWithTransformedText;
 export type TextlintPluginPostProcessResult = { messages: Array<TextlintMessage>; filePath: string };
 
 export interface TextlintPluginProcessorConstructor {
@@ -41,13 +53,18 @@ export declare class TextlintPluginProcessor {
          * For example, a plugin for binary format.
          * textlint can not handle binary and the plugin should return Pseudo-text for original binary file.
          * @see https://github.com/textlint/textlint/issues/649
-         * @param text
-         * @param filePath
+         * @param text original text
+         * @param filePath optional file path
          */
         preProcess(
             text: string,
             filePath?: string
         ): TextlintPluginPreProcessResult | Promise<TextlintPluginPreProcessResult>;
+        /**
+         * postProcess return messages and the filePath for the result.
+         * @param messages
+         * @param filePath
+         */
         postProcess(
             messages: Array<TextlintMessage>,
             filePath?: string


### PR DESCRIPTION
## Summary

This PR improves type safety and documentation for the plugin system in `@textlint/kernel`, specifically focusing on the `preProcess` result types and descriptor APIs.

- Extracted and documented `TextlintPluginPreProcessWithTransformedText` type for better clarity on handling binary/intermediate format plugins
- Added explicit return type annotations to descriptor methods for improved type safety
- Changed from wildcard exports to explicit named exports in kernel index
- Enhanced test coverage with actual plugin usage demonstration
- Added comprehensive usage examples in README

Add an advanced example


### Parse with descriptor

```js
import { TextlintKernelDescriptor } from "@textlint/kernel";
import { exampleRule } from "textlint-rule-example";
import { createDummyPlugin } from "./util/create-dummy-plugin.js";
const descriptors = new TextlintKernelDescriptor({
    plugins: [
        {
            pluginId: "text",
            plugin: createDummyPlugin([".txt"])
        },
        {
            pluginId: "markdown",
            plugin: createDummyPlugin([".md"])
        }
    ],
    rules: [
        {
            ruleId: "example",
            rule: exampleRule
        }
    ],
    filterRules: []
});
// get plugin instance
const markdownProcessor = descriptors.findPluginDescriptorWithExt(".md");
assert.ok(markdownProcessor !== undefined);
const markdownPlugin = markdownProcessor.processor.processor(".md");
const result = await markdownPlugin.preProcess("# Hello World");
// TxtAST check
assert.ok(isTxtAST(result));
assert.strictEqual(result.type, "Document");
```