### PR TITLE
fix(textlint): preflight formatter availability

### DIFF
--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -26,14 +26,55 @@ const isFormatterFunction = (formatter: unknown): formatter is FormatterFunction
 };
 type BuiltInFormatterName = keyof typeof builtinFormatterList;
 const builtinFormatterNames = Object.keys(builtinFormatterList);
+const linterOnlyFormatterNames = [
+    "checkstyle",
+    "compact",
+    "github",
+    "jslint-xml",
+    "junit",
+    "pretty-error",
+    "table",
+    "tap",
+    "unix"
+];
 const debug = debug0("textlint:textfix-formatter");
 
 export type FormatterConfig = { color?: boolean; formatterName: string };
 
+function findFormatterPath(formatterName: string): string | null {
+    if (builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
+        return formatterName;
+    }
+    if (fs.existsSync(formatterName)) {
+        return formatterName;
+    }
+    const formatterPath = path.resolve(process.cwd(), formatterName);
+    if (fs.existsSync(formatterPath)) {
+        return formatterPath;
+    }
+    return (
+        tryResolve(`textlint-formatter-${formatterName}`, {
+            parentModule: "fixer-formatter"
+        }) ||
+        tryResolve(formatterName, {
+            parentModule: "fixer-formatter"
+        }) ||
+        null
+    );
+}
+
+export function resolveFormatter(formatterName: string): string | null {
+    if (linterOnlyFormatterNames.includes(formatterName)) {
+        return null;
+    }
+    return findFormatterPath(formatterName);
+}
+
 export async function loadFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
-    if (builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
+    const formatterPath = findFormatterPath(formatterName);
+    if (formatterPath === formatterName && builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
         return {
             format(results: TextlintFixResult[]) {
                 return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
@@ -41,23 +82,6 @@ export async function loadFormatter(formatterConfig: FormatterConfig) {
         };
     }
     let formatter: FormatterFunction;
-    let formatterPath;
-    if (fs.existsSync(formatterName)) {
-        formatterPath = formatterName;
-    } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
-        formatterPath = path.resolve(process.cwd(), formatterName);
-    } else {
-        const pkgPath =
-            tryResolve(`textlint-formatter-${formatterName}`, {
-                parentModule: "fixer-formatter"
-            }) ||
-            tryResolve(formatterName, {
-                parentModule: "fixer-formatter"
-            });
-        if (pkgPath) {
-            formatterPath = pkgPath;
-        }
-    }
     if (!formatterPath) {
         throw new Error(`Could not find formatter ${formatterName}`);
     }

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -26,6 +26,8 @@ const isFormatterFunction = (formatter: unknown): formatter is FormatterFunction
 };
 type BuiltInFormatterName = keyof typeof builtinFormatterList;
 const builtinFormatterNames = Object.keys(builtinFormatterList);
+// Keep this local to avoid a package dependency cycle with @textlint/linter-formatter.
+// These linter-only built-in names must not resolve to same-named npm packages, such as pretty-error.
 const linterOnlyFormatterNames = [
     "checkstyle",
     "compact",
@@ -73,14 +75,14 @@ export function resolveFormatter(formatterName: string): string | null {
 export async function loadFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
-    const formatterPath = findFormatterPath(formatterName);
-    if (formatterPath === formatterName && builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
+    if (builtinFormatterNames.includes(formatterName as BuiltInFormatterName)) {
         return {
             format(results: TextlintFixResult[]) {
                 return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
             }
         };
     }
+    const formatterPath = findFormatterPath(formatterName);
     let formatter: FormatterFunction;
     if (!formatterPath) {
         throw new Error(`Could not find formatter ${formatterName}`);

--- a/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter.test.ts
+++ b/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter.test.ts
@@ -2,7 +2,7 @@
 "use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
-import { getFixerFormatterList } from "../src/index.js";
+import { getFixerFormatterList, resolveFormatter } from "../src/index.js";
 
 describe("@textlint/fixer-formatter-test", function () {
     describe("getFormatterList", function () {
@@ -14,6 +14,17 @@ describe("@textlint/fixer-formatter-test", function () {
                 { name: "json" },
                 { name: "stylish" }
             ]);
+        });
+    });
+
+    describe("resolveFormatter", function () {
+        it("should resolve built-in fixer formatters", function () {
+            assert.strictEqual(resolveFormatter("stylish"), "stylish");
+            assert.strictEqual(resolveFormatter("fixed-result"), "fixed-result");
+        });
+
+        it("should return null for linter-only formatters", function () {
+            assert.strictEqual(resolveFormatter("pretty-error"), null);
         });
     });
 });

--- a/packages/@textlint/linter-formatter/README.md
+++ b/packages/@textlint/linter-formatter/README.md
@@ -53,6 +53,7 @@ export interface FormatterDetail {
     name: string;
 }
 export declare function getFormatterList(): FormatterDetail[];
+export declare function resolveFormatter(formatterName: string): string | null;
 ```
 
 ## CLI

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -24,7 +24,7 @@ import unixFormatter from "./formatters/unix.js";
 const builtinFormatterList = {
     checkstyle: checkstyleFormatter,
     compact: compactFormatter,
-    "github": githubFormatter,
+    github: githubFormatter,
     "jslint-xml": jslintXMLFormatter,
     json: jsonFormatter,
     junit: junitFormatter,
@@ -36,6 +36,7 @@ const builtinFormatterList = {
 } as const;
 type BuiltInFormatterName = keyof typeof builtinFormatterList;
 const builtinFormatterNames = Object.keys(builtinFormatterList);
+const fixerOnlyFormatterNames = ["compats", "diff", "fixed-result"];
 const debug = debug0("textlint:@textlint/linter-formatter");
 type FormatterFunction = (results: TextlintResult[], formatterConfig: FormatterConfig) => string;
 const isFormatterFunction = (formatter: unknown): formatter is FormatterFunction => {
@@ -47,10 +48,40 @@ export interface FormatterConfig {
     color?: boolean;
 }
 
+function findFormatterPath(formatterName: string): string | null {
+    if (builtinFormatterNames.includes(formatterName)) {
+        return formatterName;
+    }
+    if (fs.existsSync(formatterName)) {
+        return formatterName;
+    }
+    const formatterPath = path.resolve(process.cwd(), formatterName);
+    if (fs.existsSync(formatterPath)) {
+        return formatterPath;
+    }
+    return (
+        tryResolve(`textlint-formatter-${formatterName}`, {
+            parentModule: "linter-formatter"
+        }) ||
+        tryResolve(formatterName, {
+            parentModule: "linter-formatter"
+        }) ||
+        null
+    );
+}
+
+export function resolveFormatter(formatterName: string): string | null {
+    if (fixerOnlyFormatterNames.includes(formatterName)) {
+        return null;
+    }
+    return findFormatterPath(formatterName);
+}
+
 export async function loadFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
-    if (builtinFormatterNames.includes(formatterName)) {
+    const formatterPath = findFormatterPath(formatterName);
+    if (formatterPath === formatterName && builtinFormatterNames.includes(formatterName)) {
         return {
             format(results: TextlintResult[]) {
                 return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
@@ -58,24 +89,6 @@ export async function loadFormatter(formatterConfig: FormatterConfig) {
         };
     }
     let formatter: FormatterFunction;
-    let formatterPath;
-    if (fs.existsSync(formatterName)) {
-        formatterPath = formatterName;
-    } else if (fs.existsSync(path.resolve(process.cwd(), formatterName))) {
-        formatterPath = path.resolve(process.cwd(), formatterName);
-    } else {
-        const pkgPath =
-            tryResolve(`textlint-formatter-${formatterName}`, {
-                parentModule: "linter-formatter"
-            }) ||
-            tryResolve(formatterName, {
-                parentModule: "linter-formatter"
-            });
-        if (pkgPath) {
-            formatterPath = pkgPath;
-        }
-    }
-
     if (!formatterPath) {
         throw new Error(`Could not find formatter ${formatterName}`);
     }

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -36,6 +36,8 @@ const builtinFormatterList = {
 } as const;
 type BuiltInFormatterName = keyof typeof builtinFormatterList;
 const builtinFormatterNames = Object.keys(builtinFormatterList);
+// Keep this local to avoid a package dependency cycle with @textlint/fixer-formatter.
+// These fixer-only built-in names must not resolve to same-named npm packages.
 const fixerOnlyFormatterNames = ["compats", "diff", "fixed-result"];
 const debug = debug0("textlint:@textlint/linter-formatter");
 type FormatterFunction = (results: TextlintResult[], formatterConfig: FormatterConfig) => string;
@@ -80,14 +82,14 @@ export function resolveFormatter(formatterName: string): string | null {
 export async function loadFormatter(formatterConfig: FormatterConfig) {
     const formatterName = formatterConfig.formatterName;
     debug(`formatterName: ${formatterName}`);
-    const formatterPath = findFormatterPath(formatterName);
-    if (formatterPath === formatterName && builtinFormatterNames.includes(formatterName)) {
+    if (builtinFormatterNames.includes(formatterName)) {
         return {
             format(results: TextlintResult[]) {
                 return builtinFormatterList[formatterName as BuiltInFormatterName](results, formatterConfig);
             }
         };
     }
+    const formatterPath = findFormatterPath(formatterName);
     let formatter: FormatterFunction;
     if (!formatterPath) {
         throw new Error(`Could not find formatter ${formatterName}`);

--- a/packages/@textlint/linter-formatter/test/textlint-formatter.test.ts
+++ b/packages/@textlint/linter-formatter/test/textlint-formatter.test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 "use strict";
-import { getFormatterList, loadFormatter } from "../src/index.js";
+import { getFormatterList, loadFormatter, resolveFormatter } from "../src/index.js";
 
 import { describe, it } from "vitest";
 
@@ -67,6 +67,17 @@ describe("@textlint/linter-formatter-test", function () {
                 { name: "tap" },
                 { name: "unix" }
             ]);
+        });
+    });
+
+    describe("resolveFormatter", function () {
+        it("should resolve built-in formatters", function () {
+            assert.strictEqual(resolveFormatter("stylish"), "stylish");
+            assert.strictEqual(resolveFormatter("pretty-error"), "pretty-error");
+        });
+
+        it("should return null for unavailable formatter", function () {
+            assert.strictEqual(resolveFormatter("unavailable-formatter"), null);
         });
     });
 });

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -9,7 +9,7 @@ import { loadCliDescriptor } from "./loader/CliLoader.js";
 import { createLinter, TextlintFileSearchError } from "./createLinter.js";
 import { SeverityLevel } from "./shared/type/SeverityLevel.js";
 import { printResults, showEmptyRuleWarning } from "./cli-util.js";
-import { loadFixerFormatter, loadLinterFormatter } from "./formatter.js";
+import { loadFixerFormatter, loadLinterFormatter, resolveFixerFormatter, resolveLinterFormatter } from "./formatter.js";
 import { connectStdioMcpServer, type McpServerOptions } from "./mcp/server.js";
 
 const debug = debug0("textlint:cli");
@@ -129,6 +129,13 @@ export const cli = {
      */
     async executeWithOptions(executeOptions: ExecuteOptions): Promise<number> {
         const cliOptions = executeOptions.cliOptions;
+        const formatterPath = cliOptions.fix
+            ? resolveFixerFormatter(cliOptions.format)
+            : resolveLinterFormatter(cliOptions.format);
+        if (!formatterPath) {
+            Logger.error(`Could not find formatter ${cliOptions.format}`);
+            return Promise.resolve(1);
+        }
         // cli > textlintrc
         // if cli and textlintrc have same option, cli option is prior.
         const descriptor = await loadDescriptor(cliOptions);

--- a/packages/textlint/src/formatter.ts
+++ b/packages/textlint/src/formatter.ts
@@ -1,4 +1,10 @@
-import { loadFormatter as loadFixerFormatter } from "@textlint/fixer-formatter";
-import { loadFormatter as loadLinterFormatter } from "@textlint/linter-formatter";
+import {
+    loadFormatter as loadFixerFormatter,
+    resolveFormatter as resolveFixerFormatter
+} from "@textlint/fixer-formatter";
+import {
+    loadFormatter as loadLinterFormatter,
+    resolveFormatter as resolveLinterFormatter
+} from "@textlint/linter-formatter";
 
-export { loadLinterFormatter, loadFixerFormatter };
+export { loadLinterFormatter, loadFixerFormatter, resolveLinterFormatter, resolveFixerFormatter };

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -17,15 +17,20 @@ type RunContext = {
 };
 const originLog = Logger.log;
 const originWrite = Logger.write;
+const originError = Logger.error;
 const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unknown> => {
     const originLog = Logger.log;
     const originWrite = Logger.write;
+    const originError = Logger.error;
     const messages: string[] = [];
     Logger.log = function mockLog(...message: unknown[]) {
         messages.push(message.join(" "));
     };
     Logger.write = function mockWrite(message: string) {
         messages.push(message);
+    };
+    Logger.error = function mockError(...message: unknown[]) {
+        messages.push(message.join(" "));
     };
     const context = {
         getLogs() {
@@ -49,6 +54,7 @@ const runWithMockLog = async (cb: (context: RunContext) => unknown): Promise<unk
     }
     Logger.log = originLog;
     Logger.write = originWrite;
+    Logger.error = originError;
     return;
 };
 describe("cli-test", function () {
@@ -63,6 +69,7 @@ describe("cli-test", function () {
     afterEach(function () {
         Logger.log = originLog;
         Logger.write = originWrite;
+        Logger.error = originError;
     });
     describe("when pass linting", function () {
         it("should output checkstyle xml if the results length is 0", function () {
@@ -288,6 +295,16 @@ describe("cli-test", function () {
                     const result = await cli.execute(`--rulesdir ${ruleDir} --fix ${targetFile}`);
                     assert.strictEqual(result, 0);
                     assertNotHasLog();
+                });
+            });
+
+            it("should exit before processing with unavailable fixer formatter", function () {
+                return runWithMockLog(async ({ getLogs }) => {
+                    const ruleDir = path.join(__dirname, "fixtures/fixer-rules");
+                    const targetFile = path.join(__dirname, "fixtures/not-found.md");
+                    const result = await cli.execute(`--rulesdir ${ruleDir} --fix -f pretty-error ${targetFile}`);
+                    assert.strictEqual(result, 1);
+                    assert.match(getLogs()[0], /Could not find formatter pretty-error/);
                 });
             });
         });

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -116,6 +116,15 @@ describe("cli-test", function () {
                 assert.match(getLogs()[0], /No rules found/);
             });
         });
+        it("should exit before processing with unavailable linter formatter", function () {
+            return runWithMockLog(async ({ getLogs }) => {
+                const ruleDir = path.join(__dirname, "fixtures/rules");
+                const targetFile = path.join(__dirname, "fixtures/not-found.md");
+                const result = await cli.execute(`--rulesdir ${ruleDir} -f fixed-result ${targetFile}`);
+                assert.strictEqual(result, 1);
+                assert.match(getLogs()[0], /Could not find formatter fixed-result/);
+            });
+        });
         it("should report lint warning and error by using stylish reporter", function () {
             return runWithMockLog(async ({ getLogs }) => {
                 const targetFile = path.join(__dirname, "fixtures/todo.md");


### PR DESCRIPTION
## Summary

Fixes #462.

This adds formatter availability preflight checks before lint/fix processing starts. In `--fix` mode, textlint now validates against fixer formatters; otherwise it validates against linter formatters.

## Changes

- Add `resolveFormatter()` to linter and fixer formatter packages
- Reuse existing formatter lookup behavior in `loadFormatter()`
- Preflight unavailable formatters in the CLI before processing files
- Add focused resolver and CLI tests

## Validation

- `pnpm --filter @textlint/linter-formatter test`
- `pnpm --filter @textlint/fixer-formatter test`
- `pnpm --filter textlint test`
- `pnpm run build`
