### PR TITLE
Update merge-gatekeeper action and add actions permission

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -13,10 +13,11 @@ jobs:
     # Restrict permissions of the GITHUB_TOKEN.
     # Docs: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
+      actions: read
       checks: read
       statuses: read
     steps:
       - name: Run Merge Gatekeeper
-        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
+        uses: starkware-libs/merge-gatekeeper@90b067dac75b94c354c3f47a0462d126eae40413 # v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Updated the merge-gatekeeper GitHub Action to use a different source repository and version, while also adding the `actions: read` permission to the workflow job.

## Key Changes
- Changed merge-gatekeeper action source from `upsidr/merge-gatekeeper` to `starkware-libs/merge-gatekeeper`
- Updated action version from `v1.2.1` to `v1.1.0` (commit `90b067dac75b94c354c3f47a0462d126eae40413`)
- Added `actions: read` permission to the job's permission scope

## Details
The workflow now uses the StarkWare Labs maintained version of the merge-gatekeeper action instead of the previous source. The addition of the `actions: read` permission aligns with the principle of least privilege by explicitly declaring the minimal permissions required for the job to function properly.

https://claude.ai/code/session_01CeFbyjzYb5h46EGm11zFsm