### PR TITLE
feat(textlint): add --cache-strategy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Specifying rules and plugins:
 Caching:
   --cache                     Only check changed files - default: false
   --cache-location path::String  Path to the cache file or directory - default: .textlintcache
-  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: content
+  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: metadata
 
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Specifying rules and plugins:
 Caching:
   --cache                     Only check changed files - default: false
   --cache-location path::String  Path to the cache file or directory - default: .textlintcache
+  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: content
 
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,7 @@ Specifying rules and plugins:
 Caching:
   --cache                     Only check changed files - default: false
   --cache-location path::String  Path to the cache file or directory - default: .textlintcache
+  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: content
 
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
@@ -102,6 +103,19 @@ You can enable it with the `--cache` option.
 
 ```bash
 $ textlint --cache README.md
+```
+
+You can specify the cache strategy with `--cache-strategy` option:
+
+- `content` (default): Use file content hash to detect changes. This is accurate and works in CI environments.
+- `metadata`: Use file metadata (mtime and size) to detect changes. This is faster but not reliable in CI.
+
+```bash
+# Use content hash (default, CI-safe)
+$ textlint --cache --cache-strategy content README.md
+
+# Use metadata (fast, local only)
+$ textlint --cache --cache-strategy metadata README.md
 ```
 
 If you want to clear the cache, you can use the `--no-cache` option or just remove `--cache` option.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ Specifying rules and plugins:
 Caching:
   --cache                     Only check changed files - default: false
   --cache-location path::String  Path to the cache file or directory - default: .textlintcache
-  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: content
+  --cache-strategy String     Strategy for detecting changed files - either: metadata or content - default: metadata
 
 Experimental:
   --experimental              Enable experimental flag.Some feature use on experimental.
@@ -107,15 +107,15 @@ $ textlint --cache README.md
 
 You can specify the cache strategy with `--cache-strategy` option:
 
-- `content` (default): Use file content hash to detect changes. This is accurate and works in CI environments.
-- `metadata`: Use file metadata (mtime and size) to detect changes. This is faster but not reliable in CI.
+- `metadata` (default): Use file metadata (mtime and size) to detect changes. This is faster but not reliable in CI.
+- `content`: Use file content hash to detect changes. This is accurate and works in CI environments.
 
 ```bash
-# Use content hash (default, CI-safe)
-$ textlint --cache --cache-strategy content README.md
-
-# Use metadata (fast, local only)
+# Use metadata (default, fast, local only)
 $ textlint --cache --cache-strategy metadata README.md
+
+# Use content hash (CI-safe)
+$ textlint --cache --cache-strategy content README.md
 ```
 
 If you want to clear the cache, you can use the `--no-cache` option or just remove `--cache` option.

--- a/packages/textlint/src/cli.ts
+++ b/packages/textlint/src/cli.ts
@@ -140,6 +140,7 @@ export const cli = {
         const linter = createLinter({
             cache: cliOptions.cache,
             cacheLocation: cliOptions.cacheLocation,
+            cacheStrategy: cliOptions.cacheStrategy,
             quiet: cliOptions.quiet,
             ignoreFilePath: cliOptions.ignorePath,
             descriptor

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -71,7 +71,7 @@ const createExecutor = async (options: CreateLinterOptions): Promise<ExecuteFile
             cache: options.cache ?? false,
             cacheLocation: options.cacheLocation ?? path.resolve(process.cwd(), ".textlintcache"),
             hash: await createHashForDescriptor(options.descriptor),
-            cacheStrategy: options.cacheStrategy ?? "content"
+            cacheStrategy: options.cacheStrategy ?? "metadata"
         });
         executeFileBackerManager.add(cacheBaker);
     }

--- a/packages/textlint/src/createLinter.ts
+++ b/packages/textlint/src/createLinter.ts
@@ -43,6 +43,7 @@ export type CreateLinterOptions = {
     quiet?: boolean;
     cache?: boolean;
     cacheLocation?: string;
+    cacheStrategy?: "metadata" | "content";
     /**
      * The current working directory
      */
@@ -69,7 +70,8 @@ const createExecutor = async (options: CreateLinterOptions): Promise<ExecuteFile
         const cacheBaker = new CacheBacker({
             cache: options.cache ?? false,
             cacheLocation: options.cacheLocation ?? path.resolve(process.cwd(), ".textlintcache"),
-            hash: await createHashForDescriptor(options.descriptor)
+            hash: await createHashForDescriptor(options.descriptor),
+            cacheStrategy: options.cacheStrategy ?? "content"
         });
         executeFileBackerManager.add(cacheBaker);
     }

--- a/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
+++ b/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
@@ -22,19 +22,23 @@ export type CacheBackerOptions = {
      * Config hash value
      */
     hash: string;
+    /**
+     * Cache strategy for detecting changed files.
+     * - "metadata": use file mtime and size (fast, not CI-safe)
+     * - "content": use file content hash (accurate, CI-safe)
+     */
+    cacheStrategy: "metadata" | "content";
 };
 type FileEntryCacheCustomData = {
     hashOfConfig: string;
 };
 
-const createFileEntryCache = (cacheLocation: string): FileEntryCache => {
+const createFileEntryCache = (cacheLocation: string, strategy: "metadata" | "content"): FileEntryCache => {
     const filename = path.basename(cacheLocation);
     const cacheDir = path.dirname(cacheLocation);
+    const useCheckSum = strategy === "content";
     try {
-        // use the metadata for cache instead of the file content
-        // TODO: if we want to reuse the cache in CI, we should use the file content cache and save relative path into the cache
-
-        return fileEntryCache.create(filename, cacheDir, false);
+        return fileEntryCache.create(filename, cacheDir, useCheckSum);
     } catch (error) {
         debug(`Failed to create fileEntryCache, filename: ${filename}, cacheDir: ${cacheDir}`, error);
         // remove old cache file and retry
@@ -43,7 +47,7 @@ const createFileEntryCache = (cacheLocation: string): FileEntryCache => {
         } catch (error) {
             debug(`Failed to remove cache file, filename: ${filename}, cacheDir: ${cacheDir}`, error);
         }
-        return fileEntryCache.create(filename, cacheDir, false);
+        return fileEntryCache.create(filename, cacheDir, useCheckSum);
     }
 };
 
@@ -53,7 +57,7 @@ export class CacheBacker implements AbstractBacker {
 
     constructor(private config: CacheBackerOptions) {
         this.isEnabled = config.cache;
-        this.fileCache = createFileEntryCache(config.cacheLocation);
+        this.fileCache = createFileEntryCache(config.cacheLocation, config.cacheStrategy);
     }
 
     /**

--- a/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
+++ b/packages/textlint/src/engine/execute-file-backers/cache-backer.ts
@@ -2,7 +2,6 @@
 "use strict";
 import fileEntryCache, { FileEntryCache } from "file-entry-cache";
 import debug0 from "debug";
-import path from "node:path";
 import fs from "node:fs";
 import { AbstractBacker } from "./abstruct-backer.js";
 import { TextlintResult } from "@textlint/kernel";
@@ -34,20 +33,26 @@ type FileEntryCacheCustomData = {
 };
 
 const createFileEntryCache = (cacheLocation: string, strategy: "metadata" | "content"): FileEntryCache => {
-    const filename = path.basename(cacheLocation);
-    const cacheDir = path.dirname(cacheLocation);
     const useCheckSum = strategy === "content";
+    const createCache = (): FileEntryCache => {
+        const fileCache = fileEntryCache.createFromFile(cacheLocation, useCheckSum);
+        // file-entry-cache defaults `useModifiedTime` to true, but the "content" strategy must
+        // detect changes by content hash only. Comparing mtime would invalidate the whole cache
+        // in CI because checkout changes mtime while the content stays the same.
+        fileCache.useModifiedTime = !useCheckSum;
+        return fileCache;
+    };
     try {
-        return fileEntryCache.create(filename, cacheDir, useCheckSum);
+        return createCache();
     } catch (error) {
-        debug(`Failed to create fileEntryCache, filename: ${filename}, cacheDir: ${cacheDir}`, error);
+        debug(`Failed to create fileEntryCache, cacheLocation: ${cacheLocation}`, error);
         // remove old cache file and retry
         try {
-            fs.unlinkSync(path.join(cacheDir, filename));
+            fs.unlinkSync(cacheLocation);
         } catch (error) {
-            debug(`Failed to remove cache file, filename: ${filename}, cacheDir: ${cacheDir}`, error);
+            debug(`Failed to remove cache file, cacheLocation: ${cacheLocation}`, error);
         }
-        return fileEntryCache.create(filename, cacheDir, useCheckSum);
+        return createCache();
     }
 };
 

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -209,7 +209,7 @@ export const options = optionator({
         {
             option: "cache-strategy",
             type: "String",
-            default: "content",
+            default: "metadata",
             enum: ["metadata", "content"],
             description: "Strategy for detecting changed files.",
             example: "textlint --cache --cache-strategy content docs/"

--- a/packages/textlint/src/options.ts
+++ b/packages/textlint/src/options.ts
@@ -27,6 +27,7 @@ export type CliOptions = {
     textlintrc: boolean;
     cache: boolean;
     cacheLocation: string;
+    cacheStrategy: "metadata" | "content";
     // custom node_module directory
     // textlint load modules(rules/presets/plugins) from the base directory.
     rulesBaseDirectory?: string;
@@ -204,6 +205,14 @@ export const options = optionator({
             default: path.resolve(process.cwd(), ".textlintcache"),
             description: "Path to the cache file or directory.",
             example: 'textlint --cache --cache-location "/Users/user/.textlintcache" docs/'
+        },
+        {
+            option: "cache-strategy",
+            type: "String",
+            default: "content",
+            enum: ["metadata", "content"],
+            description: "Strategy for detecting changed files.",
+            example: "textlint --cache --cache-strategy content docs/"
         },
         {
             heading: "Experimental"

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -419,6 +419,52 @@ describe("cli-test", function () {
                 assert.strictEqual(result, 0);
             });
         });
+        describe("--cache-strategy", function () {
+            const ruleModuleName = "textlint-rule-no-todo";
+            // passing content for textlint-rule-no-todo; "todo:\n" is the same
+            // byte length but triggers the rule
+            const tmpFilePath = path.join(os.tmpdir(), "cache-strategy-test.md");
+            beforeEach(() => {
+                fs.copyFileSync(path.join(__dirname, "fixtures/test.md"), tmpFilePath);
+            });
+            afterEach(() => {
+                try {
+                    fs.unlinkSync(tmpFilePath);
+                } catch {
+                    // nope
+                }
+            });
+            it("should re-lint when content is changed but mtime/size are preserved with 'content' strategy", async function () {
+                const args = `--cache --cache-location "${cacheLocation}" --cache-strategy content --rule "${ruleModuleName}" ${tmpFilePath}`;
+                const first = await cli.execute(args);
+                assert.strictEqual(first, 0);
+                const stat = fs.statSync(tmpFilePath);
+                fs.writeFileSync(tmpFilePath, "todo:\n", "utf-8");
+                fs.utimesSync(tmpFilePath, stat.atime, stat.mtime);
+                const second = await cli.execute(args);
+                assert.strictEqual(second, 1);
+            });
+            it("should not re-lint when only content is changed but mtime/size are preserved with 'metadata' strategy", async function () {
+                const args = `--cache --cache-location "${cacheLocation}" --cache-strategy metadata --rule "${ruleModuleName}" ${tmpFilePath}`;
+                const first = await cli.execute(args);
+                assert.strictEqual(first, 0);
+                const stat = fs.statSync(tmpFilePath);
+                fs.writeFileSync(tmpFilePath, "todo:\n", "utf-8");
+                fs.utimesSync(tmpFilePath, stat.atime, stat.mtime);
+                const second = await cli.execute(args);
+                assert.strictEqual(second, 0);
+            });
+            it("should use 'content' strategy by default", async function () {
+                const args = `--cache --cache-location "${cacheLocation}" --rule "${ruleModuleName}" ${tmpFilePath}`;
+                const first = await cli.execute(args);
+                assert.strictEqual(first, 0);
+                const stat = fs.statSync(tmpFilePath);
+                fs.writeFileSync(tmpFilePath, "todo:\n", "utf-8");
+                fs.utimesSync(tmpFilePath, stat.atime, stat.mtime);
+                const second = await cli.execute(args);
+                assert.strictEqual(second, 1);
+            });
+        });
     });
     describe("--print-config", function () {
         it("should print current descriptor.toJSON()", function () {

--- a/packages/textlint/test/cli/cli.test.ts
+++ b/packages/textlint/test/cli/cli.test.ts
@@ -454,7 +454,7 @@ describe("cli-test", function () {
                 const second = await cli.execute(args);
                 assert.strictEqual(second, 0);
             });
-            it("should use 'content' strategy by default", async function () {
+            it("should use 'metadata' strategy by default", async function () {
                 const args = `--cache --cache-location "${cacheLocation}" --rule "${ruleModuleName}" ${tmpFilePath}`;
                 const first = await cli.execute(args);
                 assert.strictEqual(first, 0);
@@ -462,7 +462,7 @@ describe("cli-test", function () {
                 fs.writeFileSync(tmpFilePath, "todo:\n", "utf-8");
                 fs.utimesSync(tmpFilePath, stat.atime, stat.mtime);
                 const second = await cli.execute(args);
-                assert.strictEqual(second, 1);
+                assert.strictEqual(second, 0);
             });
         });
     });

--- a/packages/textlint/test/execute-file-backers/cache-backer.test.ts
+++ b/packages/textlint/test/execute-file-backers/cache-backer.test.ts
@@ -139,6 +139,45 @@ describe("CacheBacker", function () {
             });
         });
 
+        describe("when only mtime is changed", function () {
+            it("shouldExecute return false", async () => {
+                const testCacheDir = path.join(configDir, "content-mtime-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "content"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const testFilePath = path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md");
+
+                // Ensure the file exists and is stable
+                if (!fs.existsSync(testFilePath)) {
+                    throw new Error(`Test file does not exist: ${testFilePath}`);
+                }
+
+                const prevResult = { filePath: testFilePath, messages: [] };
+                // prev
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
+
+                // Change only mtime while content stays same (e.g. CI checkout updates mtime)
+                const stat = fs.statSync(testFilePath);
+                const changedAtime = new Date(stat.atime.getTime() + 5000);
+                const changedMtime = new Date(stat.mtime.getTime() + 5000);
+                fs.utimesSync(testFilePath, changedAtime, changedMtime);
+
+                // next - create new instance to simulate next run
+                const nextCacheBacker = new CacheBacker(config);
+                const shouldExecute = nextCacheBacker.shouldExecute({
+                    filePath: prevResult.filePath
+                });
+                // "content" strategy must detect changes by content hash, not mtime
+                assert.strictEqual(shouldExecute, false);
+            });
+        });
+
         describe("when previously have failure result", function () {
             it("shouldExecute return true even if content unchanged", () => {
                 const testCacheDir = path.join(configDir, "content-failure-test");

--- a/packages/textlint/test/execute-file-backers/cache-backer.test.ts
+++ b/packages/textlint/test/execute-file-backers/cache-backer.test.ts
@@ -17,59 +17,155 @@ describe("CacheBacker", function () {
     afterAll(function () {
         fs.rmSync(configDir, { recursive: true, force: true });
     });
-    describe("when previously have success result", function () {
-        it("shouldExecute return false", async () => {
-            const testCacheDir = path.join(configDir, "success-test");
-            fs.mkdirSync(testCacheDir, { recursive: true });
-            const config: CacheBackerOptions = {
-                cache: true,
-                cacheLocation: path.resolve(testCacheDir, ".cache"),
-                hash: "test-hash"
-            };
-            const cacheBacker = new CacheBacker(config);
-            const testFilePath = path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md");
 
-            // Ensure the file exists and is stable
-            if (!fs.existsSync(testFilePath)) {
-                throw new Error(`Test file does not exist: ${testFilePath}`);
-            }
+    describe("when cacheStrategy is 'metadata'", function () {
+        describe("when previously have success result", function () {
+            it("shouldExecute return false", async () => {
+                const testCacheDir = path.join(configDir, "metadata-success-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "metadata"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const testFilePath = path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md");
 
-            const prevResult = { filePath: testFilePath, messages: [] };
-            // prev
-            cacheBacker.didExecute({ result: prevResult });
-            cacheBacker.afterAll();
+                // Ensure the file exists and is stable
+                if (!fs.existsSync(testFilePath)) {
+                    throw new Error(`Test file does not exist: ${testFilePath}`);
+                }
 
-            // Small delay to ensure file system consistency
-            await new Promise((resolve) => setTimeout(resolve, 10));
+                const prevResult = { filePath: testFilePath, messages: [] };
+                // prev
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
 
-            // next - create new instance to simulate next run
-            const nextCacheBacker = new CacheBacker(config);
-            const shouldExecute = nextCacheBacker.shouldExecute({ filePath: prevResult.filePath });
-            // If file hasn't changed and config hash matches, should not execute (return false)
-            assert.ok(shouldExecute === false);
+                // Small delay to ensure file system consistency
+                await new Promise((resolve) => setTimeout(resolve, 10));
+
+                // next - create new instance to simulate next run
+                const nextCacheBacker = new CacheBacker(config);
+                const shouldExecute = nextCacheBacker.shouldExecute({
+                    filePath: prevResult.filePath
+                });
+                // If file hasn't changed and config hash matches, should not execute (return false)
+                assert.strictEqual(shouldExecute, false);
+            });
+        });
+
+        describe("when previously have failure result", function () {
+            it("shouldExecute return true", () => {
+                const testCacheDir = path.join(configDir, "metadata-failure-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "metadata"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const prevResult = {
+                    filePath: path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md"),
+                    messages: [{} as TextlintMessage, {} as TextlintMessage]
+                };
+                // prevTextlintMessage
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
+                // next
+                const shouldExecute = cacheBacker.shouldExecute({
+                    filePath: prevResult.filePath
+                });
+                assert.strictEqual(shouldExecute, true);
+            });
         });
     });
 
-    describe("when previously have failure result", function () {
-        it("shouldExecute return true", () => {
-            const testCacheDir = path.join(configDir, "failure-test");
-            fs.mkdirSync(testCacheDir, { recursive: true });
-            const config: CacheBackerOptions = {
-                cache: true,
-                cacheLocation: path.resolve(testCacheDir, ".cache"),
-                hash: "test-hash"
-            };
-            const cacheBacker = new CacheBacker(config);
-            const prevResult = {
-                filePath: path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md"),
-                messages: [{} as TextlintMessage, {} as TextlintMessage]
-            };
-            // prevTextlintMessage
-            cacheBacker.didExecute({ result: prevResult });
-            cacheBacker.afterAll();
-            // next
-            const shouldExecute = cacheBacker.shouldExecute({ filePath: prevResult.filePath });
-            assert.ok(shouldExecute);
+    describe("when cacheStrategy is 'content'", function () {
+        describe("when file content has not changed", function () {
+            it("shouldExecute return false", () => {
+                const testCacheDir = path.join(configDir, "content-success-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const tempFile = path.join(testCacheDir, "temp.md");
+                const initialContent = "Hello, world!\n";
+                fs.writeFileSync(tempFile, initialContent, "utf-8");
+
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "content"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const prevResult = { filePath: tempFile, messages: [] };
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
+
+                const nextCacheBacker = new CacheBacker(config);
+                const shouldExecute = nextCacheBacker.shouldExecute({
+                    filePath: tempFile
+                });
+                assert.strictEqual(shouldExecute, false);
+            });
+        });
+
+        describe("when file content has changed", function () {
+            it("shouldExecute return true", () => {
+                const testCacheDir = path.join(configDir, "content-changed-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const tempFile = path.join(testCacheDir, "temp.md");
+                const initialContent = "Hello, world!\n";
+                fs.writeFileSync(tempFile, initialContent, "utf-8");
+
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "content"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const prevResult = { filePath: tempFile, messages: [] };
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
+
+                fs.writeFileSync(tempFile, "Changed content!\n", "utf-8");
+
+                const nextCacheBacker = new CacheBacker(config);
+                const shouldExecute = nextCacheBacker.shouldExecute({
+                    filePath: tempFile
+                });
+                assert.strictEqual(shouldExecute, true);
+            });
+        });
+
+        describe("when previously have failure result", function () {
+            it("shouldExecute return true even if content unchanged", () => {
+                const testCacheDir = path.join(configDir, "content-failure-test");
+                fs.mkdirSync(testCacheDir, { recursive: true });
+                const tempFile = path.join(testCacheDir, "temp.md");
+                fs.writeFileSync(tempFile, "Hello, world!\n", "utf-8");
+
+                const config: CacheBackerOptions = {
+                    cache: true,
+                    cacheLocation: path.resolve(testCacheDir, ".cache"),
+                    hash: "test-hash",
+                    cacheStrategy: "content"
+                };
+                const cacheBacker = new CacheBacker(config);
+                const prevResult = {
+                    filePath: tempFile,
+                    messages: [{} as TextlintMessage]
+                };
+                cacheBacker.didExecute({ result: prevResult });
+                cacheBacker.afterAll();
+
+                const nextCacheBacker = new CacheBacker(config);
+                const shouldExecute = nextCacheBacker.shouldExecute({
+                    filePath: tempFile
+                });
+                assert.strictEqual(shouldExecute, true);
+            });
         });
     });
 
@@ -81,7 +177,8 @@ describe("CacheBacker", function () {
             const config: CacheBackerOptions = {
                 cache: true,
                 cacheLocation: cacheFilePath,
-                hash: "test-hash"
+                hash: "test-hash",
+                cacheStrategy: "metadata"
             };
             const cacheBacker = new CacheBacker(config);
             const filePath = path.resolve(process.cwd(), "test/execute-file-backers/fixtures/test.md");


### PR DESCRIPTION
Add `--cache-strategy` CLI option to control how textlint detects changed files when using `--cache`.

~~- `content` (default): use file content hash — accurate and CI-safe~~ (corrected: default is `metadata`, see below)

- `metadata` (default): use file mtime and size — fast but not reliable in CI
- `content`: use file content hash — accurate and CI-safe

Previously the cache was hardcoded to metadata-based detection via `file-entry-cache(useCheckSum=false)`.
The default stays `metadata` to keep backward compatibility for existing `--cache` users; switching the default to `content` would be a breaking change, so it is deferred to a major version.

Reference:
- [Prettier CLI --cache-strategy](https://prettier.io/docs/en/cli#--cache-strategy)
- [ESLint --cache-strategy](https://eslint.org/docs/latest/use/command-line-interface#--cache-strategy)

Refs #1327
