### PR TITLE
feat(ast-node-types): make TxtNode properties readonly

### DIFF
--- a/docs/rule.md
+++ b/docs/rule.md
@@ -10,6 +10,9 @@ textlint's AST(Abstract Syntax Tree) is defined at the page.
 
 Each rule are represented by an object with some properties.
 The properties are equivalent to AST node types from TxtNode.
+Rule visitor receives readonly AST nodes in TypeScript.
+Rules should not mutate nodes directly, such as assigning to `node.value` or pushing to `node.children`.
+Use `context.report()` to report issues and `context.fixer` to describe text changes.
 
 The basic source code format for a rule is:
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -10,7 +10,7 @@ textlint's AST(Abstract Syntax Tree) is defined at the page.
 
 Each rule are represented by an object with some properties.
 The properties are equivalent to AST node types from TxtNode.
-Rule visitor receives readonly AST nodes in TypeScript.
+In TypeScript, built-in rule visitors keyed by `context.Syntax` (TxtNode syntax types) receive readonly AST nodes.
 Rules should not mutate nodes directly, such as assigning to `node.value` or pushing to `node.children`.
 Use `context.report()` to report issues and `context.fixer` to describe text changes.
 

--- a/docs/txtnode.md
+++ b/docs/txtnode.md
@@ -28,14 +28,14 @@ Each node has own properties that is defined in each node type.
  * Probably, Real TxtNode implementation has more properties.
  */
 interface TxtNode {
-    type: string;
-    raw: string;
-    range: TxtNodeRange;
-    loc: TxtNodeLineLocation;
+    readonly type: string;
+    readonly raw: string;
+    readonly range: TxtNodeRange;
+    readonly loc: TxtNodeLineLocation;
     // parent is runtime information
     // Not need in AST
     // For example, top Root Node like `Document` has not parent.
-    parent?: TxtNode;
+    readonly parent?: TxtNode;
 }
 
 
@@ -43,8 +43,8 @@ interface TxtNode {
  * Location
  */
 interface TxtNodeLineLocation {
-    start: TxtNodePosition;
-    end: TxtNodePosition;
+    readonly start: TxtNodePosition;
+    readonly end: TxtNodePosition;
 }
 
 /**
@@ -54,8 +54,8 @@ interface TxtNodeLineLocation {
  * https://gist.github.com/azu/8866b2cb9b7a933e01fe
  */
 interface TxtNodePosition {
-    line: number; // start with 1
-    column: number; // start with 0
+    readonly line: number; // start with 1
+    readonly column: number; // start with 0
 }
 
 /**
@@ -75,6 +75,9 @@ export type TxtNodeRange = readonly [startIndex: number, endIndex: number];
     - It is attached in runtime
     - Parser user ignore this property
 
+These properties are readonly in TypeScript.
+Rules should read the AST and report issues or fixes through the rule APIs instead of mutating nodes directly.
+
 ### `TxtTextNode`
 
 `TxtTextNode` is an abstract node that inherit `TxtNode` interface.
@@ -86,7 +89,7 @@ export type TxtNodeRange = readonly [startIndex: number, endIndex: number];
  * For example, `Str` Node is a TxtTextNode.
  */
 interface TxtTextNode extends TxtNode {
-    value: string;
+    readonly value: string;
 }
 ```
 
@@ -106,7 +109,7 @@ Example: `Str` node is a `TxtTextNode`.
  * Parent Node has children that are consist of TxtNode or TxtTextNode
  */
 interface TxtParentNode extends TxtNode {
-    children: Array<TxtNode | TxtTextNode>;
+    readonly children: readonly (TxtNode | TxtTextNode)[];
 }
 ```
 
@@ -203,9 +206,9 @@ For example, `TxtHeaderNode` has `level` property.
 
 ```ts
 export interface TxtHeaderNode extends TxtParentNode {
-    type: "Header";
-    depth: 1 | 2 | 3 | 4 | 5 | 6;
-    children: PhrasingContent[];
+    readonly type: "Header";
+    readonly depth: 1 | 2 | 3 | 4 | 5 | 6;
+    readonly children: readonly PhrasingContent[];
 }
 ```
 

--- a/packages/@textlint/ast-node-types/src/NodeType.ts
+++ b/packages/@textlint/ast-node-types/src/NodeType.ts
@@ -26,16 +26,16 @@ export type AnyTxtNode = TxtNode | TxtTextNode | TxtParentNode;
  * https://gist.github.com/azu/8866b2cb9b7a933e01fe
  */
 export type TxtNodePosition = {
-    line: number; // start with 1
-    column: number; // start with 0
+    readonly line: number; // start with 1
+    readonly column: number; // start with 0
 };
 
 /**
  * Location
  */
 export type TxtNodeLocation = {
-    start: TxtNodePosition;
-    end: TxtNodePosition;
+    readonly start: TxtNodePosition;
+    readonly end: TxtNodePosition;
 };
 
 /**
@@ -48,12 +48,12 @@ export type TxtNodeRange = readonly [startIndex: number, endIndex: number];
  * Probably, Real TxtNode implementation has more properties.
  */
 export interface TxtNode {
-    type: TxtNodeType;
-    raw: string;
-    range: TxtNodeRange;
-    loc: TxtNodeLocation;
+    readonly type: TxtNodeType;
+    readonly raw: string;
+    readonly range: TxtNodeRange;
+    readonly loc: TxtNodeLocation;
     // `parent` is created by runtime
-    parent?: TxtParentNode;
+    readonly parent?: TxtParentNode;
 }
 
 /**
@@ -62,7 +62,7 @@ export interface TxtNode {
  * For example, `Str` Node is an TxtTextNode.
  */
 export interface TxtTextNode extends TxtNode {
-    value: string;
+    readonly value: string;
 }
 
 /**
@@ -70,7 +70,7 @@ export interface TxtTextNode extends TxtNode {
  * Parent Node has children that are consist of TxtParentNode or TxtTextNode
  */
 export interface TxtParentNode extends TxtNode {
-    children: Content[];
+    readonly children: readonly Content[];
 }
 
 // ================================================================================
@@ -129,137 +129,137 @@ export type StaticPhrasingContent =
     | TxtCommentNode;
 
 export interface TxtDocumentNode extends TxtParentNode {
-    type: "Document";
+    readonly type: "Document";
 }
 
 export interface TxtParagraphNode extends TxtParentNode {
-    type: "Paragraph";
-    children: PhrasingContent[];
+    readonly type: "Paragraph";
+    readonly children: readonly PhrasingContent[];
 }
 
 export interface TxtHeaderNode extends TxtParentNode {
-    type: "Header";
-    depth: 1 | 2 | 3 | 4 | 5 | 6;
-    children: PhrasingContent[];
+    readonly type: "Header";
+    readonly depth: 1 | 2 | 3 | 4 | 5 | 6;
+    readonly children: readonly PhrasingContent[];
 }
 
 export interface TxtHorizontalRuleNode extends TxtNode {
-    type: "HorizontalRule";
+    readonly type: "HorizontalRule";
 }
 
 export interface TxtBlockQuoteNode extends TxtParentNode {
-    type: "BlockQuote";
-    children: BlockContent[];
+    readonly type: "BlockQuote";
+    readonly children: readonly BlockContent[];
 }
 
 export interface TxtListNode extends TxtParentNode {
-    type: "List";
-    ordered?: boolean | null | undefined;
-    start?: number | null | undefined;
-    spread?: boolean | null | undefined;
-    children: ListContent[];
+    readonly type: "List";
+    readonly ordered?: boolean | null | undefined;
+    readonly start?: number | null | undefined;
+    readonly spread?: boolean | null | undefined;
+    readonly children: readonly ListContent[];
 }
 
 export interface TxtListItemNode extends TxtParentNode {
-    type: "ListItem";
-    checked?: boolean | null | undefined;
-    spread?: boolean | null | undefined;
-    children: BlockContent[];
+    readonly type: "ListItem";
+    readonly checked?: boolean | null | undefined;
+    readonly spread?: boolean | null | undefined;
+    readonly children: readonly BlockContent[];
 }
 
 export interface TxtTableNode extends TxtParentNode {
-    type: "Table";
-    align?: AlignType[] | null | undefined;
-    children: TableContent[];
+    readonly type: "Table";
+    readonly align?: readonly AlignType[] | null | undefined;
+    readonly children: readonly TableContent[];
 }
 
 export interface TxtTableRowNode extends TxtParentNode {
-    type: "TableRow";
-    children: RowContent[];
+    readonly type: "TableRow";
+    readonly children: readonly RowContent[];
 }
 
 export interface TxtTableCellNode extends TxtParentNode {
-    type: "TableCell";
-    children: PhrasingContent[];
+    readonly type: "TableCell";
+    readonly children: readonly PhrasingContent[];
 }
 
 export interface TxtHtmlNode extends TxtTextNode {
-    type: "Html";
+    readonly type: "Html";
 }
 
 export interface TxtCommentNode extends TxtTextNode {
-    type: "Comment";
+    readonly type: "Comment";
 }
 
 export interface TxtCodeBlockNode extends TxtTextNode {
-    type: "CodeBlock";
-    lang?: string | null | undefined;
-    meta?: string | null | undefined;
+    readonly type: "CodeBlock";
+    readonly lang?: string | null | undefined;
+    readonly meta?: string | null | undefined;
 }
 
 export interface TxtStrNode extends TxtTextNode {
-    type: "Str";
+    readonly type: "Str";
 }
 
 export interface TxtEmphasisNode extends TxtParentNode {
-    type: "Emphasis";
-    children: PhrasingContent[];
+    readonly type: "Emphasis";
+    readonly children: readonly PhrasingContent[];
 }
 
 export interface TxtStrongNode extends TxtParentNode {
-    type: "Strong";
-    children: PhrasingContent[];
+    readonly type: "Strong";
+    readonly children: readonly PhrasingContent[];
 }
 
 export interface TxtDeleteNode extends TxtParentNode {
-    type: "Delete";
-    children: PhrasingContent[];
+    readonly type: "Delete";
+    readonly children: readonly PhrasingContent[];
 }
 
 // Inline Code
 export interface TxtCodeNode extends TxtTextNode {
-    type: "Code";
+    readonly type: "Code";
 }
 
 export interface TxtBreakNode extends TxtNode {
-    type: "Break";
+    readonly type: "Break";
 }
 
 export interface TxtLinkNode extends TxtParentNode, TxtResource {
-    type: "Link";
-    children: StaticPhrasingContent[];
+    readonly type: "Link";
+    readonly children: readonly StaticPhrasingContent[];
 }
 
 export interface TxtLinkReferenceNode extends TxtParentNode, TxtReference {
-    type: "LinkReference";
-    children: StaticPhrasingContent[];
-    referenceType: ReferenceType;
+    readonly type: "LinkReference";
+    readonly children: readonly StaticPhrasingContent[];
+    readonly referenceType: ReferenceType;
 }
 
 export interface TxtImageNode extends TxtNode, TxtResource, TxtAlternative {
-    type: "Image";
+    readonly type: "Image";
 }
 
 export interface TxtImageReferenceNode extends TxtNode, TxtAlternative, TxtReference {
-    type: "ImageReference";
-    referenceType: ReferenceType;
+    readonly type: "ImageReference";
+    readonly referenceType: ReferenceType;
 }
 
 export interface TxtDefinitionNode extends TxtNode, TxtResource, TxtReference {
-    type: "Definition";
+    readonly type: "Definition";
 }
 
 // Mixin
 export interface TxtResource {
-    url: string;
-    title?: string | null | undefined;
+    readonly url: string;
+    readonly title?: string | null | undefined;
 }
 
 export interface TxtAlternative {
-    alt?: string | null | undefined;
+    readonly alt?: string | null | undefined;
 }
 
 export interface TxtReference {
-    identifier: string;
-    label: string;
+    readonly identifier: string;
+    readonly label: string;
 }

--- a/packages/@textlint/types/test/Rule/TxtNode.test.ts
+++ b/packages/@textlint/types/test/Rule/TxtNode.test.ts
@@ -33,6 +33,31 @@ const report: TextlintRuleReporter = (context) => {
     return {
         [Syntax.Document](node) {
             expectType<TxtDocumentNode>(node);
+            // @ts-expect-error TxtNode should be readonly
+            node.type = "Paragraph";
+            // @ts-expect-error TxtNode should be readonly
+            node.raw = "";
+            // @ts-expect-error TxtNode should be readonly
+            node.range = [0, 0];
+            // @ts-expect-error TxtNode should be readonly
+            node.loc = {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 1 },
+            };
+            // @ts-expect-error TxtNode children should be readonly
+            node.children = [];
+            // @ts-expect-error TxtNode children should be readonly
+            node.children.push(node.children[0]);
+            // @ts-expect-error TxtNode location should be readonly
+            node.loc.start = { line: 1, column: 0 };
+            // @ts-expect-error TxtNode location should be readonly
+            node.loc.end = { line: 1, column: 1 };
+            // @ts-expect-error TxtNode location should be readonly
+            node.loc.start.line = 1;
+            // @ts-expect-error TxtNode location should be readonly
+            node.loc.start.column = 0;
+            // @ts-expect-error TxtNode parent should be readonly
+            node.parent = node;
         },
         [Syntax.DocumentExit](node) {
             expectType<TxtDocumentNode>(node);
@@ -51,36 +76,60 @@ const report: TextlintRuleReporter = (context) => {
         },
         [Syntax.List](node) {
             expectType<TxtListNode>(node);
+            // @ts-expect-error TxtListNode ordered should be readonly
+            node.ordered = true;
+            // @ts-expect-error TxtListNode start should be readonly
+            node.start = 1;
+            // @ts-expect-error TxtListNode spread should be readonly
+            node.spread = false;
         },
         [Syntax.ListExit](node) {
             expectType<TxtListNode>(node);
         },
         [Syntax.ListItem](node) {
             expectType<TxtListItemNode>(node);
+            // @ts-expect-error TxtListItemNode checked should be readonly
+            node.checked = false;
         },
         [Syntax.ListItemExit](node) {
             expectType<TxtListItemNode>(node);
         },
         [Syntax.Header](node) {
             expectType<TxtHeaderNode>(node);
+            // @ts-expect-error TxtHeaderNode depth should be readonly
+            node.depth = 2;
         },
         [Syntax.HeaderExit](node) {
             expectType<TxtHeaderNode>(node);
         },
         [Syntax.CodeBlock](node) {
             expectType<TxtCodeBlockNode>(node);
+            // @ts-expect-error TxtCodeBlockNode lang should be readonly
+            node.lang = "js";
+            // @ts-expect-error TxtCodeBlockNode meta should be readonly
+            node.meta = "meta";
         },
         [Syntax.CodeBlockExit](node) {
             expectType<TxtCodeBlockNode>(node);
         },
         [Syntax.Link](node) {
             expectType<TxtLinkNode>(node);
+            // @ts-expect-error TxtResource url should be readonly
+            node.url = "https://example.com";
+            // @ts-expect-error TxtResource title should be readonly
+            node.title = "example";
         },
         [Syntax.LinkExit](node) {
             expectType<TxtLinkNode>(node);
         },
         [Syntax.LinkReference](node) {
             expectType<TxtLinkReferenceNode>(node);
+            // @ts-expect-error TxtLinkReferenceNode referenceType should be readonly
+            node.referenceType = "full";
+            // @ts-expect-error TxtReference identifier should be readonly
+            node.identifier = "id";
+            // @ts-expect-error TxtReference label should be readonly
+            node.label = "label";
         },
         [Syntax.LinkReferenceExit](node) {
             expectType<TxtLinkReferenceNode>(node);
@@ -111,6 +160,8 @@ const report: TextlintRuleReporter = (context) => {
         },
         [Syntax.Image](node) {
             expectType<TxtImageNode>(node);
+            // @ts-expect-error TxtAlternative alt should be readonly
+            node.alt = "alt";
         },
         [Syntax.ImageExit](node) {
             expectType<TxtImageNode>(node);
@@ -141,6 +192,8 @@ const report: TextlintRuleReporter = (context) => {
         },
         [Syntax.Str](node) {
             expectType<TxtStrNode>(node);
+            // @ts-expect-error TxtTextNode value should be readonly
+            node.value = "modified";
         },
         [Syntax.StrExit](node) {
             expectType<TxtStrNode>(node);
@@ -159,6 +212,8 @@ const report: TextlintRuleReporter = (context) => {
         },
         [Syntax.Table](node) {
             expectType<TxtTableNode>(node);
+            // @ts-expect-error TxtTableNode align should be readonly
+            node.align?.push("left");
         },
         [Syntax.TableExit](node) {
             expectType<TxtTableNode>(node);


### PR DESCRIPTION
close #489 

This PR aims to make the properties of TxtNode in ast-node-types readonly, encouraging rule authors to avoid unintended AST mutation.

This approach looks useful for rule authors, but I'm concerned that it may make type-safe AST manipulation more cumbersome for plugin authors. It may be worth considering alternatives, such as using a ReadonlyTxtNode type specifically for nodes passed to rule visitors.