### PR TITLE
chore(deps): upgrade zod to version 4.4.3

### DIFF
--- a/packages/textlint/src/mcp/schemas.ts
+++ b/packages/textlint/src/mcp/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 /**
  * Zod schema for TextlintMessage that matches the TextlintMessage interface

--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
+import * as z from "zod";
 import { createLinter, loadTextlintrc, type CreateLinterOptions } from "../index.js";
 import { existsSync } from "node:fs";
 import { TextlintMessageSchema } from "./schemas.js";
@@ -118,7 +118,7 @@ export const setupServer = async (options: McpServerOptions = {}): Promise<McpSe
             inputSchema: {
                 filePaths: z
                     .array(z.string().min(1).describe("File path to lint"))
-                    .nonempty()
+                    .min(1)
                     .describe("Array of file paths to lint")
             },
             outputSchema: {
@@ -169,8 +169,8 @@ export const setupServer = async (options: McpServerOptions = {}): Promise<McpSe
         {
             description: "Lint text using textlint",
             inputSchema: {
-                text: z.string().nonempty().describe("Text content to lint"),
-                stdinFilename: z.string().nonempty().describe("Filename for context (e.g., 'stdin.md')")
+                text: z.string().min(1).describe("Text content to lint"),
+                stdinFilename: z.string().min(1).describe("Filename for context (e.g., 'stdin.md')")
             },
             outputSchema: {
                 filePath: z.string(),
@@ -214,7 +214,7 @@ export const setupServer = async (options: McpServerOptions = {}): Promise<McpSe
             inputSchema: {
                 filePaths: z
                     .array(z.string().min(1).describe("File path to fix"))
-                    .nonempty()
+                    .min(1)
                     .describe("Array of file paths to get fixed content for")
             },
             outputSchema: {
@@ -265,8 +265,8 @@ export const setupServer = async (options: McpServerOptions = {}): Promise<McpSe
         {
             description: "Get lint-fixed content of text using textlint",
             inputSchema: {
-                text: z.string().nonempty().describe("Text content to fix"),
-                stdinFilename: z.string().nonempty().describe("Filename for context (e.g., 'stdin.md')")
+                text: z.string().min(1).describe("Text content to fix"),
+                stdinFilename: z.string().min(1).describe("Filename for context (e.g., 'stdin.md')")
             },
             outputSchema: {
                 filePath: z.string(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,8 +292,8 @@ catalogs:
       specifier: ^3.2.6
       version: 3.2.6
     zod:
-      specifier: ^3.25.76
-      version: 3.25.76
+      specifier: ^4.4.3
+      version: 4.4.3
 
 overrides:
   '@textlint/ast-node-types': workspace:*
@@ -1059,7 +1059,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 'catalog:'
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       '@textlint/ast-node-types':
         specifier: workspace:*
         version: link:../@textlint/ast-node-types
@@ -1128,7 +1128,7 @@ importers:
         version: 4.0.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@textlint/legacy-textlint-core':
         specifier: workspace:*
@@ -10437,8 +10437,8 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
@@ -13625,7 +13625,7 @@ snapshots:
       '@types/react': 19.1.8
       react: 19.2.7
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.8)
       ajv: 8.20.0
@@ -13642,8 +13642,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
       raw-body: 3.0.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21993,11 +21993,11 @@ snapshots:
 
   zlibjs@0.3.1: {}
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -111,7 +111,7 @@ catalog:
   unified: "^9.2.2"
   unist-util-select: "^3.0.4"
   vitest: "^3.2.6"
-  zod: "^3.25.76"
+  zod: "^4.4.3"
 
 # Automatically remove unused catalog entries on install
 # https://pnpm.io/settings#cleanupunusedcatalogs


### PR DESCRIPTION
upgrade zod to version 4.4.3.

**Dependency upgrade and compatibility:**
- Upgraded the `zod` dependency from version 3.25.76 to 4.4.3 in both the workspace and lock files, ensuring all packages and transitive dependencies now use `zod@4.4.3`.

**Code and import adjustments:**
- Changed `import { z } from "zod"` to `import * as z from "zod"` in `schemas.ts` and `server.ts` to match the recommended import style for `zod@4`. [[1]](diffhunk://#diff-61139b15d8cbea7bab725b6cc904898cc411cef1ea78e7cfb948f03ea8a9f1dcL1-R1) [[2]](diffhunk://#diff-3d6d872b30c5ffe8cd4ce92475126b10fd5331586883d4ad879c4175f5cfef7eL3-R3)

**Schema API updates:**
- Replaced `.nonempty()` with `.min(1)` in all relevant `z.string()` and `z.array()` schemas in `server.ts`.