### PR TITLE
fix: prevent duplicated register in textlint-scripts

### DIFF
--- a/packages/textlint-scripts/register-ts.js
+++ b/packages/textlint-scripts/register-ts.js
@@ -1,2 +1,6 @@
 // --require textlint-scripts/register-ts
-require("./configs/ts-node-register");
+// Prevent duplicate registration
+if (!global.__textlint_scripts_register_ts_loaded) {
+    global.__textlint_scripts_register_ts_loaded = true;
+    require("./configs/ts-node-register");
+}

--- a/packages/textlint-scripts/register-ts.js
+++ b/packages/textlint-scripts/register-ts.js
@@ -1,6 +1,9 @@
 // --require textlint-scripts/register-ts
-// Prevent duplicate registration
+// Prevent duplicate registration.
+// Node.js require cache handles most cases, but in monorepos with symlinked
+// node_modules or npm link, the same logical module may resolve to different
+// absolute paths, bypassing the cache. This global flag covers that edge case.
 if (!global.__textlint_scripts_register_ts_loaded) {
-    global.__textlint_scripts_register_ts_loaded = true;
     require("./configs/ts-node-register");
+    global.__textlint_scripts_register_ts_loaded = true;
 }

--- a/packages/textlint-scripts/register.js
+++ b/packages/textlint-scripts/register.js
@@ -1,2 +1,6 @@
 // --require textlint-scripts/register
-require("./configs/babel-register");
+// Prevent duplicate registration
+if (!global.__textlint_scripts_register_loaded) {
+    global.__textlint_scripts_register_loaded = true;
+    require("./configs/babel-register");
+}

--- a/packages/textlint-scripts/register.js
+++ b/packages/textlint-scripts/register.js
@@ -1,6 +1,9 @@
 // --require textlint-scripts/register
-// Prevent duplicate registration
+// Prevent duplicate registration.
+// Node.js require cache handles most cases, but in monorepos with symlinked
+// node_modules or npm link, the same logical module may resolve to different
+// absolute paths, bypassing the cache. This global flag covers that edge case.
 if (!global.__textlint_scripts_register_loaded) {
-    global.__textlint_scripts_register_loaded = true;
     require("./configs/babel-register");
+    global.__textlint_scripts_register_loaded = true;
 }


### PR DESCRIPTION
## Description

This PR fixes duplicate register errors that occur when `--require textlint-scripts/register-ts` or `--require textlint-scripts/register` is specified multiple times.

### Problem

When a user has `--require textlint-scripts/register-ts` in both their `.mocharc` file and their `package.json` scripts, the register gets called twice, causing errors like:

```
error TS7006: Parameter 'obj' implicitly has an 'any' type.
```

This happens because the register files don't check if they've already been loaded.

### Fix

Added global variable guards to prevent duplicate registration:

1. **`register-ts.js`**: Added `global.__textlint_scripts_register_ts_loaded` check
2. **`register.js`**: Added `global.__textlint_scripts_register_loaded` check

### Changes

- **`packages/textlint-scripts/register-ts.js`**: Added duplicate registration guard
- **`packages/textlint-scripts/register.js`**: Added duplicate registration guard

### Testing

- Verified that running with duplicate `--require` no longer throws errors
- Existing functionality remains unchanged

Fixes #781
