### PR TITLE
feat: group logs based on file when using gh formatter

### DIFF
--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -38,15 +38,19 @@ function formatter(results: TextlintResult[]) {
     results.forEach(function (result) {
         const messages = result.messages;
 
-        // ::warning file={name},line={line},endLine={endLine},title={title}::{message}
+        // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github
         messages.forEach(function (message) {
+            output += `${result.filePath}: `;
+            output += `line=${message.line || 0}`;
+            output += `, col=${message.column || 0}`;
+            output += "\n";
             output += `::${getMessageType(message)} `;
             output += `file=${result.filePath},`;
             output += `line=${message.loc.start.line || 1},`;
             output += `endLine=${message.loc.end.line || message.loc.start.line || 1},`;
             output += `col=${message.loc.start.column || 1},`;
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
-            output += `title=TextLint${message.ruleId ? `->${message.ruleId}` : ""}::`;
+            output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
             output += "\n";
         });

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -41,14 +41,14 @@ function formatter(results: TextlintResult[]) {
         // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github
         messages.forEach(function (message) {
             output += `${result.filePath}: `;
-            output += `line=${message.line || 0}`;
-            output += `, col=${message.column || 0}`;
+            output += `line=${message.loc.start.line || 1}`;
+            output += `, col=${message.loc.start.column || 0}`;
             output += "\n";
             output += `::${getMessageType(message)} `;
             output += `file=${result.filePath},`;
             output += `line=${message.loc.start.line || 1},`;
             output += `endLine=${message.loc.end.line || message.loc.start.line || 1},`;
-            output += `col=${message.loc.start.column || 1},`;
+            output += `col=${message.loc.start.column || 0},`;
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -42,13 +42,13 @@ function formatter(results: TextlintResult[]) {
         messages.forEach(function (message) {
             output += `${result.filePath}: `;
             output += `line=${message.loc.start.line || 1}`;
-            output += `, col=${message.loc.start.column || 0}`;
+            output += `, col=${message.loc.start.column || 1}`;
             output += "\n";
             output += `::${getMessageType(message)} `;
             output += `file=${result.filePath},`;
             output += `line=${message.loc.start.line || 1},`;
             output += `endLine=${message.loc.end.line || message.loc.start.line || 1},`;
-            output += `col=${message.loc.start.column || 0},`;
+            output += `col=${message.loc.start.column || 1},`;
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -38,12 +38,14 @@ function formatter(results: TextlintResult[]) {
     results.forEach(function (result) {
         const messages = result.messages;
 
+        if (messages.length === 0) {
+            return;
+        }
+
+        output += `${result.filePath}\n`;
+
         // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github
         messages.forEach(function (message) {
-            output += `${result.filePath}: `;
-            output += `line=${message.loc.start.line || 1}`;
-            output += `, col=${message.loc.start.column || 1}`;
-            output += "\n";
             output += `::${getMessageType(message)} `;
             output += `file=${result.filePath},`;
             output += `line=${message.loc.start.line || 1},`;
@@ -52,6 +54,8 @@ function formatter(results: TextlintResult[]) {
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
+            output += ` @ ${message.loc.start.line || 1}:`;
+            output += `${message.loc.start.column || 1}`;
             output += "\n";
         });
     });

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -44,7 +44,7 @@ function formatter(results: TextlintResult[]) {
 
         output += `${result.filePath}\n`;
 
-        // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github
+        // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github to generate annotations
         messages.forEach(function (message) {
             output += `::${getMessageType(message)} `;
             output += `file=${result.filePath},`;
@@ -54,8 +54,8 @@ function formatter(results: TextlintResult[]) {
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
-            output += ` @ ${message.loc.start.line || 1}:`;
-            output += `${message.loc.start.column || 1}`;
+            output += ` @ L${message.loc.start.line || 1}`;
+            output += `C${message.loc.start.column || 1}`;
             output += "\n";
         });
     });

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -54,7 +54,7 @@ function formatter(results: TextlintResult[]) {
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
-            output += ` @ L${message.loc.start.line || 1}`;
+            output += ` | L${message.loc.start.line || 1}`;
             output += `C${message.loc.start.column || 1}`;
             output += "\n";
         });

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -54,7 +54,7 @@ function formatter(results: TextlintResult[]) {
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
-            output += ` | L${message.loc.start.line || 1}`;
+            output += ` | L${message.loc.start.line || 1}:`;
             output += `C${message.loc.start.column || 1}`;
             output += "\n";
         });

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -54,8 +54,8 @@ function formatter(results: TextlintResult[]) {
             output += `endColumn=${message.loc.end.column || message.loc.start.column || 1},`;
             output += `title=TextLint${message.ruleId ? ` [${message.ruleId}]` : ""}::`;
             output += `${message.message.trim()}`;
-            output += ` | L${message.loc.start.line || 1}:`;
-            output += `C${message.loc.start.column || 1}`;
+            output += ` | ${message.loc.start.line || 1}:`;
+            output += `${message.loc.start.column || 1}`;
             output += "\n";
         });
         output += "::endgroup::\n"

--- a/packages/@textlint/linter-formatter/src/formatters/github.ts
+++ b/packages/@textlint/linter-formatter/src/formatters/github.ts
@@ -42,7 +42,7 @@ function formatter(results: TextlintResult[]) {
             return;
         }
 
-        output += `${result.filePath}\n`;
+        output += `::group::${result.filePath}\n`;
 
         // ::warning file={name},line={line},endLine={endLine},title={title}::{message} is the format used by github to generate annotations
         messages.forEach(function (message) {
@@ -58,6 +58,7 @@ function formatter(results: TextlintResult[]) {
             output += `C${message.loc.start.column || 1}`;
             output += "\n";
         });
+        output += "::endgroup::\n"
     });
 
     return output;

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6,col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6,col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -228,7 +228,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=0,col=0\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
+                "foo.js: line=0, col=0\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
+                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
+                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar.\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar.\n"
             );
         });
     });
@@ -216,9 +216,7 @@ describe("formatter:github", function () {
                 messages: [
                     createTestMessage({
                         fatal: true,
-                        message: "Couldn't find foo.js.",
-                        line: 0,
-                        column: 0
+                        message: "Couldn't find foo.js."
                     })
                 ]
             })

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5,col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5,col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6,col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6,col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
             );
         });
     });
@@ -228,7 +228,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
+                "foo.js: line=0,col=0\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -226,7 +226,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=1, col=0\n::error file=foo.js,line=1,endLine=1,col=0,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
+                "foo.js: line=1, col=1\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint->foo::Unexpected foo.\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint->bar::Unexpected bar.\n"
+                "foo.js: line=5,col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo::Unexpected foo.]\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar::Unexpected bar.]\n"
             );
         });
     });
@@ -228,7 +228,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=0, col=0\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
+                "foo.js: line=1, col=0\n::error file=foo.js,line=1,endLine=1,col=0,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
+                `"::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::endgroup::
+                "`
             );
         });
 
@@ -61,7 +64,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
+                `"::group::foo.js
+                ::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::endgroup::
+                "`
             );
         });
 
@@ -70,7 +76,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
+                `"::group::foo.js
+                ::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::endgroup::
+                "`
             );
         });
     });
@@ -103,7 +112,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
+                `"::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::endgroup::
+                "`
             );
         });
     });
@@ -151,7 +163,11 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14\n"
+                `"::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14
+                ::endgroup::
+                "`
             );
         });
     });
@@ -204,7 +220,13 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\nbar.js\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14\n"
+                `"::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                ::endgroup::
+                ::group::bar.js
+                ::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14
+                ::endgroup::
+                "`
             );
         });
     });
@@ -226,7 +248,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @ L1C1\n"
+                `"::group::foo.js
+                ::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @ L1C1
+                ::endgroup::
+                "`
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -75,7 +75,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10" +
+                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
                 "::endgroup::\n"
             );
         });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -53,7 +53,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
                 "::endgroup::\n"
             );
         });
@@ -64,7 +64,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
                 "::endgroup::\n"
             );
         });
@@ -75,7 +75,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
                 "::endgroup::\n"
             );
         });
@@ -110,7 +110,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
                 "::endgroup::\n"
             );
         });
@@ -160,8 +160,8 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
-                "::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6:C14\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
+                "::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | 6:14\n" +
                 "::endgroup::\n"
             );
         });
@@ -216,10 +216,10 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | 5:10\n" +
                 "::endgroup::\n" +
                 "::group::bar.js\n" +
-                "::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6:C14\n" +
+                "::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | 6:14\n" +
                 "::endgroup::\n"
             );
         });
@@ -243,7 +243,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1:C1\n" +
+                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | 1:1\n" +
                 "::endgroup::\n"
             );
         });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,10 +52,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                `::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
                 ::endgroup::
-                "`
+                `
             );
         });
 
@@ -64,10 +64,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                `::group::foo.js
+                ::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
                 ::endgroup::
-                "`
+                `
             );
         });
 
@@ -76,10 +76,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                `::group::foo.js
+                ::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
                 ::endgroup::
-                "`
+                `
             );
         });
     });
@@ -112,10 +112,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                `::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
                 ::endgroup::
-                "`
+                `
             );
         });
     });
@@ -163,11 +163,11 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
-                ::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14
+                `::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
+                ::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14
                 ::endgroup::
-                "`
+                `
             );
         });
     });
@@ -220,13 +220,13 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10
+                `::group::foo.js
+                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
                 ::endgroup::
                 ::group::bar.js
-                ::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14
+                ::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14
                 ::endgroup::
-                "`
+                `
             );
         });
     });
@@ -248,10 +248,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `"::group::foo.js
-                ::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @ L1C1
+                `::group::foo.js
+                ::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1C1
                 ::endgroup::
-                "`
+                `
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,10 +52,9 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::endgroup::\n"
             );
         });
 
@@ -64,10 +63,9 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::endgroup::\n"
             );
         });
 
@@ -76,10 +74,9 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10" +
+                "::endgroup::\n"
             );
         });
     });
@@ -112,10 +109,9 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::endgroup::\n"
             );
         });
     });
@@ -163,11 +159,10 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14\n" +
+                "::endgroup::\n"
             );
         });
     });
@@ -220,13 +215,12 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10
-                ::endgroup::
-                ::group::bar.js
-                ::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::endgroup::\n" +
+                "::group::bar.js\n" +
+                "::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14\n" +
+                "::endgroup::\n"
             );
         });
     });
@@ -248,10 +242,9 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                `::group::foo.js
-                ::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1C1
-                ::endgroup::
-                `
+                "::group::foo.js\n" +
+                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1C1\n" +
+                "::endgroup::\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -53,7 +53,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
                 "::endgroup::\n"
             );
         });
@@ -64,7 +64,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
                 "::endgroup::\n"
             );
         });
@@ -75,7 +75,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
                 "::endgroup::\n"
             );
         });
@@ -110,7 +110,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
                 "::endgroup::\n"
             );
         });
@@ -160,8 +160,8 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
-                "::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
+                "::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6:C14\n" +
                 "::endgroup::\n"
             );
         });
@@ -216,10 +216,10 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5C10\n" +
+                "::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. | L5:C10\n" +
                 "::endgroup::\n" +
                 "::group::bar.js\n" +
-                "::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6C14\n" +
+                "::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. | L6:C14\n" +
                 "::endgroup::\n"
             );
         });
@@ -243,7 +243,7 @@ describe("formatter:github", function () {
             assert.equal(
                 result,
                 "::group::foo.js\n" +
-                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1C1\n" +
+                "::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. | L1:C1\n" +
                 "::endgroup::\n"
             );
         });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -52,7 +52,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
+                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
             );
         });
 
@@ -61,7 +61,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
+                "foo.js\n::warning file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
             );
         });
 
@@ -70,7 +70,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
+                "foo.js\n::notice file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
             );
         });
     });
@@ -103,7 +103,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\n"
+                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n"
             );
         });
     });
@@ -151,7 +151,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\nfoo.js: line=6, col=14\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar.\n"
+                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\n::warning file=foo.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14\n"
             );
         });
     });
@@ -204,7 +204,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=5, col=10\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo.\nbar.js: line=6, col=14\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar.\n"
+                "foo.js\n::error file=foo.js,line=5,endLine=5,col=10,endColumn=12,title=TextLint [foo]::Unexpected foo. @ L5C10\nbar.js\n::warning file=bar.js,line=6,endLine=6,col=14,endColumn=16,title=TextLint [bar]::Unexpected bar. @ L6C14\n"
             );
         });
     });
@@ -226,7 +226,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js: line=1, col=1\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js.\n"
+                "foo.js\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @L1C1\n"
             );
         });
     });

--- a/packages/@textlint/linter-formatter/test/formatters/github.test.ts
+++ b/packages/@textlint/linter-formatter/test/formatters/github.test.ts
@@ -226,7 +226,7 @@ describe("formatter:github", function () {
             const result = formatter(code);
             assert.equal(
                 result,
-                "foo.js\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @L1C1\n"
+                "foo.js\n::error file=foo.js,line=1,endLine=1,col=1,endColumn=1,title=TextLint::Couldn't find foo.js. @ L1C1\n"
             );
         });
     });


### PR DESCRIPTION
This groups the logs based on file just like the stylish formatter. This is so that when using the github format you can see what the messages refer to without needing to check annotation.

The current scenario is
![image](https://github.com/user-attachments/assets/da1b92d4-d750-4b16-a19f-ff8613292bf8)
