### PR TITLE
CI: Upgrade automerge-gate action to v5.0.0

### DIFF
--- a/.github/workflows/automerge-gate.yml
+++ b/.github/workflows/automerge-gate.yml
@@ -19,6 +19,6 @@ jobs:
       pull-requests: read
       actions: read
     steps:
-      - uses: pkgdeps/automerge-gate@004aadf338d613c4aba4131c6c8b9ea86f4211a1 # v4.0.0
+      - uses: pkgdeps/automerge-gate@fe5d7cd2fc17778dc42f6916f9d9990cb259ad01 # v5.0.0
         with:
           gate-mode: 'public'


### PR DESCRIPTION
## Summary
Updates the `pkgdeps/automerge-gate` GitHub Action from v4.0.0 to v5.0.0 in the automerge gate workflow.

## Changes
- Updated `pkgdeps/automerge-gate` action reference from `004aadf338d613c4aba4131c6c8b9ea86f4211a1` (v4.0.0) to `fe5d7cd2fc17778dc42f6916f9d9990cb259ad01` (v5.0.0)
- Maintained existing `gate-mode: 'public'` configuration

## Details
This upgrade brings the automerge gate workflow to the latest major version, which may include bug fixes, performance improvements, and new features from the v5.0.0 release.

https://claude.ai/code/session_01LYDxovedL8ShDVovnQucam