### PR TITLE
Inline @azu dependencies to remove external package requirements

### DIFF
--- a/packages/@textlint/linter-formatter/package.json
+++ b/packages/@textlint/linter-formatter/package.json
@@ -33,8 +33,6 @@
     "test:watch": "vitest watch"
   },
   "dependencies": {
-    "@azu/format-text": "catalog:",
-    "@azu/style-format": "catalog:",
     "@textlint/module-interop": "workspace:*",
     "@textlint/resolver": "workspace:*",
     "@textlint/types": "workspace:*",

--- a/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
@@ -23,7 +23,7 @@ import { readFileSync } from "node:fs";
 const formatTemplate = (text: string, context: Record<string, unknown>): string =>
     String(text).replace(/\{?\{([^{}]+)}}?/g, (tag, name: string) => {
         if (tag.startsWith("{{") && tag.endsWith("}}")) {
-            return "{" + name + "}";
+            return `{${name}}`;
         }
         if (!Object.prototype.hasOwnProperty.call(context, name)) {
             return tag;

--- a/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
@@ -7,10 +7,6 @@ import type { TextlintMessage, TextlintResult } from "@textlint/types";
 import { FormatterOptions } from "../FormatterOptions.js";
 
 import chalk from "chalk";
-// @ts-expect-error no types
-import format from "@azu/format-text";
-// @ts-expect-error no types
-import style from "@azu/style-format";
 import stripAnsi from "strip-ansi";
 // @ts-expect-error no types
 import pluralize from "pluralize";
@@ -21,9 +17,31 @@ import widthOfString from "string-width";
 // color set
 import { readFileSync } from "node:fs";
 
+// Inlined replacement for @azu/format-text (BSD-3-Clause, https://github.com/azu/format-text)
+// and @azu/style-format (https://github.com/azu/style-format). Replaces `{name}` placeholders
+// from a context object, leaves unknown placeholders intact, and supports `{{name}}` escaping.
+const formatTemplate = (text: string, context: Record<string, unknown>): string =>
+    String(text).replace(/\{?\{([^{}]+)}}?/g, (tag, name: string) => {
+        if (tag.startsWith("{{") && tag.endsWith("}}")) {
+            return "{" + name + "}";
+        }
+        if (!Object.prototype.hasOwnProperty.call(context, name)) {
+            return tag;
+        }
+        const value = context[name];
+        return String(typeof value === "function" ? (value as () => unknown)() : value);
+    });
+
+// Subset of @azu/style-format's ansi-codes (MIT) — only the styles used by the template below.
+const ansiStyles: Record<string, string> = {
+    reset: "\u001b[0m",
+    grey: "\u001b[90m",
+    red: "\u001b[31m"
+};
+
 const summaryColor = "yellow";
 const greenColor = "green";
-const template = style(
+const template = formatTemplate(
     "{grey}{ruleId}: {red}{title}{reset}\n" +
         "{grey}{filename}{reset}\n" +
         "    {red}{paddingForLineNo}  {v}{reset}\n" +
@@ -31,7 +49,8 @@ const template = style(
         "    {reset}{failingLineNo}. {failingLine}{reset}\n" +
         "    {grey}{nextLineNo}. {nextLine}{reset}\n" +
         "    {red}{paddingForLineNo}  {^}{reset}\n" +
-        ""
+        "",
+    ansiStyles
 );
 
 /**
@@ -100,7 +119,7 @@ function prettyError(code: string, filePath: string, message: TextlintMessage): 
     const failingLineNo = String(parsed[1].line);
     const nextLineNo = String(parsed[2].line);
     const linumlen = Math.max(previousLineNo.length, failingLineNo.length, nextLineNo.length);
-    return format(template, {
+    return formatTemplate(template, {
         ruleId: message.ruleId,
         title: message.message,
         filename: `${filePath}:${message.line}:${message.column}`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@azu/format-text':
-      specifier: ^1.0.2
-      version: 1.0.2
-    '@azu/style-format':
-      specifier: ^1.0.1
-      version: 1.0.1
     '@babel/cli':
       specifier: ^7.28.6
       version: 7.28.6
@@ -735,12 +729,6 @@ importers:
 
   packages/@textlint/linter-formatter:
     dependencies:
-      '@azu/format-text':
-        specifier: 'catalog:'
-        version: 1.0.2
-      '@azu/style-format':
-        specifier: 'catalog:'
-        version: 1.0.1
       '@textlint/module-interop':
         specifier: workspace:*
         version: link:../module-interop
@@ -1474,12 +1462,6 @@ packages:
   '@algolia/requester-node-http@5.39.0':
     resolution: {integrity: sha512-6beG+egPwXmvhAg+m0STCj+ZssDcjrLzf4L05aKm2nGglMXSSPz0cH/rM+kVD9krNfldiMctURd4wjojW1fV0w==}
     engines: {node: '>= 14.0.0'}
-
-  '@azu/format-text@1.0.2':
-    resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
-
-  '@azu/style-format@1.0.1':
-    resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
 
   '@babel/cli@7.28.6':
     resolution: {integrity: sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==}
@@ -10128,12 +10110,6 @@ snapshots:
   '@algolia/requester-node-http@5.39.0':
     dependencies:
       '@algolia/client-common': 5.39.0
-
-  '@azu/format-text@1.0.2': {}
-
-  '@azu/style-format@1.0.1':
-    dependencies:
-      '@azu/format-text': 1.0.2
 
   '@babel/cli@7.28.6(@babel/core@7.29.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,8 +16,6 @@ allowBuilds:
 # Catalog: centralized external dependency versions
 # https://pnpm.io/catalogs
 catalog:
-  "@azu/format-text": "^1.0.2"
-  "@azu/style-format": "^1.0.1"
   "@babel/cli": "^7.28.6"
   "@babel/core": "^7.29.0"
   "@babel/preset-env": "^7.29.5"


### PR DESCRIPTION
## Summary
Removed external dependencies on `@azu/format-text` and `@azu/style-format` by inlining their functionality directly into the codebase. This eliminates the need to maintain these external package dependencies while preserving the exact same behavior.

## Key Changes
- **Inlined `formatTemplate` function**: Replaced the `@azu/format-text` import with a custom implementation that handles template string interpolation with `{name}` placeholders, supports `{{name}}` escaping, and leaves unknown placeholders intact
- **Inlined ANSI style codes**: Replaced the `@azu/style-format` import with a minimal `ansiStyles` object containing only the styles used by the error template (reset, grey, red)
- **Updated template usage**: Changed the template definition to use the inlined `formatTemplate` function and pass the `ansiStyles` object as context
- **Updated function calls**: Replaced all `format()` calls with `formatTemplate()` calls
- **Removed package dependencies**: Deleted `@azu/format-text` and `@azu/style-format` from both `package.json` and `pnpm-workspace.yaml` catalog

## Implementation Details
- The inlined `formatTemplate` function uses a regex pattern `/\{?\{([^{}]+)}}?/g` to match both single and double-brace placeholders
- Proper attribution is maintained with comments referencing the original BSD-3-Clause and MIT licensed code
- The implementation is minimal and focused only on the specific use case in the pretty-error formatter

https://claude.ai/code/session_017Pc156Fj1jT78C2kQTcH8i