### PR TITLE
fix(textlint): align stdout output with --output-file (#2043)

### DIFF
--- a/packages/@textlint/fixer-formatter/README.md
+++ b/packages/@textlint/fixer-formatter/README.md
@@ -12,11 +12,11 @@ textlint output formatter for fixer
 
 ## Writing a formatter
 
-A fixer formatter receives `TextlintFixResult[]` and returns a single `string`. The returned string is written **as-is** to stdout or `--output-file` — the CLI does not append a trailing newline. Each formatter is responsible for its own trailing newline:
+A fixer formatter receives `TextlintFixResult[]` and returns a single `string`. The returned string is written **as-is** to stdout or `--output-file` — the CLI does not append a trailing newline. Each formatter is responsible for its own trailing newline.
 
-- **Human-readable formatters** (`stylish`, `compats`, `diff`) end with `\n` so the terminal prompt appears on the next line.
-- **Machine-readable formatters** (`json`) do not append `\n`.
-- **`fixed-result`** is a special case: it returns the fixed source as-is. Its trailing newline depends on the original input — the formatter preserves byte exactness so that piping `--fix --format fixed-result` to a file produces output identical to the source when no fix was needed.
+By convention, every built-in fixer formatter (`stylish`, `compats`, `diff`, `json`) ends its non-empty output with `\n`, so that stdout produces a clean terminal break and `--output-file` produces a well-formed text file.
+
+The one exception is **`fixed-result`**, which returns the fixed source as-is. Its trailing newline depends on the original input — the formatter preserves byte exactness so that piping `--fix --format fixed-result` to a file produces output identical to the source when no fix was needed.
 
 See [textlint/textlint#2043](https://github.com/textlint/textlint/issues/2043) for the original discussion.
 

--- a/packages/@textlint/fixer-formatter/README.md
+++ b/packages/@textlint/fixer-formatter/README.md
@@ -10,6 +10,16 @@ textlint output formatter for fixer
 
 - [ ] TBD
 
+## Writing a formatter
+
+A fixer formatter receives `TextlintFixResult[]` and returns a single `string`. The returned string is written **as-is** to stdout or `--output-file` — the CLI does not append a trailing newline. Each formatter is responsible for its own trailing newline:
+
+- **Human-readable formatters** (`stylish`, `compats`, `diff`) end with `\n` so the terminal prompt appears on the next line.
+- **Machine-readable formatters** (`json`) do not append `\n`.
+- **`fixed-result`** is a special case: it returns the fixed source as-is. Its trailing newline depends on the original input — the formatter preserves byte exactness so that piping `--fix --format fixed-result` to a file produces output identical to the source when no fix was needed.
+
+See [textlint/textlint#2043](https://github.com/textlint/textlint/issues/2043) for the original discussion.
+
 ## Tests
 
     npm test

--- a/packages/@textlint/fixer-formatter/src/formatters/compats.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/compats.ts
@@ -30,7 +30,7 @@ export default function (results: TextlintFixResult[]) {
     });
 
     if (total > 0) {
-        output += `\n\nFixed ${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n\nFixed ${total} problem${total !== 1 ? "s" : ""}\n`;
     }
 
     return output;

--- a/packages/@textlint/fixer-formatter/src/formatters/json.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/json.ts
@@ -2,5 +2,5 @@
 "use strict";
 import type { TextlintFixResult } from "@textlint/types";
 export default function (results: TextlintFixResult[]) {
-    return JSON.stringify(results);
+    return `${JSON.stringify(results)}\n`;
 }

--- a/packages/@textlint/fixer-formatter/test/formatters/compats.test.ts
+++ b/packages/@textlint/fixer-formatter/test/formatters/compats.test.ts
@@ -30,7 +30,8 @@ describe("formatter:compats", function () {
               "Fixed✔ single.md: line 5, col 9, Error - Unexpected foo. (foo)
 
 
-              Fixed 1 problem"
+              Fixed 1 problem
+              "
             `);
         });
     });
@@ -42,7 +43,8 @@ describe("formatter:compats", function () {
               Fixed✔ double.md: line 6, col 1, Error - Unexpected bar. (foo)
 
 
-              Fixed 2 problems"
+              Fixed 2 problems
+              "
             `);
         });
     });
@@ -59,7 +61,8 @@ describe("formatter:compats", function () {
               Fixed✔ multiple.md: line 7, col 4, Error - Unexpected bar. (foo)
 
 
-              Fixed 7 problems"
+              Fixed 7 problems
+              "
             `);
         });
     });
@@ -71,7 +74,8 @@ describe("formatter:compats", function () {
               "Fixed✔ remaining.md: line 5, col 9, Error - Unexpected foo. (foo)
 
 
-              Fixed 1 problem"
+              Fixed 1 problem
+              "
             `);
         });
     });

--- a/packages/@textlint/linter-formatter/README.md
+++ b/packages/@textlint/linter-formatter/README.md
@@ -66,6 +66,18 @@ $ textlint -f json README.md --rule no-todo | textlint-formatter -f pretty-error
 - [azu/textlint-formatter-codecov: textlint formatter for codecov json.](https://github.com/azu/textlint-formatter-codecov)
 - [azu/textlint-formatter-lcov: textlint formatter for lcov format](https://github.com/azu/textlint-formatter-lcov)
 
+## Writing a formatter
+
+A formatter receives `TextlintResult[]` and returns a single `string`. The returned string is written **as-is** to the destination — both stdout and `--output-file` get byte-identical content. The CLI does not append a trailing newline.
+
+This means each formatter is responsible for its own trailing newline:
+
+- **Human-readable formatters** (`stylish`, `compact`, `unix`, `github`, `pretty-error`, `table`, etc.) end their output with `\n` so the terminal prompt appears on the next line.
+- **Machine-readable formatters** (`json`, `checkstyle`, `jslint-xml`, `junit`) do not append `\n` — consumers parse the content and the trailing newline is not meaningful.
+- **Empty output** (no problems) returns `""`; no newline is added.
+
+See [textlint/textlint#2043](https://github.com/textlint/textlint/issues/2043) for the original discussion.
+
 ## Contributing
 
 1. Fork it!

--- a/packages/@textlint/linter-formatter/README.md
+++ b/packages/@textlint/linter-formatter/README.md
@@ -70,11 +70,12 @@ $ textlint -f json README.md --rule no-todo | textlint-formatter -f pretty-error
 
 A formatter receives `TextlintResult[]` and returns a single `string`. The returned string is written **as-is** to the destination — both stdout and `--output-file` get byte-identical content. The CLI does not append a trailing newline.
 
-This means each formatter is responsible for its own trailing newline:
+This means each formatter is responsible for its own trailing newline. By convention, every built-in formatter ends its non-empty output with `\n` so that:
 
-- **Human-readable formatters** (`stylish`, `compact`, `unix`, `github`, `pretty-error`, `table`, etc.) end their output with `\n` so the terminal prompt appears on the next line.
-- **Machine-readable formatters** (`json`, `checkstyle`, `jslint-xml`, `junit`) do not append `\n` — consumers parse the content and the trailing newline is not meaningful.
-- **Empty output** (no problems) returns `""`; no newline is added.
+- the terminal prompt appears on the next line when output goes to stdout, and
+- output written to `--output-file` is a well-formed text file (POSIX text files end with `\n`).
+
+Empty output (no problems to report) returns `""`; no newline is added.
 
 See [textlint/textlint#2043](https://github.com/textlint/textlint/issues/2043) for the original discussion.
 

--- a/packages/@textlint/linter-formatter/src/formatters/checkstyle.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/checkstyle.ts
@@ -81,7 +81,7 @@ function formatter(results: TextlintResult[]) {
         output += "</file>";
     });
 
-    output += "</checkstyle>";
+    output += "</checkstyle>\n";
 
     return output;
 }

--- a/packages/@textlint/linter-formatter/src/formatters/compact.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/compact.ts
@@ -46,7 +46,7 @@ function formatter(results: TextlintResult[]) {
     });
 
     if (total > 0) {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n${total} problem${total !== 1 ? "s" : ""}\n`;
     }
 
     return output;

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -52,7 +52,7 @@ function formatter(results: TextlintResult[]) {
         });
     });
 
-    return output.trimEnd();
+    return output;
 }
 
 export default formatter;

--- a/packages/@textlint/linter-formatter/src/formatters/jslint-xml.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/jslint-xml.ts
@@ -35,7 +35,7 @@ function formatter(results: TextlintResult[]) {
         output += "</file>";
     });
 
-    output += "</jslint>";
+    output += "</jslint>\n";
 
     return output;
 }

--- a/packages/@textlint/linter-formatter/src/formatters/json.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/json.ts
@@ -3,7 +3,7 @@
 import type { TextlintResult } from "@textlint/types";
 
 function formatter(results: TextlintResult[]) {
-    return JSON.stringify(results);
+    return `${JSON.stringify(results)}\n`;
 }
 
 export default formatter;

--- a/packages/@textlint/linter-formatter/src/formatters/unix.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/unix.ts
@@ -51,7 +51,7 @@ function formatter(results: TextlintResult[]) {
     });
 
     if (total > 0) {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n${total} problem${total !== 1 ? "s" : ""}\n`;
     }
 
     return output;

--- a/packages/@textlint/linter-formatter/test/formatters/checkstyle.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/checkstyle.test.ts
@@ -30,7 +30,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>\n'
             );
         });
 
@@ -39,7 +39,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="warning" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="warning" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>\n'
             );
         });
 
@@ -48,7 +48,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="info" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="info" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>\n'
             );
         });
     });
@@ -72,7 +72,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="&lt;&gt;&amp;&quot;&apos;.js"><error line="&lt;" column="&gt;" severity="error" message="Unexpected &lt;&gt;&amp;&quot;&apos;. (foo&gt;)" source="eslint.rules.foo&gt;" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="&lt;&gt;&amp;&quot;&apos;.js"><error line="&lt;" column="&gt;" severity="error" message="Unexpected &lt;&gt;&amp;&quot;&apos;. (foo&gt;)" source="eslint.rules.foo&gt;" /></file></checkstyle>\n'
             );
         });
     });
@@ -96,7 +96,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file></checkstyle>\n'
             );
         });
     });
@@ -128,7 +128,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /><error line="6" column="11" severity="warning" message="Unexpected bar. (bar)" source="eslint.rules.bar" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /><error line="6" column="11" severity="warning" message="Unexpected bar. (bar)" source="eslint.rules.bar" /></file></checkstyle>\n'
             );
         });
     });
@@ -165,7 +165,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file><file name="bar.js"><error line="6" column="11" severity="warning" message="Unexpected bar. (bar)" source="eslint.rules.bar" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo. (foo)" source="eslint.rules.foo" /></file><file name="bar.js"><error line="6" column="11" severity="warning" message="Unexpected bar. (bar)" source="eslint.rules.bar" /></file></checkstyle>\n'
             );
         });
     });
@@ -189,7 +189,7 @@ describe("formatter:checkstyle", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo." source="" /></file></checkstyle>'
+                '<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="foo.js"><error line="5" column="10" severity="error" message="Unexpected foo." source="" /></file></checkstyle>\n'
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/compact.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/compact.test.ts
@@ -42,19 +42,19 @@ describe("formatter:compact", function () {
 
         it("should return a string in the format filename: line x, col y, Error - z for errors", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem\n");
         });
 
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", function () {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
-            assert.equal(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem");
+            assert.equal(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem\n");
         });
 
         it("should return a string in the format filename: line x, col y, Info - z for info", function () {
             code[0].messages[0].severity = 3;
             const result = formatter(code);
-            assert.equal(result, "foo.js: line 5, col 10, Info - Unexpected foo. (foo)\n\n1 problem");
+            assert.equal(result, "foo.js: line 5, col 10, Info - Unexpected foo. (foo)\n\n1 problem\n");
         });
     });
 
@@ -76,7 +76,7 @@ describe("formatter:compact", function () {
 
         it("should return a string in the format filename: line x, col y, Error - z", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem\n");
         });
     });
 
@@ -107,7 +107,7 @@ describe("formatter:compact", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems"
+                "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems\n"
             );
         });
     });
@@ -144,7 +144,7 @@ describe("formatter:compact", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems"
+                "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems\n"
             );
         });
     });
@@ -166,7 +166,7 @@ describe("formatter:compact", function () {
 
         it("should return a string without line and column", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");
+            assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem\n");
         });
     });
 });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo."
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo."
+                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo."
+                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo."
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar."
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar."
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -228,7 +228,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js."
+                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/jslint-xml.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/jslint-xml.test.ts
@@ -30,7 +30,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>\n'
             );
         });
     });
@@ -55,7 +55,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>\n'
             );
         });
     });
@@ -87,7 +87,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>\n'
             );
         });
     });
@@ -124,7 +124,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file><file name="bar.js"><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file><file name="bar.js"><issue line="6" char="11" evidence="" reason="Unexpected bar. (bar)" /></file></jslint>\n'
             );
         });
     });
@@ -149,7 +149,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected &lt;&amp;&quot;&#39;&gt; foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected &lt;&amp;&quot;&#39;&gt; foo. (foo)" /></file></jslint>\n'
             );
         });
     });
@@ -174,7 +174,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="Unexpected foo. (foo)" /></file></jslint>\n'
             );
         });
     });
@@ -197,7 +197,7 @@ describe("formatter:jslint-xml", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="" /></file></jslint>'
+                '<?xml version="1.0" encoding="utf-8"?><jslint><file name="foo.js"><issue line="5" char="10" evidence="" reason="" /></file></jslint>\n'
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/unix.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/unix.test.ts
@@ -45,19 +45,19 @@ describe("formatter:compact", function () {
 
         it("should return a string in the format filename:line:column: error [Error/rule_id]", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem\n");
         });
 
         it("should return a string in the format filename:line:column: warning [Warning/rule_id]", function () {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Warning/foo]\n\n1 problem");
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Warning/foo]\n\n1 problem\n");
         });
 
         it("should return a string in the format filename:line:column: info [Info/rule_id]", function () {
             code[0].messages[0].severity = 3;
             const result = formatter(code);
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Info/foo]\n\n1 problem");
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Info/foo]\n\n1 problem\n");
         });
     });
 
@@ -79,7 +79,7 @@ describe("formatter:compact", function () {
 
         it("should return a string in the format filename:line:column: error [Error/rule_id]", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem\n");
         });
     });
 
@@ -110,7 +110,7 @@ describe("formatter:compact", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems"
+                "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems\n"
             );
         });
     });
@@ -147,7 +147,7 @@ describe("formatter:compact", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems"
+                "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems\n"
             );
         });
     });
@@ -169,7 +169,7 @@ describe("formatter:compact", function () {
 
         it("should return a string without line and column", function () {
             const result = formatter(code);
-            assert.equal(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem");
+            assert.equal(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem\n");
         });
     });
 });

--- a/packages/textlint/src/cli-util.ts
+++ b/packages/textlint/src/cli-util.ts
@@ -44,7 +44,10 @@ export function printResults(output: string, options: CliOptions): boolean {
             return false;
         }
     } else {
-        Logger.log(output);
+        // Use raw stdout write so the output is byte-identical to the
+        // content written when --output-file is specified.
+        // console.log would append an extra newline. See #2043.
+        Logger.write(output);
     }
     return true;
 }

--- a/packages/textlint/src/util/logger.ts
+++ b/packages/textlint/src/util/logger.ts
@@ -13,6 +13,15 @@ export class Logger {
         console.log(...message);
     }
 
+    /**
+     * Write to stdout without appending a newline.
+     * Use this for formatter output where the trailing newline must match
+     * the original content (e.g. fixed-result with --stdin).
+     */
+    static write(message: string) {
+        process.stdout.write(message);
+    }
+
     static warn(...message: unknown[]) {
         console.warn(...message);
     }

--- a/packages/textlint/test/cli-snapshot-test/cli-snapshots.test.ts
+++ b/packages/textlint/test/cli-snapshot-test/cli-snapshots.test.ts
@@ -43,9 +43,13 @@ type RunContext = {
 
 const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unknown> => {
     const originLog = Logger.log;
+    const originWrite = Logger.write;
     const messages: string[] = [];
     Logger.log = function mockLog(...message: unknown[]) {
         messages.push(message.join(" "));
+    };
+    Logger.write = function mockWrite(message: string) {
+        messages.push(message);
     };
     const context = {
         getLogs() {
@@ -68,6 +72,7 @@ const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unk
         throw error;
     }
     Logger.log = originLog;
+    Logger.write = originWrite;
     return;
 };
 

--- a/packages/textlint/test/cli/cli-exit-status-faq.test.ts
+++ b/packages/textlint/test/cli/cli-exit-status-faq.test.ts
@@ -39,12 +39,16 @@ type RunContext = {
 
 const runWithMockLogger = async (cb: (context: RunContext) => unknown): Promise<unknown> => {
     const originLog = Logger.log;
+    const originWrite = Logger.write;
     const originError = Logger.error;
     const logMessages: string[] = [];
     const errorMessages: string[] = [];
 
     Logger.log = function mockLog(...message: unknown[]) {
         logMessages.push(message.join(" "));
+    };
+    Logger.write = function mockWrite(message: string) {
+        logMessages.push(message);
     };
     Logger.error = function mockError(...message: unknown[]) {
         errorMessages.push(message.map(String).join(" "));
@@ -83,6 +87,7 @@ const runWithMockLogger = async (cb: (context: RunContext) => unknown): Promise<
     }
 
     Logger.log = originLog;
+    Logger.write = originWrite;
     Logger.error = originError;
     return;
 };

--- a/packages/textlint/test/cli/cli-preset-severity.test.ts
+++ b/packages/textlint/test/cli/cli-preset-severity.test.ts
@@ -12,9 +12,13 @@ type RunContext = {
 
 const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unknown> => {
     const originLog = Logger.log;
+    const originWrite = Logger.write;
     const messages: string[] = [];
     Logger.log = function mockLog(...message: unknown[]) {
         messages.push(message.join(" "));
+    };
+    Logger.write = function mockWrite(message: string) {
+        messages.push(message);
     };
     const context = {
         getLogs() {
@@ -28,6 +32,7 @@ const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unk
         throw error;
     }
     Logger.log = originLog;
+    Logger.write = originWrite;
     return;
 };
 

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -16,11 +16,16 @@ type RunContext = {
     assertHasLog(): unknown;
 };
 const originLog = Logger.log;
+const originWrite = Logger.write;
 const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unknown> => {
     const originLog = Logger.log;
+    const originWrite = Logger.write;
     const messages: string[] = [];
     Logger.log = function mockLog(...message: unknown[]) {
         messages.push(message.join(" "));
+    };
+    Logger.write = function mockWrite(message: string) {
+        messages.push(message);
     };
     const context = {
         getLogs() {
@@ -43,6 +48,7 @@ const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unk
         throw error;
     }
     Logger.log = originLog;
+    Logger.write = originWrite;
     return;
 };
 describe("cli-test", function () {
@@ -50,9 +56,13 @@ describe("cli-test", function () {
         Logger.log = function mockLog() {
             // mock console API
         };
+        Logger.write = function mockWrite() {
+            // mock stdout write API
+        };
     });
     afterEach(function () {
         Logger.log = originLog;
+        Logger.write = originWrite;
     });
     describe("when pass linting", function () {
         it("should output checkstyle xml if the results length is 0", function () {
@@ -321,6 +331,28 @@ describe("cli-test", function () {
                     assert.strictEqual(getLogs()[0], `This is fixed.`);
                     assert.strictEqual(result, 0);
                 });
+            });
+            // Regression test for #2043
+            it("should output fixed-result to stdout without appending an extra newline", async () => {
+                const originWrite = Logger.write;
+                const chunks: string[] = [];
+                Logger.write = function mockWrite(message: string) {
+                    chunks.push(message);
+                };
+                try {
+                    const ruleDir = path.join(__dirname, "fixtures/fixer-rules");
+                    const input = "This is fix<REMOVE_MARK>";
+                    const result = await cli.execute(
+                        `--rulesdir ${ruleDir} --fix --dry-run --stdin --stdin-filename test.md --format fixed-result`,
+                        input
+                    );
+                    assert.strictEqual(result, 0);
+                    // The combined stdout output must equal the formatter output exactly
+                    // (no trailing newline added by console.log). See #2043.
+                    assert.strictEqual(chunks.join(""), "This is fixed.");
+                } finally {
+                    Logger.write = originWrite;
+                }
             });
         });
     });


### PR DESCRIPTION
## Summary

Fixes #2043. `textlint --stdin --fix --format fixed-result` was adding an extra trailing newline to stdout because `console.log` appends one, while `--output-file` writes raw bytes. The two paths now produce byte-identical output, restoring round-trip safety for editor format-on-save and shell-pipeline use cases.

## Changes

- **`Logger.write(message)`**: new helper in `packages/textlint/src/util/logger.ts` that writes to `process.stdout` without appending a newline.
- **`printResults`**: switched the stdout branch in `packages/textlint/src/cli-util.ts` from `Logger.log(output)` to `Logger.write(output)`, so stdout and `--output-file` produce identical bytes.
- **Formatters now own their trailing newline.** Since the CLI no longer appends one, every built-in formatter now ends its non-empty output with `\n` (so the terminal prompt lands on the next line and redirected files are well-formed text files):
  - linter-formatter: `compact`, `unix`, `github` (removed an unhelpful `.trimEnd()`), `json`, `checkstyle`, `jslint-xml`
  - fixer-formatter: `compats`, `json`
  - Already ended with `\n`, unchanged: `pretty-error`, `stylish` (linter+fixer), `table`, `tap`, `diff`, `junit`
- **`fixed-result` is the deliberate exception** — it preserves source bytes so that piping `--fix --format fixed-result` to a file matches the original input when no fix is needed. This is the core fix for #2043.
- **Test mocks** updated to capture `Logger.write` alongside `Logger.log` (`cli.test.ts`, `cli-snapshot-test`, `cli-preset-severity.test.ts`, `cli-exit-status-faq.test.ts`).
- **Regression test** in `cli.test.ts` asserting that `--fix --dry-run --stdin --format fixed-result` writes the formatter output verbatim without an extra newline.
- **README docs** for `@textlint/linter-formatter` and `@textlint/fixer-formatter` now state the contract: formatter return value is written as-is; every built-in formatter ends non-empty output with `\n`; `fixed-result` is the byte-preserving exception.

## Breaking Changes

None for end users running the CLI normally.

Authors of custom textlint formatters should note that the CLI no longer appends a newline to stdout. Formatters that previously relied on `console.log` for the terminal-friendly trailing `\n` may want to append one themselves.

## Test Plan

- [x] `pnpm test` passes for `textlint`, `@textlint/linter-formatter`, `@textlint/fixer-formatter`
- [x] New regression test fails when the `Logger.write` swap is temporarily reverted
- [ ] CI green on the PR
- [ ] Manual repro:
  ```sh
  echo 'Hello, World!!' > TEST.md
  cat TEST.md | npx textlint --stdin --stdin-filename TEST.md --fix --format fixed-result > STDOUT.md
  diff -u TEST.md STDOUT.md   # should be empty
  ```

Refs #2043