### PR TITLE
fix(website): use github-actions[bot] as deploy committer

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -34,3 +34,5 @@ jobs:
           external_repository: textlint/textlint.github.io
           publish_branch: master
           publish_dir: ./website/build
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION
## Summary

The deploy commit to textlint.github.io was using `GITHUB_ACTOR` (the person who pushed to master) as the committer. This fixes it to always use `github-actions[bot]`.

## Changes

- Explicitly set `user_name` and `user_email` in `peaceiris/actions-gh-pages`
- Deploy commits are now always attributed to `github-actions[bot]`

## Breaking Changes

None

## Test Plan

- After merging to master, verify that the deploy commit to textlint.github.io has `github-actions[bot]` as the author