### PR TITLE
Update CLI documentation for lint error handling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,12 +117,12 @@ If you want to clear the cache, you can use the `--no-cache` option or just remo
 - Not found lint error
 - --fix: found errors but fix all errors, so exit with 0
 - --output-file: Found lint error but --output-file is specified
-- --dry-run: Found lint error but --dry-run is specified
 
 `1`: Lint Error
 
 - found lint error
 - --fix: found errors and could not fix all errors, so exit with 1
+- --dry-run: Found lint error but --dry-run is specified hence not fixed
 
 `2`: Fatal Error
 


### PR DESCRIPTION
Closes #1462 

Clarify behavior of --dry-run option in lint error handling.