### PR TITLE
chore: enable additional oxlint rules and apply autofixes

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,8 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": [
-    "typescript"
+    "typescript",
+    "unicorn"
   ],
   "categories": {
     "correctness": "error"
@@ -21,7 +22,11 @@
     "typescript/no-unsafe-function-type": "error",
     "typescript/unbound-method": "off",
     "typescript/restrict-template-expressions": "off",
-    "typescript/no-redundant-type-constituents": "off"
+    "typescript/no-redundant-type-constituents": "off",
+    "unicorn/prefer-node-protocol": "error",
+    "unicorn/prefer-string-starts-ends-with": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/no-empty-file": "off",
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,7 +25,7 @@
     "typescript/no-redundant-type-constituents": "off",
     "unicorn/prefer-node-protocol": "error",
     "unicorn/prefer-string-starts-ends-with": "error",
-    "unicorn/no-new-array": "off",
+    "unicorn/no-new-array": "error",
     "unicorn/no-empty-file": "off",
   },
   "overrides": [

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,7 +24,7 @@
     "typescript/restrict-template-expressions": "off",
     "typescript/no-redundant-type-constituents": "off",
     "unicorn/prefer-node-protocol": "error",
-    "unicorn/prefer-string-starts-ends-with": "off",
+    "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/no-new-array": "off",
     "unicorn/no-empty-file": "off",
   },

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -27,6 +27,7 @@
     "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/no-new-array": "error",
     "unicorn/no-empty-file": "off",
+    "typescript/consistent-type-imports": "error"
   },
   "overrides": [
     {

--- a/docs/example/rules/example-rule.js
+++ b/docs/example/rules/example-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 /**
  * @param {RuleContext} context
  */

--- a/examples/perf/perf.js
+++ b/examples/perf/perf.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 const os = require("node:os");
 const path = require("node:path");
 const { execFile } = require("node:child_process");

--- a/examples/perf/run.js
+++ b/examples/perf/run.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 // run as app
 const cli = require("textlint").cli;
 cli.execute(process.argv.concat(`${__dirname}/md/`))

--- a/examples/rulesdir/rules/no-todo.js
+++ b/examples/rulesdir/rules/no-todo.js
@@ -1,6 +1,4 @@
 // LICENSE : MIT
-"use strict";
-
 /**
  * Get parents of node.
  * The parent nodes are returned in order from the closest parent to the outer ones.

--- a/examples/use-as-ts-module/tsconfig.json
+++ b/examples/use-as-ts-module/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "lib",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "composite": true
+    "composite": true,
+    "types": ["node"]
   },
   "references": [
     {

--- a/packages/@textlint/ast-node-types/tsconfig.json
+++ b/packages/@textlint/ast-node-types/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "esnext"
       // "dom"
-    ]
+    ],
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/ast-tester/src/index.ts
+++ b/packages/@textlint/ast-tester/src/index.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import * as assert from "node:assert";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { test as UnistTest } from "./unist-test.js";
 import debug0 from "debug";
 

--- a/packages/@textlint/ast-tester/src/index.ts
+++ b/packages/@textlint/ast-tester/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { TxtNode } from "@textlint/ast-node-types";
 import { test as UnistTest } from "./unist-test.js";

--- a/packages/@textlint/ast-tester/src/unist-test.ts
+++ b/packages/@textlint/ast-tester/src/unist-test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 
 // https://github.com/wooorm/unist

--- a/packages/@textlint/ast-tester/tsconfig.json
+++ b/packages/@textlint/ast-tester/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/ast-traverse/src/index.ts
+++ b/packages/@textlint/ast-traverse/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { AnyTxtNode, TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 
 /**

--- a/packages/@textlint/ast-traverse/test/traverse-dump.ts
+++ b/packages/@textlint/ast-traverse/test/traverse-dump.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import { Controller } from "../src/index.js";
-import { TxtParentNode } from "@textlint/ast-node-types";
+import type { TxtParentNode } from "@textlint/ast-node-types";
 
 export class Dumper {
     // [enter|leave, node type, parent node type]

--- a/packages/@textlint/ast-traverse/test/traverse-dump.ts
+++ b/packages/@textlint/ast-traverse/test/traverse-dump.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { Controller } from "../src/index.js";
 import { TxtParentNode } from "@textlint/ast-node-types";
 

--- a/packages/@textlint/ast-traverse/test/txt-traverse.test.ts
+++ b/packages/@textlint/ast-traverse/test/txt-traverse.test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
+import type { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 import { describe, it } from "vitest";
 import { Controller, traverse, VisitorOption } from "../src/index.js";
 import { parse, Syntax } from "@textlint/markdown-to-ast";

--- a/packages/@textlint/ast-traverse/test/txt-traverse.test.ts
+++ b/packages/@textlint/ast-traverse/test/txt-traverse.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 import { describe, it } from "vitest";

--- a/packages/@textlint/ast-traverse/tsconfig.json
+++ b/packages/@textlint/ast-traverse/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/config-loader/src/config-loader.ts
+++ b/packages/@textlint/config-loader/src/config-loader.ts
@@ -1,7 +1,7 @@
 import { rcFile } from "rc-config-loader";
 import { TextLintModuleResolver } from "./textlint-module-resolver.js";
 import { loadFilterRules, loadPlugins, loadRules } from "./loader.js";
-import { TextlintRcConfig } from "./TextlintRcConfig.js";
+import type { TextlintRcConfig } from "./TextlintRcConfig.js";
 import type { TextlintConfigDescriptor } from "./TextlintConfigDescriptor.js";
 import { isUtf8 } from "node:buffer";
 import fs from "node:fs";

--- a/packages/@textlint/config-loader/src/config-util.ts
+++ b/packages/@textlint/config-loader/src/config-util.ts
@@ -1,23 +1,23 @@
 export function isPluginRuleKey(key: string) {
     // @<owner>/<plugin><>rule>
-    if (key[0] === "@" && key.indexOf("/textlint-plugin") !== -1) {
+    if (key.startsWith("@") && key.indexOf("/textlint-plugin") !== -1) {
         return true;
     }
     // not contain @, but contain /
     // <plugin>/<rule>
-    return key[0] !== "@" && key.indexOf("/") !== -1;
+    return !key.startsWith("@") && key.indexOf("/") !== -1;
 }
 
 export function isPresetRuleKey(key: string) {
     // "preset-name" is special pattern
-    if (/^preset-/.test(key)) {
+    if (key.startsWith("preset-")) {
         return true;
     }
-    if (/^textlint-rule-preset-/.test(key)) {
+    if (key.startsWith("textlint-rule-preset-")) {
         return true;
     }
     // scoped module: @textlint/textlint-rule-preset-foo
-    if (key[0] === "@") {
+    if (key.startsWith("@")) {
         if (key.indexOf("/preset-") !== -1 || key.indexOf("/textlint-rule-preset-") !== -1) {
             return true;
         }

--- a/packages/@textlint/config-loader/src/is.ts
+++ b/packages/@textlint/config-loader/src/is.ts
@@ -1,7 +1,6 @@
 // TODO: share with @textlint/kernel
-import type { TextlintRuleModule } from "@textlint/types";
-import { TextlintConfigRulePreset } from "./TextlintConfigDescriptor.js";
-import { TextlintFilterRuleReporter } from "@textlint/types";
+import type { TextlintRuleModule, TextlintFilterRuleReporter } from "@textlint/types";
+import type { TextlintConfigRulePreset } from "./TextlintConfigDescriptor.js";
 
 // Type guards
 function isObjectWithProperty(obj: unknown, property: string): obj is Record<string, unknown> {

--- a/packages/@textlint/config-loader/src/loader.ts
+++ b/packages/@textlint/config-loader/src/loader.ts
@@ -1,9 +1,9 @@
-import { TextLintModuleResolver } from "./textlint-module-resolver.js";
+import type { TextLintModuleResolver } from "./textlint-module-resolver.js";
 import { isPresetRuleKey } from "./config-util.js";
-import { TextlintRcConfig } from "./TextlintRcConfig.js";
+import type { TextlintRcConfig } from "./TextlintRcConfig.js";
 import { moduleInterop } from "@textlint/module-interop";
-import { TextlintConfigDescriptor } from "./TextlintConfigDescriptor.js";
-import { TextlintPluginCreator } from "@textlint/types";
+import type { TextlintConfigDescriptor } from "./TextlintConfigDescriptor.js";
+import type { TextlintPluginCreator } from "@textlint/types";
 import { isTextlintRulePresetCreator, isTextlintFilterRuleModule, isTextlintRuleModule } from "./is.js";
 import { normalizeTextlintPresetSubRuleKey } from "@textlint/utils";
 import { dynamicImport } from "@textlint/resolver";
@@ -245,11 +245,11 @@ export const loadRules = async ({
                         if (!isTextlintRuleModule(ruleModule)) {
                             ruleErrors.push(
                                 new Error(`Rule should have "rules" and "rulesConfig" properties. But ${ruleId} is not.
-                        
+
 Please check ${ruleId} is valid rule.
 FilePath: ${resolvePackage.filePath}
 
-For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md                        
+For more details, See FAQ: https://github.com/textlint/textlint/blob/master/docs/faq/failed-to-load-textlints-module.md
 `)
                             );
                             return;

--- a/packages/@textlint/config-loader/src/textlint-package-name-util.ts
+++ b/packages/@textlint/config-loader/src/textlint-package-name-util.ts
@@ -5,7 +5,7 @@ export const removePrefixFromPackageName = (prefixList: string[], packageName: s
     for (const prefix of prefixList) {
         // @scope/name -> @scope/name
         // @scope/textlint-rule-name -> @scope/name
-        if (packageName.charAt(0) === "@") {
+        if (packageName.startsWith("@")) {
             const [namespace, name] = packageName.split("/");
             if (name.startsWith(prefix)) {
                 return `${namespace}/${name.slice(prefix.length)}`;
@@ -28,7 +28,7 @@ export const removePrefixFromPackageName = (prefixList: string[], packageName: s
  * @returns {string}
  */
 export const createFullPackageName = (prefix: string, name: string): string => {
-    if (name.charAt(0) === "@") {
+    if (name.startsWith("@")) {
         const scopedPackageNameRegex = new RegExp(`^${prefix}(-|$)`);
         // if @scope/<name> -> @scope/<prefix><name>
         if (!scopedPackageNameRegex.test(name.split("/")[1])) {

--- a/packages/@textlint/config-loader/tsconfig.json
+++ b/packages/@textlint/config-loader/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./lib/"
+    "outDir": "./lib/",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/feature-flag/src/index.ts
+++ b/packages/@textlint/feature-flag/src/index.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 
 const flagMap = new Map<string, boolean>();
 /**

--- a/packages/@textlint/feature-flag/test/textlint-feature-flag.test.ts
+++ b/packages/@textlint/feature-flag/test/textlint-feature-flag.test.ts
@@ -1,4 +1,3 @@
-"use strict";
 import assert from "node:assert";
 import { beforeEach, describe, it } from "vitest";
 import {

--- a/packages/@textlint/feature-flag/tsconfig.json
+++ b/packages/@textlint/feature-flag/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/fixer-formatter/src/formatters/compats.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/compats.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 function getMessageType(message: TextlintFixResult["applyingMessages"][number] & { fatal?: boolean }) {
     if (message.fatal || message.severity === 2) {

--- a/packages/@textlint/fixer-formatter/src/formatters/diff.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/diff.ts
@@ -1,4 +1,3 @@
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 import * as fs from "node:fs";
 import { diffLines } from "diff";

--- a/packages/@textlint/fixer-formatter/src/formatters/fixed-result.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/fixed-result.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 
 export default function (results: TextlintFixResult[]) {

--- a/packages/@textlint/fixer-formatter/src/formatters/json.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/json.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 export default function (results: TextlintFixResult[]) {
     return `${JSON.stringify(results)}\n`;

--- a/packages/@textlint/fixer-formatter/src/formatters/stylish.ts
+++ b/packages/@textlint/fixer-formatter/src/formatters/stylish.ts
@@ -1,4 +1,3 @@
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 
 import chalk from "chalk";

--- a/packages/@textlint/fixer-formatter/src/index.ts
+++ b/packages/@textlint/fixer-formatter/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintFixResult } from "@textlint/types";
 import { moduleInterop } from "@textlint/module-interop";
 import fs from "node:fs";

--- a/packages/@textlint/fixer-formatter/test/formatters/compats.test.ts
+++ b/packages/@textlint/fixer-formatter/test/formatters/compats.test.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { describe, it, expect } from "vitest";
 import compats from "../../src/formatters/compats.js";
 // @ts-expect-error - fixture files don't have type definitions

--- a/packages/@textlint/fixer-formatter/test/formatters/diff.test.ts
+++ b/packages/@textlint/fixer-formatter/test/formatters/diff.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { describe, it, expect } from "vitest";
 import diff from "../../src/formatters/diff.js";
 // @ts-expect-error - fixture files don't have type definitions

--- a/packages/@textlint/fixer-formatter/test/formatters/fixed-result.test.ts
+++ b/packages/@textlint/fixer-formatter/test/formatters/fixed-result.test.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { describe, it, expect } from "vitest";
 import fixedResult from "../../src/formatters/fixed-result.js";
 // @ts-expect-error - fixture files don't have type definitions

--- a/packages/@textlint/fixer-formatter/test/formatters/stylish.test.ts
+++ b/packages/@textlint/fixer-formatter/test/formatters/stylish.test.ts
@@ -1,4 +1,3 @@
-"use strict";
 import stylish from "../../src/formatters/stylish.js";
 import { describe, it, expect } from "vitest";
 

--- a/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter.test.ts
+++ b/packages/@textlint/fixer-formatter/test/textlint-fixer-formatter.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { getFixerFormatterList } from "../src/index.js";

--- a/packages/@textlint/fixer-formatter/tsconfig.json
+++ b/packages/@textlint/fixer-formatter/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "ts-node": {
     "compilerOptions": {

--- a/packages/@textlint/kernel/src/context/TextlintFilterRuleContextImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintFilterRuleContextImpl.ts
@@ -5,7 +5,7 @@ import type {
     TextlintRuleSeverityLevel,
     TextlintSourceCode
 } from "@textlint/types";
-import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
+import type { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import { TextlintRuleErrorImpl } from "./TextlintRuleErrorImpl.js";
 import { createPaddingLocator } from "./TextlintRulePaddingLocator.js";
 import { invariant } from "../util/invariant.js";

--- a/packages/@textlint/kernel/src/context/TextlintRuleContextFixCommandGeneratorImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRuleContextFixCommandGeneratorImpl.ts
@@ -1,4 +1,4 @@
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { TextlintRuleContextFixCommandGenerator, TextlintSourceCodeRange } from "@textlint/types";
 import { invariant } from "../util/invariant.js";
 

--- a/packages/@textlint/kernel/src/context/TextlintRuleContextImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRuleContextImpl.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     TextlintRuleContext,
     TextlintRuleContextReportFunction,
     TextlintRuleError,
@@ -7,7 +7,7 @@ import {
     TextlintRuleSeverityLevel,
     TextlintSourceCode
 } from "@textlint/types";
-import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
+import type { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
 import { TextlintRuleContextFixCommandGeneratorImpl } from "./TextlintRuleContextFixCommandGeneratorImpl.js";
 import { TextlintRuleSeverityLevelKeys } from "./TextlintRuleSeverityLevelKeys.js";
 import { TextlintRuleErrorImpl } from "./TextlintRuleErrorImpl.js";

--- a/packages/@textlint/kernel/src/context/TextlintRuleErrorImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRuleErrorImpl.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import type {
     TextlintRuleContextFixCommand,

--- a/packages/@textlint/kernel/src/context/TextlintRuleErrorImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRuleErrorImpl.ts
@@ -6,7 +6,7 @@ import type {
     TextlintRuleError,
     TextlintRuleSuggestion
 } from "@textlint/types";
-import { TextlintRuleErrorPaddingLocation } from "@textlint/types";
+import type { TextlintRuleErrorPaddingLocation } from "@textlint/types";
 import { throwIfTesting } from "@textlint/feature-flag";
 import { isTextlintRuleErrorPaddingLocation } from "./TextlintRulePaddingLocator.js";
 

--- a/packages/@textlint/kernel/src/context/TextlintRulePaddingLocator.ts
+++ b/packages/@textlint/kernel/src/context/TextlintRulePaddingLocator.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     TextlintRuleErrorPaddingLocation,
     TextlintRuleErrorPaddingLocationLoc,
     TextlintRuleErrorPaddingLocationRange,
@@ -59,7 +59,7 @@ export const createPaddingLocator = (): TextlintRulePaddingLocator => {
             }
             if (aRange[0] === aRange[1]) {
                 throw new Error(`range must not be same: ${JSON.stringify(aRange)}
-                
+
 Probably, you need to use at() method instead.`);
             }
             return {

--- a/packages/@textlint/kernel/src/context/TextlintSourceCodeImpl.ts
+++ b/packages/@textlint/kernel/src/context/TextlintSourceCodeImpl.ts
@@ -5,7 +5,7 @@ import type {
     TextlintSourceCodePosition,
     TextlintSourceCodeRange
 } from "@textlint/types";
-import { AnyTxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
+import { type AnyTxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
 import { StructuredSource } from "structured-source";
 import { invariant } from "../util/invariant.js";
 

--- a/packages/@textlint/kernel/src/core/source-location.ts
+++ b/packages/@textlint/kernel/src/core/source-location.ts
@@ -7,7 +7,7 @@ import type {
     TextlintRuleSuggestion,
     TextlintMessageSuggestion
 } from "@textlint/types";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { invariant } from "../util/invariant.js";
 import { throwIfTesting } from "@textlint/feature-flag";
 import { isTextlintRuleErrorPaddingLocation } from "../context/TextlintRulePaddingLocator.js";

--- a/packages/@textlint/kernel/src/descriptor/DescriptorUtil.ts
+++ b/packages/@textlint/kernel/src/descriptor/DescriptorUtil.ts
@@ -1,4 +1,4 @@
-import { Descriptor } from "./Descriptor.js";
+import type { Descriptor } from "./Descriptor.js";
 
 /**
  * Remove duplicated descriptor

--- a/packages/@textlint/kernel/src/descriptor/DescriptorsFactory.ts
+++ b/packages/@textlint/kernel/src/descriptor/DescriptorsFactory.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintKernelFilterRule, TextlintKernelPlugin, TextlintKernelRule } from "../textlint-kernel-interface.js";
 import { TextlintFilterRuleDescriptor } from "./TextlintFilterRuleDescriptor.js";
 import { TextlintFilterRuleDescriptors } from "./TextlintFilterRuleDescriptors.js";

--- a/packages/@textlint/kernel/src/descriptor/DescriptorsFactory.ts
+++ b/packages/@textlint/kernel/src/descriptor/DescriptorsFactory.ts
@@ -1,5 +1,9 @@
 // LICENSE : MIT
-import { TextlintKernelFilterRule, TextlintKernelPlugin, TextlintKernelRule } from "../textlint-kernel-interface.js";
+import type {
+    TextlintKernelFilterRule,
+    TextlintKernelPlugin,
+    TextlintKernelRule
+} from "../textlint-kernel-interface.js";
 import { TextlintFilterRuleDescriptor } from "./TextlintFilterRuleDescriptor.js";
 import { TextlintFilterRuleDescriptors } from "./TextlintFilterRuleDescriptors.js";
 import { TextlintRuleDescriptors } from "./TextlintRuleDescriptors.js";

--- a/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import { getFilter } from "./rule-creator-helper.js";
-import { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
-import { Descriptor } from "./Descriptor.js";
+import type { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
+import type { Descriptor } from "./Descriptor.js";
 import type { TextlintFilterRuleOptions, TextlintFilterRuleReporter } from "@textlint/types";
 import { deepEqual } from "fast-equals";
 

--- a/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { getFilter } from "./rule-creator-helper.js";
 import { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
 import { Descriptor } from "./Descriptor.js";

--- a/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptors.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
 import { TextlintFilterRuleDescriptor } from "./TextlintFilterRuleDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";

--- a/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFilterRuleDescriptors.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
-import { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
-import { TextlintFilterRuleDescriptor } from "./TextlintFilterRuleDescriptor.js";
+import type { TextlintKernelFilterRule } from "../textlint-kernel-interface.js";
+import type { TextlintFilterRuleDescriptor } from "./TextlintFilterRuleDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";
 
 /**

--- a/packages/@textlint/kernel/src/descriptor/TextlintFixableRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintFixableRuleDescriptor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { getFixer } from "./rule-creator-helper.js";
 import { TextlintLintableRuleDescriptor } from "./TextlintLintableRuleDescriptor.js";
 import type { TextlintRuleReporter } from "@textlint/types";

--- a/packages/@textlint/kernel/src/descriptor/TextlintKernelDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintKernelDescriptor.ts
@@ -1,18 +1,18 @@
-import {
+import type {
     TextlintKernelFilterRule,
     TextlintKernelOptions,
     TextlintKernelPlugin,
     TextlintKernelRule
 } from "../textlint-kernel-interface.js";
-import { TextlintRuleDescriptors } from "./TextlintRuleDescriptors.js";
-import { TextlintPluginDescriptors } from "./TextlintPluginDescriptors.js";
-import { TextlintFilterRuleDescriptors } from "./TextlintFilterRuleDescriptors.js";
+import type { TextlintRuleDescriptors } from "./TextlintRuleDescriptors.js";
+import type { TextlintPluginDescriptors } from "./TextlintPluginDescriptors.js";
+import type { TextlintFilterRuleDescriptors } from "./TextlintFilterRuleDescriptors.js";
 import {
     createTextlintFilterRuleDescriptors,
     createTextlintPluginDescriptors,
     createTextlintRuleDescriptors
 } from "./DescriptorsFactory.js";
-import { TextlintPluginDescriptor } from "./TextlintPluginDescriptor.js";
+import type { TextlintPluginDescriptor } from "./TextlintPluginDescriptor.js";
 
 export interface TextlintKernelDescriptorArgs {
     // config base directory

--- a/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintKernelRule } from "../textlint-kernel-interface.js";
 import { assertRuleShape, getLinter } from "./rule-creator-helper.js";
 import type { TextlintRuleModule, TextlintRuleOptions, TextlintRuleReporter } from "@textlint/types";

--- a/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintLintableRuleDescriptor.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TextlintKernelRule } from "../textlint-kernel-interface.js";
+import type { TextlintKernelRule } from "../textlint-kernel-interface.js";
 import { assertRuleShape, getLinter } from "./rule-creator-helper.js";
 import type { TextlintRuleModule, TextlintRuleOptions, TextlintRuleReporter } from "@textlint/types";
 import { deepEqual } from "fast-equals";

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
 import { Descriptor } from "./Descriptor.js";
 import type {

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptor.ts
@@ -1,5 +1,5 @@
-import { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
-import { Descriptor } from "./Descriptor.js";
+import type { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
+import type { Descriptor } from "./Descriptor.js";
 import type {
     TextlintPluginOptions,
     TextlintPluginProcessor,

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
@@ -1,5 +1,5 @@
-import { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
-import { TextlintPluginDescriptor } from "./TextlintPluginDescriptor.js";
+import type { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
+import type { TextlintPluginDescriptor } from "./TextlintPluginDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";
 
 /**

--- a/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintPluginDescriptors.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { TextlintKernelPlugin } from "../textlint-kernel-interface.js";
 import { TextlintPluginDescriptor } from "./TextlintPluginDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";

--- a/packages/@textlint/kernel/src/descriptor/TextlintRuleDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintRuleDescriptors.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TextlintKernelRule } from "../textlint-kernel-interface.js";
+import type { TextlintKernelRule } from "../textlint-kernel-interface.js";
 import { TextlintLintableRuleDescriptor } from "./TextlintLintableRuleDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";
 import { TextlintFixableRuleDescriptor } from "./TextlintFixableRuleDescriptor.js";

--- a/packages/@textlint/kernel/src/descriptor/TextlintRuleDescriptors.ts
+++ b/packages/@textlint/kernel/src/descriptor/TextlintRuleDescriptors.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintKernelRule } from "../textlint-kernel-interface.js";
 import { TextlintLintableRuleDescriptor } from "./TextlintLintableRuleDescriptor.js";
 import { filterDuplicateDescriptor } from "./DescriptorUtil.js";

--- a/packages/@textlint/kernel/src/fixer/fixer-processor.ts
+++ b/packages/@textlint/kernel/src/fixer/fixer-processor.ts
@@ -3,9 +3,9 @@
 import type { TextlintFixResult, TextlintMessage, TextlintPluginProcessor, TextlintSourceCode } from "@textlint/types";
 import FixerTask from "../task/fixer-task.js";
 import TaskRunner from "../task/task-runner.js";
-import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
-import MessageProcessManager from "../messages/MessageProcessManager.js";
-import { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
+import type { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
+import type MessageProcessManager from "../messages/MessageProcessManager.js";
+import type { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
 import { TextlintSourceCodeImpl } from "../context/TextlintSourceCodeImpl.js";
 import _debug from "debug";
 import { applyFixesToSourceCode } from "@textlint/source-code-fixer";

--- a/packages/@textlint/kernel/src/fixer/fixer-processor.ts
+++ b/packages/@textlint/kernel/src/fixer/fixer-processor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import type { TextlintFixResult, TextlintMessage, TextlintPluginProcessor, TextlintSourceCode } from "@textlint/types";
 import FixerTask from "../task/fixer-task.js";

--- a/packages/@textlint/kernel/src/fixer/rule-fixer.ts
+++ b/packages/@textlint/kernel/src/fixer/rule-fixer.ts
@@ -1,5 +1,5 @@
 import { invariant } from "../util/invariant.js";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { TextlintSourceCodeRange } from "@textlint/types";
 
 /**

--- a/packages/@textlint/kernel/src/linter/linter-processor.ts
+++ b/packages/@textlint/kernel/src/linter/linter-processor.ts
@@ -1,10 +1,10 @@
 // LICENSE : MIT
 import LinterTask from "../task/linter-task.js";
 import TaskRunner from "../task/task-runner.js";
-import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
+import type { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
 
-import MessageProcessManager from "../messages/MessageProcessManager.js";
-import { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
+import type MessageProcessManager from "../messages/MessageProcessManager.js";
+import type { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
 import { invariant } from "../util/invariant.js";
 import type { TextlintSourceCode, TextlintPluginProcessor, TextlintResult } from "@textlint/types";
 

--- a/packages/@textlint/kernel/src/linter/linter-processor.ts
+++ b/packages/@textlint/kernel/src/linter/linter-processor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import LinterTask from "../task/linter-task.js";
 import TaskRunner from "../task/task-runner.js";
 import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";

--- a/packages/@textlint/kernel/src/messages/MessageProcessManager.ts
+++ b/packages/@textlint/kernel/src/messages/MessageProcessManager.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
 import type { TextlintMessage } from "@textlint/types";
 

--- a/packages/@textlint/kernel/src/messages/MessageProcessManager.ts
+++ b/packages/@textlint/kernel/src/messages/MessageProcessManager.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
+import type { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
 import type { TextlintMessage } from "@textlint/types";
 
 export type PreMessageProcessor = (

--- a/packages/@textlint/kernel/src/messages/filter-duplicated-process.ts
+++ b/packages/@textlint/kernel/src/messages/filter-duplicated-process.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 
 /**

--- a/packages/@textlint/kernel/src/messages/filter-ignored-process.ts
+++ b/packages/@textlint/kernel/src/messages/filter-ignored-process.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import MessageType from "../shared/type/MessageType.js";
-import { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
+import type { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
 
 /**
  * the `index` is in the `range` and return true.

--- a/packages/@textlint/kernel/src/messages/filter-ignored-process.ts
+++ b/packages/@textlint/kernel/src/messages/filter-ignored-process.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import MessageType from "../shared/type/MessageType.js";
 import { IgnoreReportedMessage, LintReportedMessage } from "../task/textlint-core-task.js";
 

--- a/packages/@textlint/kernel/src/messages/filter-severity-process.ts
+++ b/packages/@textlint/kernel/src/messages/filter-severity-process.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import type { TextlintMessage } from "@textlint/types";
-import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
+import type { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
 import { TextlintRuleSeverityLevelKeys } from "../context/TextlintRuleSeverityLevelKeys.js";
 
 /**

--- a/packages/@textlint/kernel/src/messages/filter-severity-process.ts
+++ b/packages/@textlint/kernel/src/messages/filter-severity-process.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
 import { TextlintRuleSeverityLevelKeys } from "../context/TextlintRuleSeverityLevelKeys.js";

--- a/packages/@textlint/kernel/src/messages/sort-messages-process.ts
+++ b/packages/@textlint/kernel/src/messages/sort-messages-process.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 
 /**

--- a/packages/@textlint/kernel/src/shared/rule-severity.ts
+++ b/packages/@textlint/kernel/src/shared/rule-severity.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleOptions, TextlintRuleSeverityLevel } from "@textlint/types";
 import { TextlintRuleSeverityLevelKeys } from "../context/TextlintRuleSeverityLevelKeys.js";
 

--- a/packages/@textlint/kernel/src/task/fixer-task.ts
+++ b/packages/@textlint/kernel/src/task/fixer-task.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import CoreTask from "./textlint-core-task.js";
 import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
 import { TextlintFilterRuleDescriptors, TextlintFixableRuleDescriptor } from "../descriptor/index.js";

--- a/packages/@textlint/kernel/src/task/fixer-task.ts
+++ b/packages/@textlint/kernel/src/task/fixer-task.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import CoreTask from "./textlint-core-task.js";
-import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
-import { TextlintFilterRuleDescriptors, TextlintFixableRuleDescriptor } from "../descriptor/index.js";
+import type { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
+import type { TextlintFilterRuleDescriptors, TextlintFixableRuleDescriptor } from "../descriptor/index.js";
 import type { TextlintSourceCode } from "@textlint/types";
 import { getSeverity } from "../shared/rule-severity.js";
 import { TextlintFilterRuleContextImpl } from "../context/TextlintFilterRuleContextImpl.js";

--- a/packages/@textlint/kernel/src/task/linter-task.ts
+++ b/packages/@textlint/kernel/src/task/linter-task.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import CoreTask from "./textlint-core-task.js";
 import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
 import { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";

--- a/packages/@textlint/kernel/src/task/linter-task.ts
+++ b/packages/@textlint/kernel/src/task/linter-task.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import CoreTask from "./textlint-core-task.js";
-import { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
-import { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
+import type { TextlintKernelConstructorOptions } from "../textlint-kernel-interface.js";
+import type { TextlintFilterRuleDescriptors, TextlintRuleDescriptors } from "../descriptor/index.js";
 import type { TextlintSourceCode } from "@textlint/types";
 import { getSeverity } from "../shared/rule-severity.js";
 import { TextlintRuleContextImpl } from "../context/TextlintRuleContextImpl.js";

--- a/packages/@textlint/kernel/src/task/promise-event-emitter.ts
+++ b/packages/@textlint/kernel/src/task/promise-event-emitter.ts
@@ -1,7 +1,6 @@
 // MIT © 2017 azu
 // MIT © 2017 59naga
 // https://github.com/59naga/carrack
-"use strict";
 
 export type Listener = (...args: unknown[]) => void;
 

--- a/packages/@textlint/kernel/src/task/task-runner.ts
+++ b/packages/@textlint/kernel/src/task/task-runner.ts
@@ -1,8 +1,8 @@
 // LICENSE : MIT
 import CoreTask, {
-    default as TextLintCoreTask,
-    IgnoreReportedMessage,
-    LintReportedMessage
+    type default as TextLintCoreTask,
+    type IgnoreReportedMessage,
+    type LintReportedMessage
 } from "./textlint-core-task.js";
 
 export default class TaskRunner {

--- a/packages/@textlint/kernel/src/task/task-runner.ts
+++ b/packages/@textlint/kernel/src/task/task-runner.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import CoreTask, {
     default as TextLintCoreTask,
     IgnoreReportedMessage,

--- a/packages/@textlint/kernel/src/task/textlint-core-task.ts
+++ b/packages/@textlint/kernel/src/task/textlint-core-task.ts
@@ -5,7 +5,7 @@ import { resolveLocation, resolveFixCommandLocation, resolveSuggestionsLocation 
 import timing from "../util/timing.js";
 import { invariant } from "../util/invariant.js";
 import MessageType from "../shared/type/MessageType.js";
-import { AnyTxtNode, TxtParentNode } from "@textlint/ast-node-types";
+import type { AnyTxtNode, TxtParentNode } from "@textlint/ast-node-types";
 import type {
     TextlintFilterRuleContext,
     TextlintFilterRuleOptions,

--- a/packages/@textlint/kernel/src/task/textlint-core-task.ts
+++ b/packages/@textlint/kernel/src/task/textlint-core-task.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintRuleErrorImpl } from "../context/TextlintRuleErrorImpl.js";
 import { EventEmitter, PromiseEventEmitter } from "./promise-event-emitter.js";
 import { resolveLocation, resolveFixCommandLocation, resolveSuggestionsLocation } from "../core/source-location.js";

--- a/packages/@textlint/kernel/src/textlint-kernel.ts
+++ b/packages/@textlint/kernel/src/textlint-kernel.ts
@@ -9,7 +9,7 @@ import filterIgnoredProcess from "./messages/filter-ignored-process.js";
 import filterDuplicatedProcess from "./messages/filter-duplicated-process.js";
 import filterSeverityProcess from "./messages/filter-severity-process.js";
 import sortMessageProcess from "./messages/sort-messages-process.js";
-import { TextlintKernelConstructorOptions, TextlintKernelOptions } from "./textlint-kernel-interface.js";
+import type { TextlintKernelConstructorOptions, TextlintKernelOptions } from "./textlint-kernel-interface.js";
 import type { TextlintFixResult, TextlintResult } from "@textlint/types";
 import { TextlintKernelDescriptor } from "./descriptor/index.js";
 import { TextlintSourceCodeImpl } from "./context/TextlintSourceCodeImpl.js";
@@ -154,7 +154,7 @@ export class TextlintKernel {
 
 Please report this error with the content to plugin author.
 
-${preProcessResult.stack}            
+${preProcessResult.stack}
 `,
                 filePath
             );
@@ -169,7 +169,7 @@ ${preProcessResult.stack}
             invariant(
                 isTxtAST(ast),
                 `${plugin.id} processor return invalid AST object. Please check out @textlint/ast-tester.
-            
+
 You can check the validation result with "DEBUG=textlint*" env
 
 See https://textlint.org/docs/plugin.html`
@@ -238,7 +238,7 @@ See https://textlint.org/docs/plugin.html`
             invariant(
                 isTxtAST(ast),
                 `${plugin.id} processor return invalid AST object. Please check out @textlint/ast-tester.
-            
+
 You can check the validation result with "DEBUG=textlint*" env
 
 See https://textlint.org/docs/plugin.html`

--- a/packages/@textlint/kernel/src/util/createDummyTextLintResult.ts
+++ b/packages/@textlint/kernel/src/util/createDummyTextLintResult.ts
@@ -1,4 +1,4 @@
-import { TextlintResult } from "@textlint/types";
+import type { TextlintResult } from "@textlint/types";
 
 // TODO: Fix can not support
 /**

--- a/packages/@textlint/kernel/src/util/isPluginParsedObject.ts
+++ b/packages/@textlint/kernel/src/util/isPluginParsedObject.ts
@@ -1,4 +1,4 @@
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/packages/@textlint/kernel/src/util/logger.ts
+++ b/packages/@textlint/kernel/src/util/logger.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /* eslint-disable no-console */
 

--- a/packages/@textlint/kernel/src/util/parse-by-plugin.ts
+++ b/packages/@textlint/kernel/src/util/parse-by-plugin.ts
@@ -1,6 +1,6 @@
 import { isPluginParsedObject } from "./isPluginParsedObject.js";
 import type { TextlintPluginProcessor } from "@textlint/types";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 
 type PreProcess = ReturnType<TextlintPluginProcessor["processor"]>["preProcess"];
 /**

--- a/packages/@textlint/kernel/src/util/timing.ts
+++ b/packages/@textlint/kernel/src/util/timing.ts
@@ -3,7 +3,6 @@
  * @author Brandon Mills
  * @copyright 2014 Brandon Mills. All rights reserved.
  */
-"use strict";
 import Logger from "./logger.js";
 
 /* istanbul ignore next */

--- a/packages/@textlint/kernel/src/util/timing.ts
+++ b/packages/@textlint/kernel/src/util/timing.ts
@@ -5,37 +5,15 @@
  */
 import Logger from "./logger.js";
 
-/* istanbul ignore next */
-/**
- * Align the string to left
- * @param {string} str string to evaluate
- * @param {int} len length of the string
- * @param {string} [ch] delimiter character
- * @returns {string} modified string
- * @private
- */
-function alignLeft(str: string, len: number, ch?: string) {
-    return str + new Array(len - str.length + 1).join(ch || " ");
-}
-
-/* istanbul ignore next */
-/**
- * Align the string to right
- * @param {string} str string to evaluate
- * @param {int} len length of the string
- * @param {string} [ch] delimiter character
- * @returns {string} modified string
- * @private
- */
-function alignRight(str: string, len: number, ch?: string) {
-    return new Array(len - str.length + 1).join(ch || " ") + str;
-}
-
 const isBrowser = typeof process === "undefined";
 const enabled = isBrowser ? false : Boolean(process.env.TIMING);
 
 const HEADERS = ["Rule", "Time (ms)", "Relative"];
-const ALIGN = [alignLeft, alignRight, alignRight];
+const ALIGN = [
+    (str: string, len: number, ch = " ") => str.padEnd(len, ch),
+    (str: string, len: number, ch = " ") => str.padStart(len, ch),
+    (str: string, len: number, ch = " ") => str.padStart(len, ch)
+];
 
 /* istanbul ignore next */
 /**

--- a/packages/@textlint/kernel/test/context/TextlintRuleContext.test.ts
+++ b/packages/@textlint/kernel/test/context/TextlintRuleContext.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { assertRuledescribe } from "./assert-rule-context.js";

--- a/packages/@textlint/kernel/test/context/TextlintRuleContext.test.ts
+++ b/packages/@textlint/kernel/test/context/TextlintRuleContext.test.ts
@@ -2,7 +2,7 @@
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { assertRuledescribe } from "./assert-rule-context.js";
-import { TextlintRuleModule } from "@textlint/types";
+import type { TextlintRuleModule } from "@textlint/types";
 import { TextlintKernel } from "../../src/index.js";
 import { createPluginStub } from "../helper/ExamplePlugin.js";
 

--- a/packages/@textlint/kernel/test/context/TextlintSourceCode/TextlintSourceCode.test.ts
+++ b/packages/@textlint/kernel/test/context/TextlintSourceCode/TextlintSourceCode.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { TextlintSourceCodeImpl } from "../../../src/context/TextlintSourceCodeImpl.js";
 import { parse } from "@textlint/markdown-to-ast";
 import select from "unist-util-select";

--- a/packages/@textlint/kernel/test/context/assert-rule-context.ts
+++ b/packages/@textlint/kernel/test/context/assert-rule-context.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 import assert from "node:assert";
 import type { TextlintRuleContext } from "@textlint/types";
 

--- a/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors.test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintPluginDescritors.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { TextlintPluginDescriptors } from "../../src/descriptor/index.js";

--- a/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor.test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor.test.ts
@@ -8,7 +8,7 @@ import type { TextlintRuleModule, TextlintPluginCreator, TextlintPluginOptions }
 import type { TextlintKernelPlugin, TextlintKernelRule } from "../../src/textlint-kernel-interface.js";
 import { createTextlintRuleDescriptors } from "../../src/descriptor/DescriptorsFactory.js";
 import { TextlintLintableRuleDescriptor } from "../../src/descriptor/TextlintLintableRuleDescriptor.js";
-import { TextlintFilterRuleReporter, TextlintKernelFilterRule } from "../../src/index.js";
+import type { TextlintFilterRuleReporter, TextlintKernelFilterRule } from "../../src/index.js";
 
 // @ts-expect-error Package lacks TypeScript definitions
 import preset from "textlint-rule-preset-ja-spacing";

--- a/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor.test.ts
+++ b/packages/@textlint/kernel/test/descriptor/TextlintRulesDescriptor.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { TextlintRuleDescriptors } from "../../src/descriptor/index.js";

--- a/packages/@textlint/kernel/test/descriptor/helper/dummy-plugin.ts
+++ b/packages/@textlint/kernel/test/descriptor/helper/dummy-plugin.ts
@@ -1,4 +1,4 @@
-import { TextlintPluginCreator } from "../../../src/index.js";
+import type { TextlintPluginCreator } from "../../../src/index.js";
 import type { TextlintMessage, TextlintPluginPostProcessResult } from "@textlint/types";
 import type { TxtDocumentNode } from "@textlint/ast-node-types";
 

--- a/packages/@textlint/kernel/test/descriptor/helper/example-rule.ts
+++ b/packages/@textlint/kernel/test/descriptor/helper/example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleModule } from "@textlint/types";
 
 const linter: TextlintRuleModule = function (context) {

--- a/packages/@textlint/kernel/test/descriptor/helper/fixable-example-rule.ts
+++ b/packages/@textlint/kernel/test/descriptor/helper/fixable-example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleModule } from "@textlint/types";
 
 const reporter: TextlintRuleModule = function (context) {

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer-only-is-bad.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer-only-is-bad.ts
@@ -6,7 +6,7 @@ const reporter: TextlintRuleModule = (context) => {
     return {
         [Syntax.Str](node) {
             const text = getSource(node);
-            if (/\.$/.test(text)) {
+            if (text.endsWith(".")) {
                 return;
             }
             report(

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer-only-is-bad.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer-only-is-bad.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleModule } from "@textlint/types";
 
 const reporter: TextlintRuleModule = (context) => {

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer.ts
@@ -6,7 +6,7 @@ const reporter: TextlintRuleModule = (context) => {
     return {
         [Syntax.Str](node) {
             const text = getSource(node);
-            if (/\.$/.test(text)) {
+            if (text.endsWith(".")) {
                 return;
             }
             const add = fixer.insertTextAfter(node, ".");

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/fixer.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleModule } from "@textlint/types";
 
 const reporter: TextlintRuleModule = (context) => {

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/linter.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/fixtures/linter.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleModule } from "@textlint/types";
 
 const linter: TextlintRuleModule = function (context) {

--- a/packages/@textlint/kernel/test/descriptor/rule-creator-helper/rule-creator-helper.test.ts
+++ b/packages/@textlint/kernel/test/descriptor/rule-creator-helper/rule-creator-helper.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import {

--- a/packages/@textlint/kernel/test/helper/ErrorRule.ts
+++ b/packages/@textlint/kernel/test/helper/ErrorRule.ts
@@ -1,6 +1,6 @@
 // MIT © 2017 azu
 
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { TextlintRuleContext, TextlintRuleModule, TextlintRuleReporter } from "@textlint/types";
 import * as assert from "node:assert";
 

--- a/packages/@textlint/kernel/test/helper/FilterRule.ts
+++ b/packages/@textlint/kernel/test/helper/FilterRule.ts
@@ -1,6 +1,6 @@
 // MIT © 2017 azu
 
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { TextlintFilterRuleContext, TextlintFilterRuleReporter } from "@textlint/types";
 
 export interface FilterOptions {

--- a/packages/@textlint/kernel/test/helper/SuggestionRule.ts
+++ b/packages/@textlint/kernel/test/helper/SuggestionRule.ts
@@ -1,4 +1,4 @@
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { TextlintRuleContext, TextlintRuleModule, TextlintRuleReporter } from "@textlint/types";
 
 export const report: TextlintRuleReporter = (context: Readonly<TextlintRuleContext>) => {

--- a/packages/@textlint/kernel/test/kernel-plugin.test.ts
+++ b/packages/@textlint/kernel/test/kernel-plugin.test.ts
@@ -1,14 +1,14 @@
 import { createPluginStub } from "./helper/ExamplePlugin.js";
 import { describe, it } from "vitest";
 import { errorRule } from "./helper/ErrorRule.js";
-import { TextlintKernel, TextlintPluginCreator, TextlintMessage } from "../src/index";
+import { TextlintKernel, type TextlintPluginCreator, type TextlintMessage } from "../src/index";
 import * as path from "node:path";
 import * as assert from "node:assert";
 import { createBinaryPluginStub } from "./helper/BinaryPlugin.js";
 import { createAsyncPluginStub } from "./helper/AsyncPlugin.js";
 import type { TextlintRuleReporter } from "@textlint/types";
-import { TextlintKernelOptions } from "../src/textlint-kernel-interface";
-import { TxtDocumentNode } from "@textlint/ast-node-types";
+import type { TextlintKernelOptions } from "../src/textlint-kernel-interface";
+import type { TxtDocumentNode } from "@textlint/ast-node-types";
 import { coreFlags, resetFlags } from "@textlint/feature-flag";
 
 describe("kernel-plugin", () => {

--- a/packages/@textlint/kernel/test/messages/filter-duplicated-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/filter-duplicated-process.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import filterMessages from "../../src/messages/filter-duplicated-process.js";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";

--- a/packages/@textlint/kernel/test/messages/filter-duplicated-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/filter-duplicated-process.test.ts
@@ -2,7 +2,7 @@
 import filterMessages from "../../src/messages/filter-duplicated-process.js";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";
-import { TextlintMessage } from "@textlint/types";
+import type { TextlintMessage } from "@textlint/types";
 
 describe("message-filter", function () {
     describe("when pass empty messages", function () {

--- a/packages/@textlint/kernel/test/messages/filter-ignored-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/filter-ignored-process.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import filterMessages from "../../src/messages/filter-ignored-process.js";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";

--- a/packages/@textlint/kernel/test/messages/filter-severity-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/filter-severity-process.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";
 import type { TextlintMessage } from "@textlint/types";

--- a/packages/@textlint/kernel/test/messages/sort-messages-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/sort-messages-process.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import sortMessages from "../../src/messages/sort-messages-process.js";

--- a/packages/@textlint/kernel/test/messages/sort-messages-process.test.ts
+++ b/packages/@textlint/kernel/test/messages/sort-messages-process.test.ts
@@ -2,7 +2,7 @@
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import sortMessages from "../../src/messages/sort-messages-process.js";
-import { TextlintMessage } from "@textlint/types";
+import type { TextlintMessage } from "@textlint/types";
 
 const createTextlintMessage = (
     message: Partial<TextlintMessage> & { line: number; column: number }

--- a/packages/@textlint/kernel/test/rule-fixer/rule-fixer.test.ts
+++ b/packages/@textlint/kernel/test/rule-fixer/rule-fixer.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TxtNode } from "@textlint/ast-node-types";
 import { describe, it } from "vitest";
 import RuleFixer from "../../src/fixer/rule-fixer.js";

--- a/packages/@textlint/kernel/test/rule-fixer/rule-fixer.test.ts
+++ b/packages/@textlint/kernel/test/rule-fixer/rule-fixer.test.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { describe, it } from "vitest";
 import RuleFixer from "../../src/fixer/rule-fixer.js";
 // Original: https://github.com/eslint/eslint/blob/master/tests/src/util/rule-fixer.js

--- a/packages/@textlint/kernel/test/shared/rule-severity.test.ts
+++ b/packages/@textlint/kernel/test/shared/rule-severity.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";
 import { getSeverity } from "../../src/shared/rule-severity.js";

--- a/packages/@textlint/kernel/test/snapshots/legacy-index/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/legacy-index/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = (context) => {
     const { Syntax, report, RuleError, getSource } = context;

--- a/packages/@textlint/kernel/test/snapshots/legacy-index/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/legacy-index/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/legacy-line-and-column/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/legacy-line-and-column/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = (context) => {
     const { Syntax, report, RuleError, getSource } = context;

--- a/packages/@textlint/kernel/test/snapshots/legacy-line-and-column/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/legacy-line-and-column/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/locator-at/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-at/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = (context) => {
     const { Syntax, locator, report, RuleError, getSource } = context;

--- a/packages/@textlint/kernel/test/snapshots/locator-at/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-at/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/locator-loc/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-loc/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = (context) => {
     const { Syntax, locator, report, RuleError, getSource } = context;

--- a/packages/@textlint/kernel/test/snapshots/locator-loc/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-loc/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/locator-range/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-range/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = (context) => {
     const { Syntax, locator, report, RuleError, getSource } = context;

--- a/packages/@textlint/kernel/test/snapshots/locator-range/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/locator-range/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/only-message/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/only-message/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 // disallow to write CodeBlock
 const report: TextlintRuleReporter = (context) => {

--- a/packages/@textlint/kernel/test/snapshots/only-message/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/only-message/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 
 // disallow to write CodeBlock
 const report: TextlintRuleReporter = (context) => {

--- a/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import * as path from "node:path";
 import { ThrowPlugin } from "./parse-error-plugin.js";

--- a/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/output.json
+++ b/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/output.json
@@ -2,7 +2,7 @@
     "filePath": "<root>/plugin-parse-error-should-be-lint-messages/input.md",
     "messages": [
         {
-            "message": "Failed to parse text by plugin: markdown\n\nPlease report this error with the content to plugin author.\n\n<ThrowPlugin Error's stack>            \n",
+            "message": "Failed to parse text by plugin: markdown\n\nPlease report this error with the content to plugin author.\n\n<ThrowPlugin Error's stack>\n",
             "type": "lint",
             "loc": {
                 "start": {

--- a/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/parse-error-plugin.ts
+++ b/packages/@textlint/kernel/test/snapshots/plugin-parse-error-should-be-lint-messages/parse-error-plugin.ts
@@ -1,4 +1,4 @@
-import { TextlintPluginCreator } from "@textlint/types";
+import type { TextlintPluginCreator } from "@textlint/types";
 
 export const ThrowPlugin: TextlintPluginCreator = {
     Processor: class ThrowPluginProcessor {

--- a/packages/@textlint/kernel/test/snapshots/suggestions-rule/index.ts
+++ b/packages/@textlint/kernel/test/snapshots/suggestions-rule/index.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleModule } from "@textlint/types";
+import type { TextlintRuleModule } from "@textlint/types";
 
 // Rule that reports suggestions for Str nodes
 const report: TextlintRuleModule = (context) => {

--- a/packages/@textlint/kernel/test/snapshots/suggestions-rule/options.ts
+++ b/packages/@textlint/kernel/test/snapshots/suggestions-rule/options.ts
@@ -1,4 +1,4 @@
-import { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../../../src/textlint-kernel-interface.js";
 import rule from "./index.js";
 import { createPluginStub } from "../../helper/ExamplePlugin.js";
 import * as path from "node:path";

--- a/packages/@textlint/kernel/test/source-code-fixer/source-code-fixer.test.ts
+++ b/packages/@textlint/kernel/test/source-code-fixer/source-code-fixer.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from "vitest";
 import { applyFixesToSourceCode, revertSourceCode, applyFixesToText } from "@textlint/source-code-fixer";
 import { parse } from "@textlint/markdown-to-ast";
 import { TextlintSourceCodeImpl } from "../../src/context/TextlintSourceCodeImpl.js";
-import { TextlintMessage, TextlintSourceCode } from "@textlint/types";
+import type { TextlintMessage, TextlintSourceCode } from "@textlint/types";
 
 const TEST_CODE = "var answer = 6 * 7;";
 const TEST_AST = parse(TEST_CODE);

--- a/packages/@textlint/kernel/test/source-location/source-location.test.ts
+++ b/packages/@textlint/kernel/test/source-location/source-location.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import {

--- a/packages/@textlint/kernel/test/source-location/source-location.test.ts
+++ b/packages/@textlint/kernel/test/source-location/source-location.test.ts
@@ -10,9 +10,9 @@ import RuleFixer from "../../src/fixer/rule-fixer.js";
 import createDummySourceCode from "../util/dummy-source-code.js";
 import { coreFlags, resetFlags } from "@textlint/feature-flag";
 import { TextlintRuleErrorImpl } from "../../src/context/TextlintRuleErrorImpl.js";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { createPaddingLocator } from "../../src/context/TextlintRulePaddingLocator.js";
-import { TextlintRuleError } from "@textlint/types";
+import type { TextlintRuleError } from "@textlint/types";
 
 // Workaround for structured-source serialization
 const assertDeepStrictEqualAsJSON = (a: unknown, b: unknown, message?: string) => {

--- a/packages/@textlint/kernel/test/textlint-kernel-snapshots.test.ts
+++ b/packages/@textlint/kernel/test/textlint-kernel-snapshots.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import * as assert from "node:assert";
-import { TextlintKernelOptions } from "../src/textlint-kernel-interface.js";
+import type { TextlintKernelOptions } from "../src/textlint-kernel-interface.js";
 import { TextlintKernel } from "../src/index.js";
 
 // Use a relative path for test files in vitest

--- a/packages/@textlint/kernel/test/textlint-kernel.test.ts
+++ b/packages/@textlint/kernel/test/textlint-kernel.test.ts
@@ -4,8 +4,8 @@ import { describe, it } from "vitest";
 import { TextlintKernel } from "../src/textlint-kernel.js";
 import { errorRule } from "./helper/ErrorRule.js";
 import { suggestionRule } from "./helper/SuggestionRule.js";
-import { createPluginStub, ExampleProcessorOptions } from "./helper/ExamplePlugin.js";
-import { TextlintKernelOptions } from "../src/textlint-kernel-interface.js";
+import { createPluginStub, type ExampleProcessorOptions } from "./helper/ExamplePlugin.js";
+import type { TextlintKernelOptions } from "../src/textlint-kernel-interface.js";
 import { filterRule } from "./helper/FilterRule.js";
 import { TextlintRuleSeverityLevelKeys } from "../src/context/TextlintRuleSeverityLevelKeys.js";
 

--- a/packages/@textlint/kernel/test/textlint-kernel.test.ts
+++ b/packages/@textlint/kernel/test/textlint-kernel.test.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 import { describe, it } from "vitest";
 import { TextlintKernel } from "../src/textlint-kernel.js";

--- a/packages/@textlint/kernel/test/util/createTextlintMessage.ts
+++ b/packages/@textlint/kernel/test/util/createTextlintMessage.ts
@@ -3,7 +3,7 @@ import createDummySourceCode from "./dummy-source-code.js";
 import { resolveLocation } from "../../src/core/source-location.js";
 import { TextlintRuleErrorImpl } from "../../src/context/TextlintRuleErrorImpl.js";
 import { createPaddingLocator } from "../../src/context/TextlintRulePaddingLocator.js";
-import { IgnoreReportedMessage } from "../../src/task/textlint-core-task.js";
+import type { IgnoreReportedMessage } from "../../src/task/textlint-core-task.js";
 
 /**
  * Create TextlintMessage from text and base message

--- a/packages/@textlint/kernel/test/util/dummy-source-code.ts
+++ b/packages/@textlint/kernel/test/util/dummy-source-code.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse } from "@textlint/markdown-to-ast";
 import * as path from "node:path";
 import { TextlintSourceCodeImpl } from "../../src/context/TextlintSourceCodeImpl.js";

--- a/packages/@textlint/kernel/tsconfig.json
+++ b/packages/@textlint/kernel/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/legacy-textlint-core/tsconfig.json
+++ b/packages/@textlint/legacy-textlint-core/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "esnext"
       // "dom"
-    ]
+    ],
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/linter-formatter/src/formatters/checkstyle.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/checkstyle.ts
@@ -3,7 +3,6 @@
  * @author Ian Christian Myers
  */
 
-"use strict";
 import type { TextlintMessage, TextlintResult } from "@textlint/types";
 
 //------------------------------------------------------------------------------

--- a/packages/@textlint/linter-formatter/src/formatters/compact.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/compact.ts
@@ -3,7 +3,6 @@
  * @author Nicholas C. Zakas
  */
 
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 //------------------------------------------------------------------------------

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -4,7 +4,6 @@
  * @copyright 2015 James Thompson 2025. All rights reserved.
  */
 
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 //------------------------------------------------------------------------------

--- a/packages/@textlint/linter-formatter/src/formatters/jslint-xml.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/jslint-xml.ts
@@ -2,7 +2,6 @@
  * @fileoverview JSLint XML reporter
  * @author Ian Christian Myers
  */
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 import lodash from "lodash";

--- a/packages/@textlint/linter-formatter/src/formatters/json.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/json.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 function formatter(results: TextlintResult[]) {

--- a/packages/@textlint/linter-formatter/src/formatters/junit.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/junit.ts
@@ -2,7 +2,6 @@
  * @fileoverview jUnit Reporter
  * @author Jamund Ferguson
  */
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 import lodash from "lodash";

--- a/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
@@ -2,7 +2,6 @@
 
 // Original code is https://github.com/azer/prettify-error
 // Author : azer
-"use strict";
 import type { TextlintMessage, TextlintResult } from "@textlint/types";
 import { FormatterOptions } from "../FormatterOptions.js";
 

--- a/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/pretty-error.ts
@@ -3,7 +3,7 @@
 // Original code is https://github.com/azer/prettify-error
 // Author : azer
 import type { TextlintMessage, TextlintResult } from "@textlint/types";
-import { FormatterOptions } from "../FormatterOptions.js";
+import type { FormatterOptions } from "../FormatterOptions.js";
 
 import chalk from "chalk";
 // @ts-expect-error no types

--- a/packages/@textlint/linter-formatter/src/formatters/stylish.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/stylish.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TextlintResult } from "@textlint/types";
-import { FormatterOptions } from "../FormatterOptions.js";
+import type { FormatterOptions } from "../FormatterOptions.js";
 
 import chalk from "chalk";
 // @ts-expect-error no types

--- a/packages/@textlint/linter-formatter/src/formatters/stylish.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/stylish.ts
@@ -3,7 +3,6 @@
  * @author Sindre Sorhus
  */
 
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 import { FormatterOptions } from "../FormatterOptions.js";
 

--- a/packages/@textlint/linter-formatter/src/formatters/table.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/table.ts
@@ -4,7 +4,6 @@
  * @copyright 2016 Gajus Kuizinas <gajus@gajus.com>. All rights reserved.
  */
 
-"use strict";
 import type { TextlintMessage, TextlintResult } from "@textlint/types";
 import { FormatterOptions } from "../FormatterOptions.js";
 

--- a/packages/@textlint/linter-formatter/src/formatters/table.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/table.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TextlintMessage, TextlintResult } from "@textlint/types";
-import { FormatterOptions } from "../FormatterOptions.js";
+import type { FormatterOptions } from "../FormatterOptions.js";
 
 //------------------------------------------------------------------------------
 // Requirements

--- a/packages/@textlint/linter-formatter/src/formatters/tap.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/tap.ts
@@ -3,7 +3,6 @@
  * @author Jonathan Kingston
  */
 
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 import yaml from "js-yaml";

--- a/packages/@textlint/linter-formatter/src/formatters/unix.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/unix.ts
@@ -4,7 +4,6 @@
  * @copyright 2015 oshi-shinobu. All rights reserved.
  */
 
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 //------------------------------------------------------------------------------

--- a/packages/@textlint/linter-formatter/src/index.ts
+++ b/packages/@textlint/linter-formatter/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintResult } from "@textlint/types";
 
 import { moduleInterop } from "@textlint/module-interop";
@@ -24,7 +23,7 @@ import unixFormatter from "./formatters/unix.js";
 const builtinFormatterList = {
     checkstyle: checkstyleFormatter,
     compact: compactFormatter,
-    "github": githubFormatter,
+    github: githubFormatter,
     "jslint-xml": jslintXMLFormatter,
     json: jsonFormatter,
     junit: junitFormatter,

--- a/packages/@textlint/linter-formatter/test/formatters/table.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/table.test.ts
@@ -3,7 +3,6 @@
  * @author Gajus Kuizinas <gajus@gajus.com>
  * @copyright 2016 Gajus Kuizinas <gajus@gajus.com>. All rights reserved.
  */
-"use strict";
 import formatter from "../../src/formatters/table.js";
 import type { TextlintResult } from "@textlint/types";
 import { createTestMessage, createTestResult } from "../test-helper";

--- a/packages/@textlint/linter-formatter/test/textlint-formatter.test.ts
+++ b/packages/@textlint/linter-formatter/test/textlint-formatter.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { getFormatterList, loadFormatter } from "../src/index.js";
 
 import { describe, it } from "vitest";

--- a/packages/@textlint/linter-formatter/tsconfig.json
+++ b/packages/@textlint/linter-formatter/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "ts-node": {
     "compilerOptions": {

--- a/packages/@textlint/markdown-to-ast/debug-broken-auto-link.mts
+++ b/packages/@textlint/markdown-to-ast/debug-broken-auto-link.mts
@@ -1,3 +1,4 @@
+/* oxlint-disable no-console */
 import fs from "node:fs";
 import path from "node:path";
 import { parse } from "./src/index.js";

--- a/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
+++ b/packages/@textlint/markdown-to-ast/src/mapping/markdown-syntax-map.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { ASTNodeTypes } from "@textlint/ast-node-types";
 
 export const SyntaxMap = {

--- a/packages/@textlint/markdown-to-ast/test/compliance-tests.ts
+++ b/packages/@textlint/markdown-to-ast/test/compliance-tests.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import { describe, it } from "vitest";
 import { test as astTest } from "@textlint/ast-tester";
 import { parse } from "../src/index";
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import type { Node } from "unist";
 // String -> [String]
 describe("Compliance tests", function () {

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TxtNode } from "@textlint/ast-node-types";
+import type { TxtNode } from "@textlint/ast-node-types";
 import { beforeEach, describe, it } from "vitest";
 import { parse, Syntax } from "../src/index";
 import assert from "node:assert";

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TxtNode } from "@textlint/ast-node-types";
 import { beforeEach, describe, it } from "vitest";
 import { parse, Syntax } from "../src/index";

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
@@ -218,10 +218,10 @@ describe("markdown-parser", function () {
             let node: TxtNode, AST: TxtNode;
             AST = parse("- item");
             node = findFirstTypedNode(AST, Syntax.ListItem);
-            assert(/^-/.test(node.raw));
+            assert(node.raw.startsWith("- "));
             AST = parse("* item");
             node = findFirstTypedNode(AST, Syntax.ListItem);
-            assert(/^\*/.test(node.raw));
+            assert(node.raw.startsWith("* "));
         });
         it("should have marker_offser of each items", function () {
             const AST = parse("- item\n" + "   - item2"); // second line should has offset

--- a/packages/@textlint/markdown-to-ast/tools/create-fixtures.js
+++ b/packages/@textlint/markdown-to-ast/tools/create-fixtures.js
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 /*
     Create fixtures from markdown_fixtures
 

--- a/packages/@textlint/markdown-to-ast/tools/update-fixtures.js
+++ b/packages/@textlint/markdown-to-ast/tools/update-fixtures.js
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 /*
     Update fixtures/output.json from fixtures/input.md
 

--- a/packages/@textlint/markdown-to-ast/tsconfig.json
+++ b/packages/@textlint/markdown-to-ast/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/module-interop/test/fixtures/esmodule.js
+++ b/packages/@textlint/module-interop/test/fixtures/esmodule.js
@@ -1,3 +1,2 @@
-"use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = 42;

--- a/packages/@textlint/module-interop/tsconfig.json
+++ b/packages/@textlint/module-interop/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/resolver/test/index.test.ts
+++ b/packages/@textlint/resolver/test/index.test.ts
@@ -4,7 +4,7 @@ import {
     registerResolveHook,
     registerImportHook,
     dynamicImport,
-    ResolverContext,
+    type ResolverContext,
     tryResolve,
     clearHooks,
 } from "../src/index.js";

--- a/packages/@textlint/resolver/tsconfig.json
+++ b/packages/@textlint/resolver/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/source-code-fixer/src/source-code-fixer.ts
+++ b/packages/@textlint/source-code-fixer/src/source-code-fixer.ts
@@ -112,7 +112,7 @@ export function applyFixesToSourceCode(
                     prefix = "";
                     start = 0;
                 }
-                if (start === 0 && insertionText[0] === BOM) {
+                if (start === 0 && insertionText.startsWith(BOM)) {
                     // Set BOM.
                     prefix = BOM;
                     insertionText = insertionText.slice(1);

--- a/packages/@textlint/source-code-fixer/tsconfig.json
+++ b/packages/@textlint/source-code-fixer/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/text-to-ast/src/index.ts
+++ b/packages/@textlint/text-to-ast/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse } from "./plaintext-parser.js";
 import { Syntax } from "./plaintext-syntax.js";
 

--- a/packages/@textlint/text-to-ast/src/plaintext-parser.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-parser.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { Syntax } from "./plaintext-syntax.js";
 import type { TxtBreakNode, TxtDocumentNode, TxtNode, TxtParagraphNode } from "@textlint/ast-node-types";
 import { TxtStrNode } from "@textlint/ast-node-types";

--- a/packages/@textlint/text-to-ast/src/plaintext-parser.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-parser.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import { Syntax } from "./plaintext-syntax.js";
 import type { TxtBreakNode, TxtDocumentNode, TxtNode, TxtParagraphNode } from "@textlint/ast-node-types";
-import { TxtStrNode } from "@textlint/ast-node-types";
+import type { TxtStrNode } from "@textlint/ast-node-types";
 
 function parseLine(lineText: string, lineNumber: number, startIndex: number): TxtStrNode {
     // Inline Node have `value`. It it not part of TxtNode.

--- a/packages/@textlint/text-to-ast/src/plaintext-syntax.ts
+++ b/packages/@textlint/text-to-ast/src/plaintext-syntax.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { ASTNodeTypes } from "@textlint/ast-node-types";
 
 export const Syntax = {

--- a/packages/@textlint/text-to-ast/test/compliance.test.ts
+++ b/packages/@textlint/text-to-ast/test/compliance.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse } from "../src/index.js";
 import { describe, it } from "vitest";
 import { test as testAST, isTxtAST } from "@textlint/ast-tester";

--- a/packages/@textlint/text-to-ast/test/plaintext-parser.test.ts
+++ b/packages/@textlint/text-to-ast/test/plaintext-parser.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse, Syntax } from "../src/index.js";
 import { describe, it } from "vitest";
 import assert from "node:assert";

--- a/packages/@textlint/text-to-ast/tsconfig.json
+++ b/packages/@textlint/text-to-ast/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.ts
+++ b/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse } from "@textlint/markdown-to-ast";
 import type {
     TextlintPluginOptions,

--- a/packages/@textlint/textlint-plugin-markdown/src/index.ts
+++ b/packages/@textlint/textlint-plugin-markdown/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { MarkdownProcessor } from "./MarkdownProcessor.js";
 
 export default {

--- a/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
+++ b/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { TextlintKernel, TextlintPluginOptions } from "@textlint/kernel";

--- a/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
+++ b/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import assert from "node:assert";
 import { describe, it } from "vitest";
-import { TextlintKernel, TextlintPluginOptions } from "@textlint/kernel";
+import { TextlintKernel, type TextlintPluginOptions } from "@textlint/kernel";
 import fs from "node:fs";
 import path from "node:path";
 import MarkdownPlugin from "../src/index.js";

--- a/packages/@textlint/textlint-plugin-markdown/tsconfig.json
+++ b/packages/@textlint/textlint-plugin-markdown/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/textlint-plugin-text/src/TextProcessor.ts
+++ b/packages/@textlint/textlint-plugin-text/src/TextProcessor.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { parse } from "@textlint/text-to-ast";
 import type {
     TextlintPluginProcessor,

--- a/packages/@textlint/textlint-plugin-text/src/index.ts
+++ b/packages/@textlint/textlint-plugin-text/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextProcessor } from "./TextProcessor.js";
 export default {
     Processor: TextProcessor

--- a/packages/@textlint/textlint-plugin-text/test/TextProcessor.test.ts
+++ b/packages/@textlint/textlint-plugin-text/test/TextProcessor.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import { describe, it } from "vitest";
 import fs from "node:fs";
 import TextPlugin from "../src/index.js";
-import { TextlintKernel, TextlintPluginOptions } from "@textlint/kernel";
+import { TextlintKernel, type TextlintPluginOptions } from "@textlint/kernel";
 import path from "node:path";
 
 const lintFile = (filePath: string, options: boolean | TextlintPluginOptions | undefined = true) => {

--- a/packages/@textlint/textlint-plugin-text/test/TextProcessor.test.ts
+++ b/packages/@textlint/textlint-plugin-text/test/TextProcessor.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import fs from "node:fs";

--- a/packages/@textlint/textlint-plugin-text/tsconfig.json
+++ b/packages/@textlint/textlint-plugin-text/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/types/src/Message/TextlintResult.ts
+++ b/packages/@textlint/types/src/Message/TextlintResult.ts
@@ -1,5 +1,5 @@
 // "range" will be replaced by "text"
-import { TextlintRuleSeverityLevel } from "../Rule/TextlintRuleSeverityLevel.js";
+import type { TextlintRuleSeverityLevel } from "../Rule/TextlintRuleSeverityLevel.js";
 
 export interface TextlintMessageFixCommand {
     text: string;

--- a/packages/@textlint/types/src/Rule/TextlintBaseRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintBaseRuleContext.ts
@@ -1,7 +1,7 @@
-import { TextlintRuleErrorConstructor } from "./TextlintRuleError.js";
-import { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
-import { TextlintRuleSeverityLevel } from "./TextlintRuleSeverityLevel.js";
-import { TextlintRulePaddingLocator } from "./TextlintRulePaddingLocator.js";
+import type { TextlintRuleErrorConstructor } from "./TextlintRuleError.js";
+import type { ASTNodeTypes, TxtNode } from "@textlint/ast-node-types";
+import type { TextlintRuleSeverityLevel } from "./TextlintRuleSeverityLevel.js";
+import type { TextlintRulePaddingLocator } from "./TextlintRulePaddingLocator.js";
 
 /**
  * This Base class is internal.

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleContext.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
+import type { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
 
 /**
  * Message of ignoring

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleContext.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
 
 /**

--- a/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintFilterRuleModule.ts
@@ -1,8 +1,8 @@
 /**
  * Filter rule reporter function
  */
-import { TextlintFilterRuleContext } from "./TextlintFilterRuleContext.js";
-import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
+import type { TextlintFilterRuleContext } from "./TextlintFilterRuleContext.js";
+import type { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
 /**
  * textlint filter rule option values is object or boolean.
  * if this option value is false, disable the filter rule.

--- a/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
@@ -1,9 +1,9 @@
 // LICENSE : MIT
 
-import { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
-import { TxtNode } from "@textlint/ast-node-types";
-import { TextlintRuleError, TextlintRuleReportedObject } from "./TextlintRuleError.js";
-import { TextlintRuleContextFixCommandGenerator } from "./TextlintRuleContextFixCommandGenerator.js";
+import type { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
+import type { TxtNode } from "@textlint/ast-node-types";
+import type { TextlintRuleError, TextlintRuleReportedObject } from "./TextlintRuleError.js";
+import type { TextlintRuleContextFixCommandGenerator } from "./TextlintRuleContextFixCommandGenerator.js";
 
 /**
  * context.report function

--- a/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleContext.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintBaseRuleContext } from "./TextlintBaseRuleContext.js";
 import { TxtNode } from "@textlint/ast-node-types";

--- a/packages/@textlint/types/src/Rule/TextlintRuleContextFixCommandGenerator.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleContextFixCommandGenerator.ts
@@ -1,6 +1,6 @@
-import { TxtNode } from "@textlint/ast-node-types";
-import { TextlintSourceCodeRange } from "../Source/TextlintSourceCode.js";
-import { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
+import type { TxtNode } from "@textlint/ast-node-types";
+import type { TextlintSourceCodeRange } from "../Source/TextlintSourceCode.js";
+import type { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
 
 /**
  * Creates code fixing commands for rules.

--- a/packages/@textlint/types/src/Rule/TextlintRuleError.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleError.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
-import { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
-import { TextlintRuleSuggestion } from "./TextlintRuleSuggestion.js";
+import type { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
+import type { TextlintRuleSuggestion } from "./TextlintRuleSuggestion.js";
 
 export type TextlintRuleErrorPaddingLocationLoc = {
     start: {

--- a/packages/@textlint/types/src/Rule/TextlintRuleError.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleError.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
 import { TextlintRuleSuggestion } from "./TextlintRuleSuggestion.js";
 

--- a/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleModule.ts
@@ -1,9 +1,9 @@
 /**
  * Rule reporter function
  */
-import { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
-import { TextlintRuleOptions } from "./TextlintRuleOptions.js";
-import { TextlintRuleContext } from "./TextlintRuleContext.js";
+import type { ASTNodeTypes, TypeofTxtNode } from "@textlint/ast-node-types";
+import type { TextlintRuleOptions } from "./TextlintRuleOptions.js";
+import type { TextlintRuleContext } from "./TextlintRuleContext.js";
 
 /**
  * Rule Reporter Handler object define handler for each TxtNode type.

--- a/packages/@textlint/types/src/Rule/TextlintRuleOptions.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleOptions.ts
@@ -2,7 +2,7 @@
  * textlint rule option values is object or boolean.
  * if this option value is false, disable the rule.
  */
-import { TextlintRuleSeverityLevelKey } from "./TextlintRuleSeverityLevelKey.js";
+import type { TextlintRuleSeverityLevelKey } from "./TextlintRuleSeverityLevelKey.js";
 
 export type TextlintRuleOptions<T extends object = object> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/@textlint/types/src/Rule/TextlintRulePaddingLocator.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRulePaddingLocator.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleErrorPaddingLocation } from "./TextlintRuleError.js";
+import type { TextlintRuleErrorPaddingLocation } from "./TextlintRuleError.js";
 
 export type TextlintRulePaddingLocator = {
     /**

--- a/packages/@textlint/types/src/Rule/TextlintRuleSuggestion.ts
+++ b/packages/@textlint/types/src/Rule/TextlintRuleSuggestion.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
+import type { TextlintRuleContextFixCommand } from "./TextlintRuleContextFixCommand.js";
 
 export interface TextlintRuleSuggestion {
     id: string;

--- a/packages/@textlint/types/src/Source/TextlintSourceCode.ts
+++ b/packages/@textlint/types/src/Source/TextlintSourceCode.ts
@@ -1,4 +1,4 @@
-import { AnyTxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
+import type { AnyTxtNode, ASTNodeTypes } from "@textlint/ast-node-types";
 
 export interface TextlintSourceCodePosition {
     line: number;

--- a/packages/@textlint/types/test/Rule/TextlintRuleModule.test.ts
+++ b/packages/@textlint/types/test/Rule/TextlintRuleModule.test.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleModule, TextlintRuleOptions, TextlintRuleReporter } from "../../src/index.js";
+import type { TextlintRuleModule, TextlintRuleOptions, TextlintRuleReporter } from "../../src/index.js";
 
 const noop = (..._args: unknown[]) => {};
 // test any

--- a/packages/@textlint/types/test/Rule/TxtNode.test.ts
+++ b/packages/@textlint/types/test/Rule/TxtNode.test.ts
@@ -1,5 +1,5 @@
 // Node type test
-import {
+import type {
     TxtBlockQuoteNode,
     TxtBreakNode,
     TxtCodeBlockNode,
@@ -22,8 +22,8 @@ import {
     TxtStrNode,
     TxtStrongNode,
 } from "@textlint/ast-node-types";
-import { TxtTableCellNode, TxtTableNode, TxtTableRowNode } from "@textlint/ast-node-types/lib/src/NodeType";
-import { TextlintRuleReporter } from "../../src/index.js";
+import type { TxtTableCellNode, TxtTableNode, TxtTableRowNode } from "@textlint/ast-node-types/lib/src/NodeType";
+import type { TextlintRuleReporter } from "../../src/index.js";
 
 const noop = (..._args: unknown[]) => {};
 export const expectType = <Type>(_: Type): void => void 0;

--- a/packages/@textlint/types/tsconfig.json
+++ b/packages/@textlint/types/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "esnext"
       // "dom"
-    ]
+    ],
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/@textlint/utils/src/KeyPath/KeyPathUtil.ts
+++ b/packages/@textlint/utils/src/KeyPath/KeyPathUtil.ts
@@ -37,7 +37,7 @@ export const removePrefixFromPackageName = (prefixList: string[], packageName: s
     for (const prefix of prefixList) {
         // @scope/name -> @scope/name
         // @scope/textlint-rule-name -> @scope/name
-        if (packageName.charAt(0) === "@") {
+        if (packageName.startsWith("@")) {
             const [namespace, name] = packageName.split("/");
             if (name.startsWith(prefix)) {
                 return `${namespace}/${name.slice(prefix.length)}`;

--- a/packages/@textlint/utils/tsconfig.json
+++ b/packages/@textlint/utils/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/packages/textlint-scripts/configs/babel-register.js
+++ b/packages/textlint-scripts/configs/babel-register.js
@@ -4,7 +4,7 @@
  * Note: This register does not type-check
  * Please use --require textlint-scripts/register-ts instead of it
  */
-const fs = require("fs");
+const fs = require("node:fs");
 const paths = require("../configs/paths");
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 const babelConfig = require("./babel.config");

--- a/packages/textlint-scripts/configs/babel.config.js
+++ b/packages/textlint-scripts/configs/babel.config.js
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const fs = require("node:fs");
 const paths = require("../configs/paths");
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 const NO_INLINE = !!process.env.NO_INLINE;

--- a/packages/textlint-scripts/configs/paths.js
+++ b/packages/textlint-scripts/configs/paths.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);

--- a/packages/textlint-scripts/configs/ts-node-register.js
+++ b/packages/textlint-scripts/configs/ts-node-register.js
@@ -5,7 +5,7 @@
  * Note: It does not babel-plugin-static-fs
  * Some behavior is a bit of difference
  */
-const fs = require("fs");
+const fs = require("node:fs");
 const paths = require("../configs/paths");
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 if (!useTypeScript) {

--- a/packages/textlint-scripts/examples/example-ts/src/index.ts
+++ b/packages/textlint-scripts/examples/example-ts/src/index.ts
@@ -1,5 +1,5 @@
 import common from "./common";
-import { TextlintRuleModule, TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleModule, TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = function (context, _options = {}) {
     const { Syntax, RuleError, report, getSource } = context;

--- a/packages/textlint-scripts/examples/example-ts/src/index.ts
+++ b/packages/textlint-scripts/examples/example-ts/src/index.ts
@@ -1,4 +1,3 @@
-"use strict";
 import common from "./common";
 import { TextlintRuleModule, TextlintRuleReporter } from "@textlint/types";
 

--- a/packages/textlint-scripts/examples/example-ts/tsconfig.json
+++ b/packages/textlint-scripts/examples/example-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "composite": true,
     "outDir": "./dist",
-    "declarationDir": "./dist"
+    "declarationDir": "./dist",
+    "types": ["node"]
   },
   "references": [
     {

--- a/packages/textlint-scripts/examples/example/test/index-test.js
+++ b/packages/textlint-scripts/examples/example/test/index-test.js
@@ -1,4 +1,3 @@
-"use strict";
 // See https://github.com/textlint/textlint/tree/master/packages/textlint-tester
 import TextLintTester from "textlint-tester";
 // rule

--- a/packages/textlint-scripts/scripts/build.js
+++ b/packages/textlint-scripts/scripts/build.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = "production";
-const fs = require("fs");
+const fs = require("node:fs");
 const spawn = require("cross-spawn");
 const paths = require("../configs/paths");
 const args = process.argv.slice(2);

--- a/packages/textlint-scripts/scripts/build.js
+++ b/packages/textlint-scripts/scripts/build.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 // Do this as the first thing so that any code reading it knows the right env.
 process.env.NODE_ENV = "production";
 const fs = require("fs");

--- a/packages/textlint-scripts/scripts/init.js
+++ b/packages/textlint-scripts/scripts/init.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 const fs = require("node:fs");
 const path = require("node:path");
 const confirmer = require("confirmer");

--- a/packages/textlint-scripts/scripts/test.js
+++ b/packages/textlint-scripts/scripts/test.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 process.env.NODE_ENV = "test";
 const spawn = require("cross-spawn");
 const fs = require("fs");

--- a/packages/textlint-scripts/scripts/test.js
+++ b/packages/textlint-scripts/scripts/test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 process.env.NODE_ENV = "test";
 const spawn = require("cross-spawn");
-const fs = require("fs");
+const fs = require("node:fs");
 const args = process.argv.slice(2);
 const paths = require("../configs/paths");
 const useTypeScript = fs.existsSync(paths.appTsConfig);

--- a/packages/textlint-tester/src/test-util.ts
+++ b/packages/textlint-tester/src/test-util.ts
@@ -1,5 +1,5 @@
-import * as assert from "assert";
-import * as fs from "fs/promises";
+import * as assert from "node:assert";
+import * as fs from "node:fs/promises";
 import { TextlintResult } from "@textlint/kernel";
 import { TesterErrorDefinition } from "./textlint-tester";
 

--- a/packages/textlint-tester/src/test-util.ts
+++ b/packages/textlint-tester/src/test-util.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert";
 import * as fs from "node:fs/promises";
-import { TextlintResult } from "@textlint/kernel";
-import { TesterErrorDefinition } from "./textlint-tester";
+import type { TextlintResult } from "@textlint/kernel";
+import type { TesterErrorDefinition } from "./textlint-tester";
 
 export type TestTextlintLinter = {
     lintText(text: string, ext: string): Promise<TextlintResult>;

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -2,19 +2,19 @@
 import * as assert from "node:assert";
 import { testInvalid, testValid } from "./test-util";
 import {
-    TextlintFixResult,
+    type TextlintFixResult,
     TextlintKernel,
     TextlintKernelDescriptor,
-    TextlintKernelPlugin,
-    TextlintPluginCreator,
-    TextlintRuleModule
+    type TextlintKernelPlugin,
+    type TextlintPluginCreator,
+    type TextlintRuleModule
 } from "@textlint/kernel";
 import { coreFlags } from "@textlint/feature-flag";
 import textPlugin from "@textlint/textlint-plugin-text";
 import markdownPlugin from "@textlint/textlint-plugin-markdown";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { TextlintPluginOptions, TextlintRuleOptions } from "@textlint/types";
+import type { TextlintPluginOptions, TextlintRuleOptions } from "@textlint/types";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 const globalObject = globalThis;

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import * as assert from "assert";
+import * as assert from "node:assert";
 import { testInvalid, testValid } from "./test-util";
 import {
     TextlintFixResult,
@@ -12,8 +12,8 @@ import {
 import { coreFlags } from "@textlint/feature-flag";
 import textPlugin from "@textlint/textlint-plugin-text";
 import markdownPlugin from "@textlint/textlint-plugin-markdown";
-import fs from "fs/promises";
-import path from "path";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { TextlintPluginOptions, TextlintRuleOptions } from "@textlint/types";
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "assert";
 import { testInvalid, testValid } from "./test-util";
 import {

--- a/packages/textlint-tester/src/textlint-tester.ts
+++ b/packages/textlint-tester/src/textlint-tester.ts
@@ -6,6 +6,7 @@ import {
     TextlintKernel,
     TextlintKernelDescriptor,
     type TextlintKernelPlugin,
+    type TextlintKernelRule,
     type TextlintPluginCreator,
     type TextlintRuleModule
 } from "@textlint/kernel";
@@ -76,16 +77,8 @@ function assertTestConfig(testConfig: TestConfig): void {
     }
 }
 
-export type TestConfigPlugin = {
-    pluginId: string;
-    plugin: TextlintPluginCreator;
-    options?: TextlintPluginOptions | boolean;
-};
-export type TestConfigRule = {
-    ruleId: string;
-    rule: TextlintRuleModule;
-    options?: TextlintRuleOptions | boolean;
-};
+export type TestConfigPlugin = TextlintKernelPlugin;
+export type TestConfigRule = TextlintKernelRule;
 export type TestConfig = {
     plugins?: TestConfigPlugin[];
     rules: TestConfigRule[];

--- a/packages/textlint-tester/test/async.test.ts
+++ b/packages/textlint-tester/test/async.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import TextLintTester from "../src/index";
 import type { TextlintRuleReporter } from "@textlint/types";
 

--- a/packages/textlint-tester/test/fixtures/broken-rules/NaN-rule.js
+++ b/packages/textlint-tester/test/fixtures/broken-rules/NaN-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 function reporter(context) {
     const { Syntax, RuleError, fixer, report, getSource } = context;
     return {

--- a/packages/textlint-tester/test/fixtures/broken-rules/invlid-column-rule.js
+++ b/packages/textlint-tester/test/fixtures/broken-rules/invlid-column-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 function reporter(context) {
     const { Syntax, RuleError, fixer, report, getSource } = context;
     return {

--- a/packages/textlint-tester/test/fixtures/broken-rules/invlid-index-rule.js
+++ b/packages/textlint-tester/test/fixtures/broken-rules/invlid-index-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 function reporter(context) {
     const { Syntax, RuleError, fixer, report, getSource } = context;
     return {

--- a/packages/textlint-tester/test/fixtures/broken-rules/invlid-line-rule.js
+++ b/packages/textlint-tester/test/fixtures/broken-rules/invlid-line-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 function reporter(context) {
     const { Syntax, RuleError, fixer, report, getSource } = context;
     return {

--- a/packages/textlint-tester/test/fixtures/broken-rules/invlid-minus-index-rule.js
+++ b/packages/textlint-tester/test/fixtures/broken-rules/invlid-minus-index-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 function reporter(context) {
     const { Syntax, RuleError, fixer, report, getSource } = context;
     return {

--- a/packages/textlint-tester/test/fixtures/rule/fixer-rule-add.ts
+++ b/packages/textlint-tester/test/fixtures/rule/fixer-rule-add.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleReporter } from "@textlint/types";
+import type { TextlintRuleReporter } from "@textlint/types";
 import { RuleHelper } from "textlint-rule-helper";
 
 const reporter: TextlintRuleReporter = (context) => {

--- a/packages/textlint-tester/test/fixtures/rule/fixer-rule-add.ts
+++ b/packages/textlint-tester/test/fixtures/rule/fixer-rule-add.ts
@@ -10,7 +10,7 @@ const reporter: TextlintRuleReporter = (context) => {
                 return;
             }
             const text = getSource(node);
-            if (/\.$/.test(text)) {
+            if (text.endsWith(".")) {
                 return;
             }
             const index = text.length;

--- a/packages/textlint-tester/test/fixtures/rule/no-todo.ts
+++ b/packages/textlint-tester/test/fixtures/rule/no-todo.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 import { RuleHelper } from "textlint-rule-helper";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {

--- a/packages/textlint-tester/test/fixtures/rule/with-suggestions.ts
+++ b/packages/textlint-tester/test/fixtures/rule/with-suggestions.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     const { Syntax, RuleError, report, fixer } = context;

--- a/packages/textlint-tester/test/suggestions.test.ts
+++ b/packages/textlint-tester/test/suggestions.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import TextLintTester from "../src/index";
 import type { TextlintRuleReporter } from "@textlint/types";
 

--- a/packages/textlint-tester/test/textlint-tester-error-format.ts
+++ b/packages/textlint-tester/test/textlint-tester-error-format.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "assert";
 import { createTestLinter, createTextlintKernelDescriptor } from "../src/textlint-tester";
 import { testValid, testInvalid } from "../src/test-util";

--- a/packages/textlint-tester/test/textlint-tester-error-format.ts
+++ b/packages/textlint-tester/test/textlint-tester-error-format.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import * as assert from "assert";
+import * as assert from "node:assert";
 import { createTestLinter, createTextlintKernelDescriptor } from "../src/textlint-tester";
 import { testValid, testInvalid } from "../src/test-util";
 import rule from "./fixtures/rule/no-todo";

--- a/packages/textlint-tester/test/textlint-tester-fixer.test.ts
+++ b/packages/textlint-tester/test/textlint-tester-fixer.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import TextLintTester from "../src/index";
 import path from "path";
 import fixerRule from "./fixtures/rule/fixer-rule-add";

--- a/packages/textlint-tester/test/textlint-tester-fixer.test.ts
+++ b/packages/textlint-tester/test/textlint-tester-fixer.test.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import TextLintTester from "../src/index";
-import path from "path";
+import path from "node:path";
 import fixerRule from "./fixtures/rule/fixer-rule-add";
 
 const tester = new TextLintTester();

--- a/packages/textlint-tester/test/textlint-tester-invalid-testcofig.test.ts
+++ b/packages/textlint-tester/test/textlint-tester-invalid-testcofig.test.ts
@@ -1,4 +1,4 @@
-import * as assert from "assert";
+import * as assert from "node:assert";
 // @ts-expect-error: no types
 import htmlPlugin from "textlint-plugin-html";
 import noTodoRule from "./fixtures/rule/no-todo";

--- a/packages/textlint-tester/test/textlint-tester.test.ts
+++ b/packages/textlint-tester/test/textlint-tester.test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "node:path";
 import TextLintTester from "../src/index";
 import noTodo from "./fixtures/rule/no-todo";
 // @ts-expect-error: no types

--- a/packages/textlint-tester/tsconfig.json
+++ b/packages/textlint-tester/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node", "mocha"]
   },
   "include": [
     "src/**/*"

--- a/packages/textlint/bin/textlint.js
+++ b/packages/textlint/bin/textlint.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-"use strict";
 const streamConsumers = require("node:stream/consumers");
 const useStdIn = process.argv.indexOf("--stdin") > -1;
 const isDebug = process.argv.indexOf("--debug") > -1;

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 import debug0 from "debug";
-import { CliOptions, options } from "./options.js";
+import { type CliOptions, options } from "./options.js";
 import { createConfigFile } from "./config/config-initializer.js";
 import { TextLintFixer } from "./fixer/textlint-fixer.js";
 import { Logger } from "./util/logger.js";

--- a/packages/textlint/src/config/config-initializer.ts
+++ b/packages/textlint/src/config/config-initializer.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintPackageNamePrefix } from "@textlint/utils";
 
 import fs from "node:fs";

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -1,11 +1,11 @@
 // LICENSE : MIT
-import { TextlintKernel, TextlintKernelDescriptor, TextlintResult } from "@textlint/kernel";
+import { TextlintKernel, type TextlintKernelDescriptor, type TextlintResult } from "@textlint/kernel";
 import {
     searchFiles,
     scanFilePath,
-    ScanFilePathResult,
+    type ScanFilePathResult,
     pathsToGlobPatterns,
-    SearchFilesResultError
+    type SearchFilesResultError
 } from "./util/find-util.js";
 import { ExecuteFileBackerManager } from "./engine/execute-file-backer-manager.js";
 import { CacheBacker } from "./engine/execute-file-backers/cache-backer.js";
@@ -13,7 +13,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { Logger } from "./util/logger.js";
-import { TextlintFixResult } from "@textlint/types";
+import type { TextlintFixResult } from "@textlint/types";
 import debug0 from "debug";
 import { separateByAvailability } from "./util/separate-by-availability.js";
 

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintKernel, TextlintKernelDescriptor, TextlintResult } from "@textlint/kernel";
 import {
     searchFiles,
@@ -28,8 +27,8 @@ export class TextlintFileSearchError extends Error {
 
     constructor({ errors, patterns }: { errors: SearchFilesResultError[]; patterns: string[] }) {
         super(`Not found target files.
-        
-Patterns: ${patterns.join(", ")}        
+
+Patterns: ${patterns.join(", ")}
 Reason: ${errors.map((e) => e.type).join(", ") || "Unknown error"}`);
         this.errors = errors;
         this.patterns = patterns;

--- a/packages/textlint/src/engine/execute-file-backer-manager.ts
+++ b/packages/textlint/src/engine/execute-file-backer-manager.ts
@@ -1,5 +1,5 @@
-import { AbstractBacker } from "./execute-file-backers/abstruct-backer.js";
-import { TextlintResult } from "@textlint/kernel";
+import type { AbstractBacker } from "./execute-file-backers/abstruct-backer.js";
+import type { TextlintResult } from "@textlint/kernel";
 
 export class ExecuteFileBackerManager {
     private _backers: AbstractBacker[];

--- a/packages/textlint/src/engine/execute-file-backers/abstruct-backer.ts
+++ b/packages/textlint/src/engine/execute-file-backers/abstruct-backer.ts
@@ -1,5 +1,4 @@
 // MIT © 2016 azu
-"use strict";
 
 import type { TextlintResult } from "@textlint/kernel";
 

--- a/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
+++ b/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
@@ -1,5 +1,4 @@
 // MIT © 2016 azu
-"use strict";
 import fileEntryCache, { FileEntryCache } from "file-entry-cache";
 import debug0 from "debug";
 import path from "node:path";

--- a/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
+++ b/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
@@ -1,10 +1,10 @@
 // MIT © 2016 azu
-import fileEntryCache, { FileEntryCache } from "file-entry-cache";
+import fileEntryCache, { type FileEntryCache } from "file-entry-cache";
 import debug0 from "debug";
 import path from "node:path";
 import fs from "node:fs";
-import { AbstractBacker } from "./abstruct-backer.js";
-import { TextlintResult } from "@textlint/kernel";
+import type { AbstractBacker } from "./abstruct-backer.js";
+import type { TextlintResult } from "@textlint/kernel";
 
 const debug = debug0("textlint:CacheBacker");
 

--- a/packages/textlint/src/engine/processor-map.ts
+++ b/packages/textlint/src/engine/processor-map.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /**
  * Processor Map object

--- a/packages/textlint/src/engine/rule-loader.ts
+++ b/packages/textlint/src/engine/rule-loader.ts
@@ -1,7 +1,7 @@
 import { moduleInterop } from "@textlint/module-interop";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { TextlintKernelRule } from "@textlint/kernel";
+import type { TextlintKernelRule } from "@textlint/kernel";
 import { dynamicImport } from "@textlint/resolver";
 import { isTextlintRuleModule } from "@textlint/config-loader";
 

--- a/packages/textlint/src/engine/rule-loader.ts
+++ b/packages/textlint/src/engine/rule-loader.ts
@@ -1,4 +1,3 @@
-"use strict";
 import { moduleInterop } from "@textlint/module-interop";
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/packages/textlint/src/engine/rule-map.ts
+++ b/packages/textlint/src/engine/rule-map.ts
@@ -1,6 +1,4 @@
 // LICENSE : MIT
-"use strict";
-
 import type { TextlintRuleModule } from "@textlint/types";
 
 /**

--- a/packages/textlint/src/fixer/textlint-fixer.ts
+++ b/packages/textlint/src/fixer/textlint-fixer.ts
@@ -1,4 +1,4 @@
-import { TextlintFixResult } from "@textlint/kernel";
+import type { TextlintFixResult } from "@textlint/kernel";
 import fs from "node:fs/promises";
 
 function overWriteResult(result: TextlintFixResult): Promise<void> {

--- a/packages/textlint/src/index.ts
+++ b/packages/textlint/src/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /**
  * Command line interface

--- a/packages/textlint/src/loader/CliLoader.ts
+++ b/packages/textlint/src/loader/CliLoader.ts
@@ -1,6 +1,6 @@
 import { loadPackagesFromRawConfig } from "@textlint/config-loader";
-import { CliOptions } from "../options.js";
-import { TextlintKernelDescriptor, TextlintKernelRule } from "@textlint/kernel";
+import type { CliOptions } from "../options.js";
+import { TextlintKernelDescriptor, type TextlintKernelRule } from "@textlint/kernel";
 import { normalizeTextlintPluginKey, normalizeTextlintRuleKey } from "@textlint/utils";
 import debug_ from "debug";
 import { loadFromDirAsESM } from "../engine/rule-loader.js";

--- a/packages/textlint/src/loader/TextlintrcLoader.ts
+++ b/packages/textlint/src/loader/TextlintrcLoader.ts
@@ -1,5 +1,5 @@
 import { loadConfig } from "@textlint/config-loader";
-import { TextlintKernelDescriptor, TextlintKernelPlugin } from "@textlint/kernel";
+import { TextlintKernelDescriptor, type TextlintKernelPlugin } from "@textlint/kernel";
 import path from "node:path";
 import textPlugin from "@textlint/textlint-plugin-text";
 import markdownPlugin from "@textlint/textlint-plugin-markdown";

--- a/packages/textlint/src/mcp/server.ts
+++ b/packages/textlint/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { createLinter, loadTextlintrc, type CreateLinterOptions } from "../index.js";
 import { existsSync } from "node:fs";
 import { TextlintMessageSchema } from "./schemas.js";
-import { TextlintKernelDescriptor } from "@textlint/kernel";
+import type { TextlintKernelDescriptor } from "@textlint/kernel";
 import debug from "debug";
 
 const mcpDebug = debug("textlint:mcp");

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { getFormatterList, FormatterDetail } from "@textlint/linter-formatter";
 import { getFixerFormatterList, FixerFormatterDetail } from "@textlint/fixer-formatter";
 import path from "node:path";

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
-import { getFormatterList, FormatterDetail } from "@textlint/linter-formatter";
-import { getFixerFormatterList, FixerFormatterDetail } from "@textlint/fixer-formatter";
+import { getFormatterList, type FormatterDetail } from "@textlint/linter-formatter";
+import { getFixerFormatterList, type FixerFormatterDetail } from "@textlint/fixer-formatter";
 import path from "node:path";
 // @ts-expect-error: no type definition
 import optionator from "optionator";

--- a/packages/textlint/src/shared/type/SeverityLevel.ts
+++ b/packages/textlint/src/shared/type/SeverityLevel.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 /**
  * Severity level
  * It is used in configuration and message

--- a/packages/textlint/src/util/logger.ts
+++ b/packages/textlint/src/util/logger.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /* eslint-disable no-console */
 
@@ -34,7 +33,7 @@ You can control this deprecation message by Node.js command-line flags.
 If the NODE_OPTIONS=--throw-deprecation is used, the deprecation warning is thrown as an exception rather than being emitted as an event.
 If the NODE_OPTIONS=--no-deprecation is used, the deprecation warning is suppressed.
 If the NODE_OPTIONS=--trace-deprecation is used, the deprecation warning is printed to stderr along with the full stack trace.
-        
+
 `;
         process.emitWarning(templateDeprecatedionMessage, {
             type: "DeprecationWarning"

--- a/packages/textlint/src/util/object-to-kernel-format.ts
+++ b/packages/textlint/src/util/object-to-kernel-format.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     TextlintFilterRuleReporter,
     TextlintKernelFilterRule,
     TextlintKernelPlugin,

--- a/packages/textlint/test/cli-snapshot-test/cli-snapshots.test.ts
+++ b/packages/textlint/test/cli-snapshot-test/cli-snapshots.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as fs from "node:fs";
 import { describe, it } from "vitest";
 import * as path from "node:path";

--- a/packages/textlint/test/cli/cli-exit-status-faq.test.ts
+++ b/packages/textlint/test/cli/cli-exit-status-faq.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { cli } from "../../src/cli.js";

--- a/packages/textlint/test/cli/cli-preset-severity.test.ts
+++ b/packages/textlint/test/cli/cli-preset-severity.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { cli } from "../../src/cli.js";

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import * as assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { cli } from "../../src/cli.js";

--- a/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.js
+++ b/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 /**
  * @param {import("@textlint/types").TextlintRuleContext} context
  */

--- a/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.js
+++ b/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-add.js
@@ -10,7 +10,7 @@ const reporter = (context) => {
         },
         [Syntax.Str](node) {
             const text = getSource(node);
-            if (/\.$/.test(text)) {
+            if (text.endsWith(".")) {
                 return;
             }
             const add = fixer.insertTextAfter(node, ".");

--- a/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-remove.js
+++ b/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-remove.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 /**
  * @param {import("@textlint/types").TextlintRuleContext} context
  */

--- a/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-replace.js
+++ b/packages/textlint/test/cli/fixtures/fixer-rules/fixer-rule-replace.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 /**
  * @param {import("@textlint/types").TextlintRuleContext} context
  */

--- a/packages/textlint/test/cli/fixtures/rules/@textlint/textlint-rule-example.ts
+++ b/packages/textlint/test/cli/fixtures/rules/@textlint/textlint-rule-example.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/cli/fixtures/rules/@textlint/textlint-rule-example.ts
+++ b/packages/textlint/test/cli/fixtures/rules/@textlint/textlint-rule-example.ts
@@ -1,10 +1,7 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
-/**
- * @param {RuleContext} context
- */
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {
         [context.Syntax.Str](node) {

--- a/packages/textlint/test/cli/fixtures/rules/async-rule.js
+++ b/packages/textlint/test/cli/fixtures/rules/async-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /**
  * @param {import("@textlint/types").TextlintRuleContext} context

--- a/packages/textlint/test/cli/fixtures/rules/example-rule.js
+++ b/packages/textlint/test/cli/fixtures/rules/example-rule.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 /**
  * @param {import("@textlint/types").TextlintRuleContext} context

--- a/packages/textlint/test/cli/fixtures/rules/issue81/no-default-assign-rule.ts
+++ b/packages/textlint/test/cli/fixtures/rules/issue81/no-default-assign-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/cli/fixtures/rules/issue81/no-default-assign-rule.ts
+++ b/packages/textlint/test/cli/fixtures/rules/issue81/no-default-assign-rule.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 // This module has not module.export, but has module.export.default
 // See https://github.com/textlint/textlint/issues/81

--- a/packages/textlint/test/cli/fixtures/rules/no-error/textlint-rule-no-error.ts
+++ b/packages/textlint/test/cli/fixtures/rules/no-error/textlint-rule-no-error.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext } from "@textlint/types";
+import type { TextlintRuleContext } from "@textlint/types";
 
 // Do no error rule
 export default function (_context: TextlintRuleContext) {

--- a/packages/textlint/test/cli/fixtures/rules/no-todo.js
+++ b/packages/textlint/test/cli/fixtures/rules/no-todo.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { RuleHelper } from "textlint-rule-helper";
 
 /**

--- a/packages/textlint/test/config-initializer/config-initializer.test.ts
+++ b/packages/textlint/test/config-initializer/config-initializer.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { createConfigFile } from "../../src/config/config-initializer.js";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { Logger } from "../../src/util/logger.js";

--- a/packages/textlint/test/engine/fixtures/rule-loader/bar.ts
+++ b/packages/textlint/test/engine/fixtures/rule-loader/bar.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 export default function () {
     return {};
 }

--- a/packages/textlint/test/engine/fixtures/rule-loader/foo.js
+++ b/packages/textlint/test/engine/fixtures/rule-loader/foo.js
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 export default function () {
     return {};
 }

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 const reporter = (context: TextlintRuleContext): TextlintRuleReportHandler => {
     const { Syntax, fixer, report, getSource } = context;

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
@@ -7,7 +7,7 @@ const reporter = (context: TextlintRuleContext): TextlintRuleReportHandler => {
     return {
         [Syntax.Str](node) {
             const text = getSource(node);
-            if (/\.$/.test(text)) {
+            if (text.endsWith(".")) {
                 return;
             }
             const add = fixer.insertTextAfter(node, ".");

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-add.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-remove.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-remove.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 const reporter = (context: TextlintRuleContext): TextlintRuleReportHandler => {
     const { Syntax, fixer, report, getSource } = context;

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-remove.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-remove.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-replace.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-replace.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 const reporter = (context: TextlintRuleContext): TextlintRuleReportHandler => {
     const { Syntax, fixer, report, getSource } = context;

--- a/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-replace.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/fixer-rules/fixer-rule-replace.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textfix-engine/formatter/example-fixer-formatter.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/formatter/example-fixer-formatter.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintFixResult } from "@textlint/types";
+import type { TextlintFixResult } from "@textlint/types";
 
 module.exports = function (results: TextlintFixResult[]) {
     return `example-fixer-formatter\n${results

--- a/packages/textlint/test/engine/fixtures/textfix-engine/formatter/example-fixer-formatter.ts
+++ b/packages/textlint/test/engine/fixtures/textfix-engine/formatter/example-fixer-formatter.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintFixResult } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/filters/filter-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/filters/filter-rule.ts
@@ -1,10 +1,7 @@
 // LICENSE : MIT
 
-import { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
-/**
- * @param {TextLintFilterRuleContext} context
- */
 export default function (context: TextlintFilterRuleContext): TextlintRuleReportHandler {
     return {
         [context.Syntax.Str](node) {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/filters/filter-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/filters/filter-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/formatter/example-formatter.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/formatter/example-formatter.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintResult } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/formatter/example-formatter.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/formatter/example-formatter.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintResult } from "@textlint/types";
+import type { TextlintResult } from "@textlint/types";
 
 export default function (results: TextlintResult[]) {
     return `example-formatter\n${results

--- a/packages/textlint/test/engine/fixtures/textlint-engine/issue81/no-default-assign-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/issue81/no-default-assign-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/issue81/no-default-assign-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/issue81/no-default-assign-rule.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 // This module has not module.export, but has module.export.default
 // See https://github.com/textlint/textlint/issues/81

--- a/packages/textlint/test/engine/fixtures/textlint-engine/plugins/@textlint/textlint-plugin-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/plugins/@textlint/textlint-plugin-example/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 
 export class ExampleProcessor {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-plugin-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-plugin-example/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintMessage } from "@textlint/types";
 
 export class ExampleProcessor {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import a from "./rules/textlint-rule-a.js";
 import b from "./rules/textlint-rule-b.js";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/rules/textlint-rule-a.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/rules/textlint-rule-a.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/rules/textlint-rule-b.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/plugins/textlint-rule-plugin-invalid/rules/textlint-rule-b.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/presets/@textlint/textlint-rule-preset-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/presets/@textlint/textlint-rule-preset-example/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import exampleRule from "./rules/example-rule.js";
 
 module.exports = {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/presets/@textlint/textlint-rule-preset-example/rules/example-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/presets/@textlint/textlint-rule-preset-example/rules/example-rule.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import a from "./rules/textlint-rule-a.js";
 import b from "./rules/textlint-rule-b.js";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/rules/textlint-rule-a.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/rules/textlint-rule-a.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/rules/textlint-rule-b.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/presets/textlint-rule-preset-example/rules/textlint-rule-b.ts
@@ -1,4 +1,4 @@
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/@textlint/textlint-rule-example.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/@textlint/textlint-rule-example.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/@textlint/textlint-rule-example.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/@textlint/textlint-rule-example.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 /**
  * @param {RuleContext} context

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/example-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/example-rule.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/example-rule.ts
@@ -1,10 +1,7 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
-/**
- * @param {RuleContext} context
- */
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {
         [context.Syntax.Str](node) {

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/textlint-rule-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/textlint-rule-example/index.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/engine/fixtures/textlint-engine/rules/textlint-rule-example/index.ts
+++ b/packages/textlint/test/engine/fixtures/textlint-engine/rules/textlint-rule-example/index.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 /**
  * @param {RuleContext} context

--- a/packages/textlint/test/engine/rule-loader.test.ts
+++ b/packages/textlint/test/engine/rule-loader.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import path from "node:path";
 import { describe, it } from "vitest";
 import * as assert from "node:assert";

--- a/packages/textlint/test/execute-file-backers/cache-backer.test.ts
+++ b/packages/textlint/test/execute-file-backers/cache-backer.test.ts
@@ -4,8 +4,8 @@ import { describe, it, beforeAll, afterAll } from "vitest";
 import path from "node:path";
 import os from "node:os";
 import fs from "node:fs";
-import { CacheBacker, CacheBackerOptions } from "../../src/engine/execute-file-backers/cache-backer.js";
-import { TextlintMessage } from "@textlint/types";
+import { CacheBacker, type CacheBackerOptions } from "../../src/engine/execute-file-backers/cache-backer.js";
+import type { TextlintMessage } from "@textlint/types";
 
 describe("CacheBacker", function () {
     let configDir: string;

--- a/packages/textlint/test/execute-file-backers/cache-backer.test.ts
+++ b/packages/textlint/test/execute-file-backers/cache-backer.test.ts
@@ -1,5 +1,4 @@
 // MIT © 2016 azu
-"use strict";
 import assert from "node:assert";
 import { describe, it, beforeAll, afterAll } from "vitest";
 import path from "node:path";

--- a/packages/textlint/test/mcp-snapshot-test/mcp-snapshots.test.ts
+++ b/packages/textlint/test/mcp-snapshot-test/mcp-snapshots.test.ts
@@ -3,9 +3,9 @@ import { describe, it, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { setupServer } from "../../src/mcp/server.js";
 import {

--- a/packages/textlint/test/mcp-snapshot-test/snapshot-utils.ts
+++ b/packages/textlint/test/mcp-snapshot-test/snapshot-utils.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import {
+import type {
     McpResponse,
     McpToolRequest,
     SnapshotContext,

--- a/packages/textlint/test/mcp/server.test.ts
+++ b/packages/textlint/test/mcp/server.test.ts
@@ -3,9 +3,9 @@ import { afterEach, beforeEach, describe, it, expect } from "vitest";
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { setupServer, connectStdioMcpServer } from "../../src/mcp/server.js";
 

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintFilterRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-filter-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintFilterRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-plugin.ts
@@ -1,5 +1,5 @@
 import type { TxtDocumentNode } from "@textlint/ast-node-types";
-import { TextlintPluginProcessorConstructor } from "@textlint/kernel";
+import type { TextlintPluginProcessorConstructor } from "@textlint/kernel";
 import type { TextlintMessage } from "@textlint/types";
 
 class ExampleProcessor {

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.ts
+++ b/packages/textlint/test/object-to-kernel-format/fixtures/example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/other/fixtures/no-error-rules/textlint-rule-no-error.js
+++ b/packages/textlint/test/other/fixtures/no-error-rules/textlint-rule-no-error.js
@@ -1,5 +1,3 @@
-import { TextlintRuleContext } from "@textlint/types";
-
 // Do no error rule
 /**
  * @param {import("@textlint/types").TextlintRuleContext} _context

--- a/packages/textlint/test/other/fixtures/no-todo.ts
+++ b/packages/textlint/test/other/fixtures/no-todo.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 import { RuleHelper } from "textlint-rule-helper";
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {

--- a/packages/textlint/test/other/fixtures/no-todo.ts
+++ b/packages/textlint/test/other/fixtures/no-todo.ts
@@ -1,5 +1,5 @@
 // LICENSE : MIT
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 import { RuleHelper } from "textlint-rule-helper";
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     const helper = new RuleHelper(context);

--- a/packages/textlint/test/other/parsing.test.ts
+++ b/packages/textlint/test/other/parsing.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import path from "node:path";

--- a/packages/textlint/test/pluguins/PluginOption.test.ts
+++ b/packages/textlint/test/pluguins/PluginOption.test.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { createPluginStub } from "./fixtures/example-plugin.js";

--- a/packages/textlint/test/pluguins/fixtures/example-rule.ts
+++ b/packages/textlint/test/pluguins/fixtures/example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/pluguins/fixtures/example-rule.ts
+++ b/packages/textlint/test/pluguins/fixtures/example-rule.ts
@@ -1,10 +1,7 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
-/**
- * @param {RuleContext} context
- */
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {
         [context.Syntax.Str](node) {

--- a/packages/textlint/test/rule-context/fixtures/rules/throw-error-in-rule.ts
+++ b/packages/textlint/test/rule-context/fixtures/rules/throw-error-in-rule.ts
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 export default function (context: TextlintRuleContext): TextlintRuleReportHandler {
     return {

--- a/packages/textlint/test/rule-context/fixtures/rules/throw-error-in-rule.ts
+++ b/packages/textlint/test/rule-context/fixtures/rules/throw-error-in-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/rule-context/rule-context.test.ts
+++ b/packages/textlint/test/rule-context/rule-context.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import path from "node:path";

--- a/packages/textlint/test/rule-context/rule-context.test.ts
+++ b/packages/textlint/test/rule-context/rule-context.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, it } from "vitest";
 import path from "node:path";
 import { TextlintRuleSeverityLevelKeys } from "@textlint/kernel";
 import { coreFlags, resetFlags } from "@textlint/feature-flag";
-import {
+import type {
     TextlintFilterRuleContext,
     TextlintFilterRuleReportHandler,
     TextlintRuleContext,

--- a/packages/textlint/test/rule-tips/fixtures/rules/after-all.ts
+++ b/packages/textlint/test/rule-tips/fixtures/rules/after-all.ts
@@ -1,6 +1,6 @@
 // MIT © 2017 azu
 
-import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
+import type { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 
 const callAsync = (text: string) => {
     // do something by async

--- a/packages/textlint/test/rule-tips/fixtures/rules/after-all.ts
+++ b/packages/textlint/test/rule-tips/fixtures/rules/after-all.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 
 import { TextlintRuleContext, TextlintRuleReportHandler } from "@textlint/types";
 

--- a/packages/textlint/test/rule-tips/rule-tips-after-all.test.ts
+++ b/packages/textlint/test/rule-tips/rule-tips-after-all.test.ts
@@ -1,5 +1,4 @@
 // MIT © 2017 azu
-"use strict";
 import * as assert from "node:assert";
 import { describe, it } from "vitest";
 import { createAfterAllRule } from "./fixtures/rules/after-all.js";

--- a/packages/textlint/test/textlint-core/async-rule.test.ts
+++ b/packages/textlint/test/textlint-core/async-rule.test.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
 import { TextlintRuleModule } from "@textlint/kernel";

--- a/packages/textlint/test/textlint-core/async-rule.test.ts
+++ b/packages/textlint/test/textlint-core/async-rule.test.ts
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, it } from "vitest";
-import { TextlintRuleModule } from "@textlint/kernel";
+import type { TextlintRuleModule } from "@textlint/kernel";
 import { coreFlags, resetFlags } from "@textlint/feature-flag";
 // fixture
 import fixtureRule from "./fixtures/rules/example-rule.js";

--- a/packages/textlint/test/textlint-core/fixtures/rules/async-rule.ts
+++ b/packages/textlint/test/textlint-core/fixtures/rules/async-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleReporter } from "@textlint/types";
 
 const report: TextlintRuleReporter = function (context) {

--- a/packages/textlint/test/textlint-core/fixtures/rules/example-rule.ts
+++ b/packages/textlint/test/textlint-core/fixtures/rules/example-rule.ts
@@ -1,5 +1,4 @@
 // LICENSE : MIT
-"use strict";
 import type { TextlintRuleReporter } from "@textlint/types";
 
 const reporter: TextlintRuleReporter = function (context) {

--- a/packages/textlint/tsconfig.json
+++ b/packages/textlint/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "lib"
+    "outDir": "lib",
+    "types": ["node"]
   },
   "include": [
     "src/**/*"

--- a/scripts/rename-test-files.js
+++ b/scripts/rename-test-files.js
@@ -3,9 +3,9 @@
  * Script to rename test files from `-test.ts` to `.test.ts` pattern
  * This ensures consistency with vitest's default test file patterns
  */
-const fs = require("fs");
-const path = require("path");
-const { execSync } = require("child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { execSync } = require("node:child_process");
 
 // Find all -test.ts files recursively
 function findTestFiles(dir) {

--- a/test/benchmark/format-bench.mjs
+++ b/test/benchmark/format-bench.mjs
@@ -14,7 +14,7 @@
     }
 ]
  */
-import * as fs from "fs";
+import * as fs from "node:fs";
 
 /**
  * @type {import("./result.json")}

--- a/website/static/js/index.js
+++ b/website/static/js/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable*/
-"use strict";
 
 function debounce(func, wait, immediate) {
     var timeout;


### PR DESCRIPTION
(The description was generated by LLM.)

## Summary

Enable additional oxlint rules and apply their autofixes across the codebase.
The `.oxlintrc.json` changes are the source of truth — each code change is
enforced going forward by a newly enabled rule.

## Enabled rules

- `unicorn` plugin
  - `unicorn/prefer-node-protocol` — use `node:` protocol for builtin imports
  - `unicorn/prefer-string-starts-ends-with` — use `String#startsWith/endsWith`
  - `unicorn/no-new-array`
- `typescript/consistent-type-imports` — use `import type` for type-only imports

## Other changes

- chore(tsconfig): set explicit `types` in preparation for TypeScript 6.0
- chore: remove redundant `use strict` directives
- refactor(textlint-tester): reuse kernel types for `TestConfigRule`/`TestConfigPlugin`
- chore: disable console warnings in debug-broken-auto-link

## Notes

- All changes are mechanical autofixes except the textlint-tester refactor
  (type-alias dedup, no behavior/public-API change).
- Please use **Rebase and merge** to preserve the per-rule commit history.