### PR TITLE
chore(deps): upgrade prettier to v3

### DIFF
--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -41,105 +41,105 @@ export type TypeofTxtNode<T extends ASTNodeTypes | string> =
     T extends ASTNodeTypes.Document
         ? TxtDocumentNode
         : T extends ASTNodeTypes.DocumentExit
-        ? TxtDocumentNode
-        : T extends ASTNodeTypes.Paragraph // Paragraph Str.
-        ? TxtParagraphNode
-        : T extends ASTNodeTypes.ParagraphExit
-        ? TxtParagraphNode
-        : T extends ASTNodeTypes.BlockQuote // > Str
-        ? TxtBlockQuoteNode
-        : T extends ASTNodeTypes.BlockQuoteExit
-        ? TxtBlockQuoteNode
-        : T extends ASTNodeTypes.List // - item
-        ? TxtListNode
-        : T extends ASTNodeTypes.ListExit
-        ? TxtListNode
-        : T extends ASTNodeTypes.ListItem // - item
-        ? TxtListItemNode
-        : T extends ASTNodeTypes.ListItemExit
-        ? TxtListItemNode
-        : T extends ASTNodeTypes.Header // # Str
-        ? TxtHeaderNode
-        : T extends ASTNodeTypes.HeaderExit
-        ? TxtHeaderNode
-        : T extends ASTNodeTypes.CodeBlock
-        ? /* ```
-           * code block
-           * ```
-           */
-          TxtCodeBlockNode
-        : T extends ASTNodeTypes.CodeBlockExit
-        ? TxtCodeBlockNode
-        : T extends ASTNodeTypes.HtmlBlock // <div>\n</div>
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.HtmlBlockExit
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.Link // [link](https://example.com)
-        ? TxtLinkNode
-        : T extends ASTNodeTypes.LinkExit
-        ? TxtLinkNode
-        : T extends ASTNodeTypes.LinkReference // [link][1]
-        ? TxtLinkReferenceNode
-        : T extends ASTNodeTypes.LinkReferenceExit
-        ? TxtLinkReferenceNode
-        : T extends ASTNodeTypes.Delete // ~~Str~~
-        ? TxtDeleteNode
-        : T extends ASTNodeTypes.DeleteExit
-        ? TxtDeleteNode
-        : T extends ASTNodeTypes.Emphasis // *Str*
-        ? TxtEmphasisNode
-        : T extends ASTNodeTypes.EmphasisExit
-        ? TxtEmphasisNode
-        : T extends ASTNodeTypes.Strong // __Str__
-        ? TxtStrongNode
-        : T extends ASTNodeTypes.StrongExit
-        ? TxtStrongNode
-        : T extends ASTNodeTypes.Break // Str<space><space>
-        ? TxtBreakNode
-        : T extends ASTNodeTypes.BreakExit
-        ? TxtBreakNode
-        : T extends ASTNodeTypes.Image // ![alt](https://example.com/img)
-        ? TxtImageNode
-        : T extends ASTNodeTypes.ImageExit
-        ? TxtImageNode
-        : T extends ASTNodeTypes.ImageReference // ![alt][1]
-        ? TxtImageReferenceNode
-        : T extends ASTNodeTypes.ImageReferenceExit
-        ? TxtImageReferenceNode
-        : T extends ASTNodeTypes.Definition // [1]: https://example.com
-        ? TxtDefinitionNode
-        : T extends ASTNodeTypes.DefinitionExit
-        ? TxtDefinitionNode
-        : T extends ASTNodeTypes.HorizontalRule // ----
-        ? TxtHorizontalRuleNode
-        : T extends ASTNodeTypes.HorizontalRuleExit
-        ? TxtHorizontalRuleNode
-        : T extends ASTNodeTypes.Comment // Markdown does not have comment(It is Html comment). Some plugins use comment as a marker.
-        ? TxtCommentNode
-        : T extends ASTNodeTypes.CommentExit
-        ? TxtCommentNode
-        : T extends ASTNodeTypes.Str // Str
-        ? TxtStrNode
-        : T extends ASTNodeTypes.StrExit
-        ? TxtStrNode
-        : T extends ASTNodeTypes.Code // `code`
-        ? TxtCodeNode
-        : T extends ASTNodeTypes.CodeExit
-        ? TxtCodeNode
-        : T extends ASTNodeTypes.Html // <span>Str</span>
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.HtmlExit
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.Table
-        ? TxtTableNode
-        : T extends ASTNodeTypes.TableExit
-        ? TxtTableNode
-        : T extends ASTNodeTypes.TableRow
-        ? TxtTableRowNode
-        : T extends ASTNodeTypes.TableRowExit
-        ? TxtTableRowNode
-        : T extends ASTNodeTypes.TableCell
-        ? TxtTableCellNode
-        : T extends ASTNodeTypes.TableCellExit
-        ? TxtTableCellNode
-        : AnyTxtNode;
+          ? TxtDocumentNode
+          : T extends ASTNodeTypes.Paragraph // Paragraph Str.
+            ? TxtParagraphNode
+            : T extends ASTNodeTypes.ParagraphExit
+              ? TxtParagraphNode
+              : T extends ASTNodeTypes.BlockQuote // > Str
+                ? TxtBlockQuoteNode
+                : T extends ASTNodeTypes.BlockQuoteExit
+                  ? TxtBlockQuoteNode
+                  : T extends ASTNodeTypes.List // - item
+                    ? TxtListNode
+                    : T extends ASTNodeTypes.ListExit
+                      ? TxtListNode
+                      : T extends ASTNodeTypes.ListItem // - item
+                        ? TxtListItemNode
+                        : T extends ASTNodeTypes.ListItemExit
+                          ? TxtListItemNode
+                          : T extends ASTNodeTypes.Header // # Str
+                            ? TxtHeaderNode
+                            : T extends ASTNodeTypes.HeaderExit
+                              ? TxtHeaderNode
+                              : T extends ASTNodeTypes.CodeBlock
+                                ? /* ```
+                                   * code block
+                                   * ```
+                                   */
+                                  TxtCodeBlockNode
+                                : T extends ASTNodeTypes.CodeBlockExit
+                                  ? TxtCodeBlockNode
+                                  : T extends ASTNodeTypes.HtmlBlock // <div>\n</div>
+                                    ? TxtHtmlNode
+                                    : T extends ASTNodeTypes.HtmlBlockExit
+                                      ? TxtHtmlNode
+                                      : T extends ASTNodeTypes.Link // [link](https://example.com)
+                                        ? TxtLinkNode
+                                        : T extends ASTNodeTypes.LinkExit
+                                          ? TxtLinkNode
+                                          : T extends ASTNodeTypes.LinkReference // [link][1]
+                                            ? TxtLinkReferenceNode
+                                            : T extends ASTNodeTypes.LinkReferenceExit
+                                              ? TxtLinkReferenceNode
+                                              : T extends ASTNodeTypes.Delete // ~~Str~~
+                                                ? TxtDeleteNode
+                                                : T extends ASTNodeTypes.DeleteExit
+                                                  ? TxtDeleteNode
+                                                  : T extends ASTNodeTypes.Emphasis // *Str*
+                                                    ? TxtEmphasisNode
+                                                    : T extends ASTNodeTypes.EmphasisExit
+                                                      ? TxtEmphasisNode
+                                                      : T extends ASTNodeTypes.Strong // __Str__
+                                                        ? TxtStrongNode
+                                                        : T extends ASTNodeTypes.StrongExit
+                                                          ? TxtStrongNode
+                                                          : T extends ASTNodeTypes.Break // Str<space><space>
+                                                            ? TxtBreakNode
+                                                            : T extends ASTNodeTypes.BreakExit
+                                                              ? TxtBreakNode
+                                                              : T extends ASTNodeTypes.Image // ![alt](https://example.com/img)
+                                                                ? TxtImageNode
+                                                                : T extends ASTNodeTypes.ImageExit
+                                                                  ? TxtImageNode
+                                                                  : T extends ASTNodeTypes.ImageReference // ![alt][1]
+                                                                    ? TxtImageReferenceNode
+                                                                    : T extends ASTNodeTypes.ImageReferenceExit
+                                                                      ? TxtImageReferenceNode
+                                                                      : T extends ASTNodeTypes.Definition // [1]: https://example.com
+                                                                        ? TxtDefinitionNode
+                                                                        : T extends ASTNodeTypes.DefinitionExit
+                                                                          ? TxtDefinitionNode
+                                                                          : T extends ASTNodeTypes.HorizontalRule // ----
+                                                                            ? TxtHorizontalRuleNode
+                                                                            : T extends ASTNodeTypes.HorizontalRuleExit
+                                                                              ? TxtHorizontalRuleNode
+                                                                              : T extends ASTNodeTypes.Comment // Markdown does not have comment(It is Html comment). Some plugins use comment as a marker.
+                                                                                ? TxtCommentNode
+                                                                                : T extends ASTNodeTypes.CommentExit
+                                                                                  ? TxtCommentNode
+                                                                                  : T extends ASTNodeTypes.Str // Str
+                                                                                    ? TxtStrNode
+                                                                                    : T extends ASTNodeTypes.StrExit
+                                                                                      ? TxtStrNode
+                                                                                      : T extends ASTNodeTypes.Code // `code`
+                                                                                        ? TxtCodeNode
+                                                                                        : T extends ASTNodeTypes.CodeExit
+                                                                                          ? TxtCodeNode
+                                                                                          : T extends ASTNodeTypes.Html // <span>Str</span>
+                                                                                            ? TxtHtmlNode
+                                                                                            : T extends ASTNodeTypes.HtmlExit
+                                                                                              ? TxtHtmlNode
+                                                                                              : T extends ASTNodeTypes.Table
+                                                                                                ? TxtTableNode
+                                                                                                : T extends ASTNodeTypes.TableExit
+                                                                                                  ? TxtTableNode
+                                                                                                  : T extends ASTNodeTypes.TableRow
+                                                                                                    ? TxtTableRowNode
+                                                                                                    : T extends ASTNodeTypes.TableRowExit
+                                                                                                      ? TxtTableRowNode
+                                                                                                      : T extends ASTNodeTypes.TableCell
+                                                                                                        ? TxtTableCellNode
+                                                                                                        : T extends ASTNodeTypes.TableCellExit
+                                                                                                          ? TxtTableCellNode
+                                                                                                          : AnyTxtNode;

--- a/packages/@textlint/legacy-textlint-core/src/index.ts
+++ b/packages/@textlint/legacy-textlint-core/src/index.ts
@@ -40,7 +40,7 @@ const builtInPlugins = [
  */
 const rulesObjectToKernelRule: (
     rules: { [p: string]: TextlintRuleModule },
-    rulesOption: { [p: string]: TextlintKernelRule["options"] }
+    rulesOption: { [p: string]: TextlintKernelRule["options"] },
 ) => TextlintKernelRule[] = (rules, rulesOption) => {
     return Object.keys(rules).map((ruleId) => {
         return {
@@ -53,7 +53,7 @@ const rulesObjectToKernelRule: (
 
 const filterRulesObjectToKernelRule: (
     rules: { [p: string]: TextlintFilterRuleReporter },
-    rulesOption: { [p: string]: TextlintKernelFilterRule["options"] }
+    rulesOption: { [p: string]: TextlintKernelFilterRule["options"] },
 ) => TextlintKernelFilterRule[] = (rules, rulesOption): TextlintKernelFilterRule[] => {
     return Object.keys(rules).map((ruleId) => {
         return {
@@ -77,7 +77,7 @@ const filterRulesObjectToKernelRule: (
  */
 export const pluginsObjectToKernelRule = (
     plugins: { [index: string]: TextlintPluginCreator },
-    pluginsOption: { [index: string]: TextlintKernelPlugin["options"] }
+    pluginsOption: { [index: string]: TextlintKernelPlugin["options"] },
 ): TextlintKernelPlugin[] => {
     return Object.keys(plugins).map((pluginId) => {
         return {
@@ -114,7 +114,7 @@ export class TextLintCore {
                 rules: rulesObjectToKernelRule(rules, rulesOption),
                 filterRules: [],
                 plugins: [],
-            })
+            }),
         );
     }
 
@@ -129,7 +129,7 @@ export class TextLintCore {
                 rules: [],
                 filterRules: filterRulesObjectToKernelRule(filterRules, filterRulesConfig),
                 plugins: [],
-            })
+            }),
         );
     }
 
@@ -156,7 +156,7 @@ export class TextLintCore {
                 rules: [],
                 filterRules: [],
                 plugins: pluginsObjectToKernelRule(plugins, pluginsConfig),
-            })
+            }),
         );
     }
 

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -24,7 +24,7 @@ import unixFormatter from "./formatters/unix.js";
 const builtinFormatterList = {
     checkstyle: checkstyleFormatter,
     compact: compactFormatter,
-    "github": githubFormatter,
+    github: githubFormatter,
     "jslint-xml": jslintXMLFormatter,
     json: jsonFormatter,
     junit: junitFormatter,

--- a/packages/@textlint/resolver/src/index.ts
+++ b/packages/@textlint/resolver/src/index.ts
@@ -10,7 +10,7 @@ type ResolverSkipResult = undefined;
  */
 export type ResolveHook = (
     specifier: string,
-    context: ResolverContext
+    context: ResolverContext,
 ) =>
     | {
           url: string | undefined;
@@ -21,7 +21,7 @@ export type ResolveHook = (
  */
 export type ImportHook = (
     specifier: string,
-    context: ResolverContext
+    context: ResolverContext,
 ) => Promise<
     | {
           exports: Record<string, unknown>;
@@ -92,7 +92,7 @@ const convertToFileUrl = (filePath: string) => {
  */
 export const dynamicImport = async (
     specifier: string,
-    context: ResolverContext
+    context: ResolverContext,
 ): Promise<{
     exports: Record<string, unknown> | undefined;
 }> => {

--- a/packages/@textlint/text-to-ast/src/plaintext-parser.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-parser.ts
@@ -149,38 +149,41 @@ export function parse(text: string): TxtDocumentNode {
     const isEmptyLine = (line: LineWithBreak | LastLine | EmptyLine, index: number): line is EmptyLine => {
         return index !== lastLineIndex && line.text === "";
     };
-    const children = textLineByLine.reduce(function (result, currentLine, index) {
-        const lineNumber = index + 1;
-        if (isLastEmptyLine(currentLine, index)) {
-            return result;
-        }
-        // \n
-        if (isEmptyLine(currentLine, index)) {
-            const emptyBreakNode = createBRNode({
-                lineBreak: currentLine.lineBreak,
-                lineNumber,
-                startIndex
-            });
-            startIndex += emptyBreakNode.raw.length;
-            result.push(emptyBreakNode);
-            return result;
-        }
+    const children = textLineByLine.reduce(
+        function (result, currentLine, index) {
+            const lineNumber = index + 1;
+            if (isLastEmptyLine(currentLine, index)) {
+                return result;
+            }
+            // \n
+            if (isEmptyLine(currentLine, index)) {
+                const emptyBreakNode = createBRNode({
+                    lineBreak: currentLine.lineBreak,
+                    lineNumber,
+                    startIndex
+                });
+                startIndex += emptyBreakNode.raw.length;
+                result.push(emptyBreakNode);
+                return result;
+            }
 
-        // (Paragraph > Str) -> Br?
-        const strNode = parseLine(currentLine.text, lineNumber, startIndex);
-        const paragraph = createParagraph([strNode]);
-        startIndex += paragraph.raw.length;
-        result.push(paragraph);
-        // add Break node with actual line break value
-        // It should support CRLF
-        // https://github.com/textlint/textlint/issues/656
-        if (currentLine.lineBreak !== null) {
-            const breakNode = createEndedBRNode({ prevNode: paragraph, lineBreakText: currentLine.lineBreak });
-            startIndex += breakNode.raw.length;
-            result.push(breakNode);
-        }
-        return result;
-    }, [] as (TxtBreakNode | TxtParagraphNode)[]);
+            // (Paragraph > Str) -> Br?
+            const strNode = parseLine(currentLine.text, lineNumber, startIndex);
+            const paragraph = createParagraph([strNode]);
+            startIndex += paragraph.raw.length;
+            result.push(paragraph);
+            // add Break node with actual line break value
+            // It should support CRLF
+            // https://github.com/textlint/textlint/issues/656
+            if (currentLine.lineBreak !== null) {
+                const breakNode = createEndedBRNode({ prevNode: paragraph, lineBreakText: currentLine.lineBreak });
+                startIndex += breakNode.raw.length;
+                result.push(breakNode);
+            }
+            return result;
+        },
+        [] as (TxtBreakNode | TxtParagraphNode)[]
+    );
     const lastLine = textLineByLine[textLineByLine.length - 1];
     if (lastLine === undefined) {
         return {

--- a/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
+++ b/packages/@textlint/types/src/Plugin/TextlintPluginModule.ts
@@ -58,7 +58,7 @@ export declare class TextlintPluginProcessor {
          */
         preProcess(
             text: string,
-            filePath?: string
+            filePath?: string,
         ): TextlintPluginPreProcessResult | Promise<TextlintPluginPreProcessResult>;
         /**
          * postProcess return messages and the filePath for the result.
@@ -67,7 +67,7 @@ export declare class TextlintPluginProcessor {
          */
         postProcess(
             messages: Array<TextlintMessage>,
-            filePath?: string
+            filePath?: string,
         ): TextlintPluginPostProcessResult | Promise<TextlintPluginPostProcessResult>;
     };
 }

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
@@ -27,7 +27,7 @@ export type TextlintFilterRuleReportHandler = {
  */
 export type TextlintFilterRuleReporter = (
     context: Readonly<TextlintFilterRuleContext>,
-    options?: TextlintFilterRuleOptions
+    options?: TextlintFilterRuleOptions,
 ) => TextlintFilterRuleReportHandler;
 /**
  * textlint filter module exports

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -24,7 +24,7 @@ export type TextlintRuleReportHandler = { [P in ASTNodeTypes]?: (node: TypeofTxt
  */
 export type TextlintRuleReporter<T extends object = object> = (
     context: Readonly<TextlintRuleContext>,
-    options?: TextlintRuleOptions<T>
+    options?: TextlintRuleOptions<T>,
 ) => TextlintRuleReportHandler;
 /**
  * If Textlint rule has fixer, it should both of { linter, fixer }.

--- a/packages/@textlint/utils/test/KeyPath/config-key-normalizer.test.ts
+++ b/packages/@textlint/utils/test/KeyPath/config-key-normalizer.test.ts
@@ -94,7 +94,7 @@ describe("config-key-normalizer", function () {
                         preset: pattern.preset,
                         rule: pattern.rule,
                     }),
-                    pattern.result
+                    pattern.result,
                 );
             });
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ catalogs:
       specifier: ^2.0.0
       version: 2.0.0
     prettier:
-      specifier: ^2.8.1
-      version: 2.8.8
+      specifier: 3.8.3
+      version: 3.8.3
     prh:
       specifier: ^5.4.4
       version: 5.4.4
@@ -331,7 +331,7 @@ importers:
         version: 0.23.0
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -578,7 +578,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -728,7 +728,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -865,7 +865,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -886,7 +886,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
@@ -911,7 +911,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1023,7 +1023,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1044,7 +1044,7 @@ importers:
         version: 24.13.2
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -1211,7 +1211,7 @@ importers:
         version: 16.4.0
       prettier:
         specifier: 'catalog:'
-        version: 2.8.8
+        version: 3.8.3
 
   packages/textlint-scripts/examples/example:
     dependencies:
@@ -8537,9 +8537,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-error@4.0.0:
@@ -19602,7 +19602,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@2.8.8: {}
+  prettier@3.8.3: {}
 
   pretty-error@4.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -70,7 +70,7 @@ catalog:
   path-to-glob-pattern: "^2.0.1"
   pkg-to-readme: "^3.0.1"
   pluralize: "^2.0.0"
-  prettier: "^2.8.1"
+  prettier: "3.8.3"
   prh: "^5.4.4"
   prism-react-renderer: "^2.4.1"
   rc-config-loader: "^4.1.4"


### PR DESCRIPTION
This PR upgrades Prettier from v2 to v3 and applies the new formatting rules across the entire codebase.

This PR contains a lot of file changes due to the formatting updates introduced in Prettier v3 (e.g., changes to default behaviors like `trailingComma: "all"`).