### PR TITLE
fix(ci): remove CNAME from website PR preview build

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -45,6 +45,10 @@ jobs:
         env:
           DOCUSAURUS_BASE_URL: "/textlint/pr-preview/pr-${{ github.event.number }}/"
 
+      - name: Remove CNAME from preview build
+        if: github.event.action != 'closed'
+        run: rm -f ./website/build/CNAME
+
       - name: Deploy PR preview
         uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
         with:


### PR DESCRIPTION
## Summary

The website PR preview deployment currently includes the `CNAME` file from the built website, which causes the preview URL to redirect to the production domain (textlint.org) instead of serving the preview. This PR removes `CNAME` from `./website/build` before the `pr-preview-action` deploys, so the preview URL works as expected.

## Changes

- Add a new "Remove CNAME from preview build" step in `.github/workflows/website-preview.yml` that runs `rm -f ./website/build/CNAME` when the workflow is not triggered by a PR close event.

## Breaking Changes

None.

## Test Plan

- Open this PR and confirm the `website-preview` workflow succeeds.
- Visit the PR preview URL (`https://textlint.github.io/textlint/pr-preview/pr-<number>/`) and verify it serves the preview site instead of redirecting to textlint.org.