### PR TITLE
feat(markdown-to-ast): add support for TOML and JSON frontmatter

### DIFF
--- a/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
+++ b/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
@@ -26,6 +26,8 @@ export const SyntaxMap = {
     // remark(markdown) extension
     // Following type is not in @textlint/ast-node-types
     yaml: "Yaml",
+    toml: "Toml",
+    json: "Json",
     table: "Table",
     tableRow: "TableRow",
     tableCell: "TableCell",

--- a/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
+++ b/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
@@ -12,9 +12,22 @@ import frontmatter from "remark-frontmatter";
 import footnotes from "remark-footnotes";
 import type { Node } from "unist";
 
-const remark = unified().use(remarkParse).use(frontmatter, ["yaml"]).use(remarkGfm).use(footnotes, {
-    inlineNotes: true
-});
+const remark = unified()
+    .use(remarkParse)
+    .use(frontmatter, [
+        "yaml",
+        "toml",
+        // Hexo style
+        { type: "json", fence: { open: ";;;", close: ";;;" } },
+        // 11ty style
+        { type: "json", fence: { open: "---json", close: "---" } },
+        // Hugo style
+        { type: "json", fence: { open: "{", close: "}" } }
+    ])
+    .use(remarkGfm)
+    .use(footnotes, {
+        inlineNotes: true
+    });
 export const parseMarkdown = (text: string): Node => {
     return remark.parse(text);
 };

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-11ty.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-11ty.text/input.md
@@ -1,0 +1,10 @@
+---json
+{
+    "title": "My Article Title",
+    "date": "2024-01-15",
+    "author": "John Doe",
+    "tags": ["markdown", "tutorial", "web"]
+}
+---
+
+# Article Content

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-11ty.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-11ty.text/output.json
@@ -1,0 +1,79 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Json",
+            "value": "{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                144
+            ],
+            "raw": "---json\n{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}\n---"
+        },
+        {
+            "type": "Header",
+            "depth": 1,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Article Content",
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        148,
+                        163
+                    ],
+                    "raw": "Article Content"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 17
+                }
+            },
+            "range": [
+                146,
+                163
+            ],
+            "raw": "# Article Content"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 11,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        164
+    ],
+    "raw": "---json\n{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}\n---\n\n# Article Content\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hexo.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hexo.text/input.md
@@ -1,0 +1,8 @@
+;;;
+"title": "My Article Title",
+"date": "2024-01-15",
+"author": "John Doe",
+"tags": ["markdown", "tutorial", "web"]
+;;;
+
+# Article Content

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hexo.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hexo.text/output.json
@@ -1,0 +1,79 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Json",
+            "value": "\"title\": \"My Article Title\",\n\"date\": \"2024-01-15\",\n\"author\": \"John Doe\",\n\"tags\": [\"markdown\", \"tutorial\", \"web\"]",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                120
+            ],
+            "raw": ";;;\n\"title\": \"My Article Title\",\n\"date\": \"2024-01-15\",\n\"author\": \"John Doe\",\n\"tags\": [\"markdown\", \"tutorial\", \"web\"]\n;;;"
+        },
+        {
+            "type": "Header",
+            "depth": 1,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Article Content",
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        124,
+                        139
+                    ],
+                    "raw": "Article Content"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 17
+                }
+            },
+            "range": [
+                122,
+                139
+            ],
+            "raw": "# Article Content"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 9,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        140
+    ],
+    "raw": ";;;\n\"title\": \"My Article Title\",\n\"date\": \"2024-01-15\",\n\"author\": \"John Doe\",\n\"tags\": [\"markdown\", \"tutorial\", \"web\"]\n;;;\n\n# Article Content\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hugo.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hugo.text/input.md
@@ -1,0 +1,8 @@
+{
+    "title": "My Article Title",
+    "date": "2024-01-15",
+    "author": "John Doe",
+    "tags": ["markdown", "tutorial", "web"]
+}
+
+# Article Content

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hugo.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-hugo.text/output.json
@@ -1,0 +1,79 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Json",
+            "value": "    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            },
+            "range": [
+                0,
+                132
+            ],
+            "raw": "{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}"
+        },
+        {
+            "type": "Header",
+            "depth": 1,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Article Content",
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        136,
+                        151
+                    ],
+                    "raw": "Article Content"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 17
+                }
+            },
+            "range": [
+                134,
+                151
+            ],
+            "raw": "# Article Content"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 9,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        152
+    ],
+    "raw": "{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}\n\n# Article Content\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-vitepress.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-vitepress.text/input.md
@@ -1,0 +1,10 @@
+---
+{
+    "title": "My Article Title",
+    "date": "2024-01-15",
+    "author": "John Doe",
+    "tags": ["markdown", "tutorial", "web"]
+}
+---
+
+# Article Content

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-vitepress.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-json-vitepress.text/output.json
@@ -1,0 +1,79 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Yaml",
+            "value": "{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                140
+            ],
+            "raw": "---\n{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}\n---"
+        },
+        {
+            "type": "Header",
+            "depth": 1,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Article Content",
+                    "loc": {
+                        "start": {
+                            "line": 10,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 10,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        144,
+                        159
+                    ],
+                    "raw": "Article Content"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 0
+                },
+                "end": {
+                    "line": 10,
+                    "column": 17
+                }
+            },
+            "range": [
+                142,
+                159
+            ],
+            "raw": "# Article Content"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 11,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        160
+    ],
+    "raw": "---\n{\n    \"title\": \"My Article Title\",\n    \"date\": \"2024-01-15\",\n    \"author\": \"John Doe\",\n    \"tags\": [\"markdown\", \"tutorial\", \"web\"]\n}\n---\n\n# Article Content\n"
+}

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-toml.text/input.md
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-toml.text/input.md
@@ -1,0 +1,8 @@
++++
+title = "My Article Title"
+date = 2024-01-15
+author = "John Doe"
+tags = ["markdown", "tutorial", "web"]
++++
+
+# Article Content

--- a/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-toml.text/output.json
+++ b/packages/@textlint/markdown-to-ast/test/fixtures/frontmatter-toml.text/output.json
@@ -1,0 +1,79 @@
+{
+    "type": "Document",
+    "children": [
+        {
+            "type": "Toml",
+            "value": "title = \"My Article Title\"\ndate = 2024-01-15\nauthor = \"John Doe\"\ntags = [\"markdown\", \"tutorial\", \"web\"]",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                111
+            ],
+            "raw": "+++\ntitle = \"My Article Title\"\ndate = 2024-01-15\nauthor = \"John Doe\"\ntags = [\"markdown\", \"tutorial\", \"web\"]\n+++"
+        },
+        {
+            "type": "Header",
+            "depth": 1,
+            "children": [
+                {
+                    "type": "Str",
+                    "value": "Article Content",
+                    "loc": {
+                        "start": {
+                            "line": 8,
+                            "column": 2
+                        },
+                        "end": {
+                            "line": 8,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        115,
+                        130
+                    ],
+                    "raw": "Article Content"
+                }
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 17
+                }
+            },
+            "range": [
+                113,
+                130
+            ],
+            "raw": "# Article Content"
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 9,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        131
+    ],
+    "raw": "+++\ntitle = \"My Article Title\"\ndate = 2024-01-15\nauthor = \"John Doe\"\ntags = [\"markdown\", \"tutorial\", \"web\"]\n+++\n\n# Article Content\n"
+}


### PR DESCRIPTION
close https://github.com/textlint/textlint/issues/2006

## Changes

This PR adds support for TOML and JSON frontmatter to the `markdown-to-ast` package.

### TOML

Similar to YAML, `micromark-extension-frontmatter` supports TOML by default via its presets[^1]. Therefore, we simply need to enable TOML in `remark-frontmatter`.

[^1]: https://github.com/micromark/micromark-extension-frontmatter/blob/727a56e89c80e9829b3d6bb2a1bca9ec21630c84/dev/lib/to-matters.js#L8

### JSON

I wasn't entirely sure about the JSON frontmatter specifications, so I looked into it. It turns out there are several dialects across different tools like VitePress, 11ty, Hugo, and Hexo[^2]. This is likely why `remark-frontmatter` lacks a predefined marker for JSON.

[^2]: https://github.com/eslint/markdown/issues/404

In this PR, I have added support for what I consider to be the major formats by setting up custom markers.

#### VitePress[^3]

[^3]: https://vitepress.dev/guide/frontmatter#alternative-frontmatter-formats

```md
---
{
    "title": "My Article Title",
    "date": "2024-01-15",
    "author": "John Doe",
    "tags": ["markdown", "tutorial", "web"]
}
---

# Article Content
```

In the textlint AST, this is parsed as YAML. However, since textlint doesn't officially target YAML nodes for linting, I believe this won't cause any immediate issues. It is also possible to check if the YAML content can be parsed as JSON and convert it into a JSON node during a post-processing step.

#### 11ty[^4]

[^4]: https://www.11ty.dev/docs/data-frontmatter/#json-front-matter

```md
---json
{
    "title": "My Article Title",
    "date": "2024-01-15",
    "author": "John Doe",
    "tags": ["markdown", "tutorial", "web"]
}
---

# Article Content
```

#### Hugo[^5]

[^5]: https://gohugo.io/content-management/front-matter/

```md
{
    "title": "My Article Title",
    "date": "2024-01-15",
    "author": "John Doe",
    "tags": ["markdown", "tutorial", "web"]
}

# Article Content
```

#### Hexo[^6]

[^6]: https://www.npmjs.com/package/hexo-front-matter

```md
;;;
"title": "My Article Title",
"date": "2024-01-15",
"author": "John Doe",
"tags": ["markdown", "tutorial", "web"]
;;;

# Article Content
```