### PR TITLE
refactor(ast-node-types): simplify TypeofTxtNode with a lookup map

### DIFF
--- a/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
+++ b/packages/@textlint/ast-node-types/src/TypeofTxtNode.ts
@@ -28,118 +28,70 @@ import type {
 } from "./NodeType.js";
 
 /**
+ * Mapping from ASTNodeTypes (enter/exit) to the corresponding TxtNode interface.
+ */
+interface TxtNodeTypeMap {
+    [ASTNodeTypes.Document]: TxtDocumentNode;
+    [ASTNodeTypes.DocumentExit]: TxtDocumentNode;
+    [ASTNodeTypes.Paragraph]: TxtParagraphNode;
+    [ASTNodeTypes.ParagraphExit]: TxtParagraphNode;
+    [ASTNodeTypes.BlockQuote]: TxtBlockQuoteNode;
+    [ASTNodeTypes.BlockQuoteExit]: TxtBlockQuoteNode;
+    [ASTNodeTypes.List]: TxtListNode;
+    [ASTNodeTypes.ListExit]: TxtListNode;
+    [ASTNodeTypes.ListItem]: TxtListItemNode;
+    [ASTNodeTypes.ListItemExit]: TxtListItemNode;
+    [ASTNodeTypes.Header]: TxtHeaderNode;
+    [ASTNodeTypes.HeaderExit]: TxtHeaderNode;
+    [ASTNodeTypes.CodeBlock]: TxtCodeBlockNode;
+    [ASTNodeTypes.CodeBlockExit]: TxtCodeBlockNode;
+    [ASTNodeTypes.HtmlBlock]: TxtHtmlNode;
+    [ASTNodeTypes.HtmlBlockExit]: TxtHtmlNode;
+    [ASTNodeTypes.Link]: TxtLinkNode;
+    [ASTNodeTypes.LinkExit]: TxtLinkNode;
+    [ASTNodeTypes.LinkReference]: TxtLinkReferenceNode;
+    [ASTNodeTypes.LinkReferenceExit]: TxtLinkReferenceNode;
+    [ASTNodeTypes.Delete]: TxtDeleteNode;
+    [ASTNodeTypes.DeleteExit]: TxtDeleteNode;
+    [ASTNodeTypes.Emphasis]: TxtEmphasisNode;
+    [ASTNodeTypes.EmphasisExit]: TxtEmphasisNode;
+    [ASTNodeTypes.Strong]: TxtStrongNode;
+    [ASTNodeTypes.StrongExit]: TxtStrongNode;
+    [ASTNodeTypes.Break]: TxtBreakNode;
+    [ASTNodeTypes.BreakExit]: TxtBreakNode;
+    [ASTNodeTypes.Image]: TxtImageNode;
+    [ASTNodeTypes.ImageExit]: TxtImageNode;
+    [ASTNodeTypes.ImageReference]: TxtImageReferenceNode;
+    [ASTNodeTypes.ImageReferenceExit]: TxtImageReferenceNode;
+    [ASTNodeTypes.Definition]: TxtDefinitionNode;
+    [ASTNodeTypes.DefinitionExit]: TxtDefinitionNode;
+    [ASTNodeTypes.HorizontalRule]: TxtHorizontalRuleNode;
+    [ASTNodeTypes.HorizontalRuleExit]: TxtHorizontalRuleNode;
+    [ASTNodeTypes.Comment]: TxtCommentNode;
+    [ASTNodeTypes.CommentExit]: TxtCommentNode;
+    [ASTNodeTypes.Str]: TxtStrNode;
+    [ASTNodeTypes.StrExit]: TxtStrNode;
+    [ASTNodeTypes.Code]: TxtCodeNode;
+    [ASTNodeTypes.CodeExit]: TxtCodeNode;
+    [ASTNodeTypes.Html]: TxtHtmlNode;
+    [ASTNodeTypes.HtmlExit]: TxtHtmlNode;
+    [ASTNodeTypes.Table]: TxtTableNode;
+    [ASTNodeTypes.TableExit]: TxtTableNode;
+    [ASTNodeTypes.TableRow]: TxtTableRowNode;
+    [ASTNodeTypes.TableRowExit]: TxtTableRowNode;
+    [ASTNodeTypes.TableCell]: TxtTableCellNode;
+    [ASTNodeTypes.TableCellExit]: TxtTableCellNode;
+}
+
+/**
  * Type utility for TxtNodeType
- * Return TxtNode interface for the TxtNodeTYpe
+ * Return TxtNode interface for the TxtNodeType
  *
  * @example
  * ```ts
- * type NodeType = TxtNodeTypeOfNode<ASTNodeTypes.Document>;
+ * type NodeType = TypeofTxtNode<ASTNodeTypes.Document>;
  * ```
  */
-export type TypeofTxtNode<T extends ASTNodeTypes | string> =
-    // Root
-    T extends ASTNodeTypes.Document
-        ? TxtDocumentNode
-        : T extends ASTNodeTypes.DocumentExit
-        ? TxtDocumentNode
-        : T extends ASTNodeTypes.Paragraph // Paragraph Str.
-        ? TxtParagraphNode
-        : T extends ASTNodeTypes.ParagraphExit
-        ? TxtParagraphNode
-        : T extends ASTNodeTypes.BlockQuote // > Str
-        ? TxtBlockQuoteNode
-        : T extends ASTNodeTypes.BlockQuoteExit
-        ? TxtBlockQuoteNode
-        : T extends ASTNodeTypes.List // - item
-        ? TxtListNode
-        : T extends ASTNodeTypes.ListExit
-        ? TxtListNode
-        : T extends ASTNodeTypes.ListItem // - item
-        ? TxtListItemNode
-        : T extends ASTNodeTypes.ListItemExit
-        ? TxtListItemNode
-        : T extends ASTNodeTypes.Header // # Str
-        ? TxtHeaderNode
-        : T extends ASTNodeTypes.HeaderExit
-        ? TxtHeaderNode
-        : T extends ASTNodeTypes.CodeBlock
-        ? /* ```
-           * code block
-           * ```
-           */
-          TxtCodeBlockNode
-        : T extends ASTNodeTypes.CodeBlockExit
-        ? TxtCodeBlockNode
-        : T extends ASTNodeTypes.HtmlBlock // <div>\n</div>
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.HtmlBlockExit
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.Link // [link](https://example.com)
-        ? TxtLinkNode
-        : T extends ASTNodeTypes.LinkExit
-        ? TxtLinkNode
-        : T extends ASTNodeTypes.LinkReference // [link][1]
-        ? TxtLinkReferenceNode
-        : T extends ASTNodeTypes.LinkReferenceExit
-        ? TxtLinkReferenceNode
-        : T extends ASTNodeTypes.Delete // ~~Str~~
-        ? TxtDeleteNode
-        : T extends ASTNodeTypes.DeleteExit
-        ? TxtDeleteNode
-        : T extends ASTNodeTypes.Emphasis // *Str*
-        ? TxtEmphasisNode
-        : T extends ASTNodeTypes.EmphasisExit
-        ? TxtEmphasisNode
-        : T extends ASTNodeTypes.Strong // __Str__
-        ? TxtStrongNode
-        : T extends ASTNodeTypes.StrongExit
-        ? TxtStrongNode
-        : T extends ASTNodeTypes.Break // Str<space><space>
-        ? TxtBreakNode
-        : T extends ASTNodeTypes.BreakExit
-        ? TxtBreakNode
-        : T extends ASTNodeTypes.Image // ![alt](https://example.com/img)
-        ? TxtImageNode
-        : T extends ASTNodeTypes.ImageExit
-        ? TxtImageNode
-        : T extends ASTNodeTypes.ImageReference // ![alt][1]
-        ? TxtImageReferenceNode
-        : T extends ASTNodeTypes.ImageReferenceExit
-        ? TxtImageReferenceNode
-        : T extends ASTNodeTypes.Definition // [1]: https://example.com
-        ? TxtDefinitionNode
-        : T extends ASTNodeTypes.DefinitionExit
-        ? TxtDefinitionNode
-        : T extends ASTNodeTypes.HorizontalRule // ----
-        ? TxtHorizontalRuleNode
-        : T extends ASTNodeTypes.HorizontalRuleExit
-        ? TxtHorizontalRuleNode
-        : T extends ASTNodeTypes.Comment // Markdown does not have comment(It is Html comment). Some plugins use comment as a marker.
-        ? TxtCommentNode
-        : T extends ASTNodeTypes.CommentExit
-        ? TxtCommentNode
-        : T extends ASTNodeTypes.Str // Str
-        ? TxtStrNode
-        : T extends ASTNodeTypes.StrExit
-        ? TxtStrNode
-        : T extends ASTNodeTypes.Code // `code`
-        ? TxtCodeNode
-        : T extends ASTNodeTypes.CodeExit
-        ? TxtCodeNode
-        : T extends ASTNodeTypes.Html // <span>Str</span>
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.HtmlExit
-        ? TxtHtmlNode
-        : T extends ASTNodeTypes.Table
-        ? TxtTableNode
-        : T extends ASTNodeTypes.TableExit
-        ? TxtTableNode
-        : T extends ASTNodeTypes.TableRow
-        ? TxtTableRowNode
-        : T extends ASTNodeTypes.TableRowExit
-        ? TxtTableRowNode
-        : T extends ASTNodeTypes.TableCell
-        ? TxtTableCellNode
-        : T extends ASTNodeTypes.TableCellExit
-        ? TxtTableCellNode
-        : AnyTxtNode;
+export type TypeofTxtNode<T extends ASTNodeTypes | string> = T extends keyof TxtNodeTypeMap
+    ? TxtNodeTypeMap[T]
+    : AnyTxtNode;


### PR DESCRIPTION
Replace the long nested conditional type with a TxtNodeTypeMap interface
and an indexed access lookup. Behavior is unchanged for both single and
union node types, with AnyTxtNode kept as the fallback.

Also fix doc comment typos (TxtNodeTYpe, TxtNodeTypeOfNode).