### PR TITLE
feat(textlint-plugin-markdown): add CJK-friendly emphasis and strikethrough support

### DIFF
--- a/packages/@textlint/markdown-to-ast/README.md
+++ b/packages/@textlint/markdown-to-ast/README.md
@@ -26,13 +26,13 @@ This library is a part of [textlint/textlint](https://github.com/textlint/textli
 
 ## Installation
 
-```
+```sh
 npm install @textlint/markdown-to-ast
 ```
 
 ## Usage
 
-```js
+```ts
 import { parse } from "@textlint/markdown-to-ast";
 
 const markdown = "It's a *text*";
@@ -139,11 +139,19 @@ const AST = parse(markdown);
 */
 ```
 
+To enable CJK-friendly emphasis and GFM strikethrough parsing, set `cjkFriendly` to `true`. This option is disabled by default.
+
+```ts
+const AST = parse("**このアスタリスクは強調記号として認識されず、そのまま表示されます。**この文のせいで。", {
+    cjkFriendly: true
+});
+```
+
 If you want to know real use-case, please see [textlint/textlint](https://github.com/textlint/textlint "textlint/textlint").
 
 ## Tests
 
-```
+```sh
 npm test
 ```
 

--- a/packages/@textlint/markdown-to-ast/README.md
+++ b/packages/@textlint/markdown-to-ast/README.md
@@ -139,12 +139,21 @@ const AST = parse(markdown);
 */
 ```
 
-To enable CJK-friendly emphasis and GFM strikethrough parsing, set `cjkFriendly` to `true`. This option is disabled by default.
+Enable `cjkFriendly` when parsing Markdown that uses CJK-friendly rules for emphasis and GFM strikethrough. Otherwise, keep the default `false` to use CommonMark and GFM parsing.
+
+When `cjkFriendly` is enabled, `parse()` returns AST nodes for emphasis and GFM strikethrough next to CJK text without spaces:
 
 ```ts
-const AST = parse("**このアスタリスクは強調記号として認識されず、そのまま表示されます。**この文のせいで。", {
-    cjkFriendly: true
-});
+const markdown = `**重要です。**次の文です。
+~~削除します。~~次の文です。
+
+**很重要。**下一句。
+~~删除。~~下一句。
+
+**중요합니다.**다음 문장입니다.
+~~삭제합니다.~~다음 문장입니다.`;
+
+const AST = parse(markdown, { cjkFriendly: true });
 ```
 
 If you want to know real use-case, please see [textlint/textlint](https://github.com/textlint/textlint "textlint/textlint").

--- a/packages/@textlint/markdown-to-ast/package.json
+++ b/packages/@textlint/markdown-to-ast/package.json
@@ -38,6 +38,8 @@
     "debug": "catalog:",
     "neotraverse": "catalog:",
     "remark-footnotes": "catalog:",
+    "remark-cjk-friendly": "catalog:",
+    "remark-cjk-friendly-gfm-strikethrough": "catalog:",
     "remark-frontmatter": "catalog:",
     "remark-gfm": "catalog:",
     "remark-parse": "catalog:",

--- a/packages/@textlint/markdown-to-ast/src/index.ts
+++ b/packages/@textlint/markdown-to-ast/src/index.ts
@@ -3,7 +3,7 @@ import type { TxtDocumentNode } from "@textlint/ast-node-types";
 import { ASTNodeTypes } from "@textlint/ast-node-types";
 import traverse from "neotraverse/legacy";
 import debug0 from "debug";
-import { parseMarkdown } from "./parse-markdown.js";
+import { parseMarkdown, type ParseMarkdownOptions } from "./parse-markdown.js";
 import { StructuredSource } from "structured-source";
 
 const debug = debug0("@textlint/markdown-to-ast");
@@ -167,8 +167,9 @@ function calculatePositionFromSiblings(
 /**
  * parse Markdown text and return ast mapped location info.
  * @param {string} text
+ * @param {ParseMarkdownOptions} options
  */
-export function parse(text: string): TxtDocumentNode {
+export function parse(text: string, options: ParseMarkdownOptions = {}): TxtDocumentNode {
     // remark-parse's AST does not consider BOM
     // AST's position does not +1 by BOM
     // So, just trim BOM and parse it for `raw` property
@@ -177,7 +178,7 @@ export function parse(text: string): TxtDocumentNode {
     // https://github.com/micromark/micromark/blob/0f19c1ac25964872a160d8b536878b125ddfe393/lib/preprocess.mjs#L29-L31
     const hasBOM = text.charCodeAt(0) === 0xfeff;
     const textWithoutBOM = hasBOM ? text.slice(1) : text;
-    const ast = parseMarkdown(textWithoutBOM);
+    const ast = parseMarkdown(textWithoutBOM, options);
     const source = new StructuredSource(textWithoutBOM);
 
     // Collect all nodes without position for advanced processing

--- a/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
+++ b/packages/@textlint/markdown-to-ast/src/parse-markdown.ts
@@ -1,9 +1,15 @@
 import { unified, type Processor } from "unified";
+import remarkCjkFriendly from "remark-cjk-friendly/parseOnly";
+import remarkCjkFriendlyGfmStrikethrough from "remark-cjk-friendly-gfm-strikethrough/parseOnly";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import frontmatter from "remark-frontmatter";
 import footnotes from "remark-footnotes";
 import type { Node } from "unist";
+
+export type ParseMarkdownOptions = {
+    cjkFriendly?: boolean;
+};
 
 // FIXME: Disable auto link literal transforms that break AST node
 // https://github.com/remarkjs/remark-gfm/issues/16
@@ -14,24 +20,32 @@ const disableGfmAutolinkLiteralTransforms = function (this: Processor): void {
     }
 };
 
-const remark = unified()
-    .use(remarkParse)
-    .use(frontmatter, [
-        "yaml",
-        "toml",
-        // Hexo style
-        { type: "json", fence: { open: ";;;", close: ";;;" } },
-        // 11ty style
-        { type: "json", fence: { open: "---json", close: "---" } },
-        // Hugo style
-        { type: "json", fence: { open: "{", close: "}" } }
-    ])
-    .use(remarkGfm)
-    .use(disableGfmAutolinkLiteralTransforms)
-    .use(footnotes, {
-        inlineNotes: true
-    });
+const createRemarkProcessor = (options: ParseMarkdownOptions) => {
+    const processor = unified()
+        .use(remarkParse)
+        .use(frontmatter, [
+            "yaml",
+            "toml",
+            // Hexo style
+            { type: "json", fence: { open: ";;;", close: ";;;" } },
+            // 11ty style
+            { type: "json", fence: { open: "---json", close: "---" } },
+            // Hugo style
+            { type: "json", fence: { open: "{", close: "}" } }
+        ])
+        .use(remarkGfm)
+        .use(disableGfmAutolinkLiteralTransforms)
+        .use(footnotes, {
+            inlineNotes: true
+        })
+        .use(remarkCjkFriendly, options.cjkFriendly === true)
+        .use(remarkCjkFriendlyGfmStrikethrough, options.cjkFriendly === true);
+    return processor;
+};
 
-export const parseMarkdown = (text: string): Node => {
-    return remark.parse(text);
+const remarkProcessor = createRemarkProcessor({});
+const cjkFriendlyRemarkProcessor = createRemarkProcessor({ cjkFriendly: true });
+
+export const parseMarkdown = (text: string, options: ParseMarkdownOptions = {}): Node => {
+    return (options.cjkFriendly ? cjkFriendlyRemarkProcessor : remarkProcessor).parse(text);
 };

--- a/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
+++ b/packages/@textlint/markdown-to-ast/test/markdown-parser.test.ts
@@ -398,4 +398,53 @@ describe("markdown-parser", function () {
             shouldHaveImplementTxtNode(node, rawValue);
         });
     });
+
+    describe("Parser extensions", function () {
+        describe("cjkFriendly", function () {
+            describe("emphasis", function () {
+                const markedText = "**このアスタリスクは強調記号として認識されず、そのまま表示されます。**";
+                const trailingText = "この文のせいで。";
+                const input = `${markedText}${trailingText}`;
+
+                it("should be disabled by default", function () {
+                    const node = findFirstTypedNode(parse(input), Syntax.Str, input);
+                    shouldHaveImplementTxtNode(node, input);
+                });
+
+                it("should be disabled when cjkFriendly is false", function () {
+                    assert.deepStrictEqual(parse(input, { cjkFriendly: false }), parse(input));
+                });
+
+                it("should parse CJK-adjacent emphasis when enabled", function () {
+                    const ast = parse(input, { cjkFriendly: true });
+                    const strongNode = findFirstTypedNode(ast, Syntax.Strong, markedText);
+                    const trailingNode = findFirstTypedNode(ast, Syntax.Str, trailingText);
+                    shouldHaveImplementInlineTxtNode(strongNode, markedText, input);
+                    shouldHaveImplementInlineTxtNode(trailingNode, trailingText, input);
+                });
+            });
+
+            describe("GFM strikethrough", function () {
+                const leadingText = "a";
+                const markedText = "~~a()~~";
+                const trailingText = "あ";
+                const input = `${leadingText}${markedText}${trailingText}`;
+
+                it("should be disabled by default", function () {
+                    const node = findFirstTypedNode(parse(input), Syntax.Str, input);
+                    shouldHaveImplementTxtNode(node, input);
+                });
+
+                it("should parse CJK-adjacent strikethrough when enabled", function () {
+                    const ast = parse(input, { cjkFriendly: true });
+                    const leadingNode = findFirstTypedNode(ast, Syntax.Str, leadingText);
+                    const deleteNode = findFirstTypedNode(ast, Syntax.Delete, markedText);
+                    const trailingNode = findFirstTypedNode(ast, Syntax.Str, trailingText);
+                    shouldHaveImplementInlineTxtNode(leadingNode, leadingText, input);
+                    shouldHaveImplementInlineTxtNode(deleteNode, markedText, input);
+                    shouldHaveImplementInlineTxtNode(trailingNode, trailingText, input);
+                });
+            });
+        });
+    });
 });

--- a/packages/@textlint/textlint-plugin-markdown/README.md
+++ b/packages/@textlint/textlint-plugin-markdown/README.md
@@ -4,46 +4,71 @@ Markdown support for [textlint](https://github.com/textlint/textlint "textlint")
 
 ## Installation
 
-    npm install @textlint/textlint-plugin-markdown
+```sh
+npm install @textlint/textlint-plugin-markdown
+```
 
 ## Usage
 
 Built-in support on textlint.
 No need configuration.
 
-------
+---
 
 Following config is set by default.
 
-```
+```json
 {
-    "plugins": {
-        "@textlint/markdown": true
-    }
+  "plugins": {
+    "@textlint/markdown": true
+  }
 }
 ```
 
 ## Options
 
-- `extensions`: `string[]`
-    - Additional file extensions for markdown
-    
-For example, if you want to treat [MDX](https://github.com/mdx-js/mdx) as markdown, put following config to `.textlintrc`    
+- `extensions`: `string[]` (default: `[]`)
+  - Additional file extensions for markdown.
+- `cjkFriendly`: `boolean` (default: `false`)
+  - Enable CJK-friendly emphasis and GFM strikethrough parsing with the [`remark-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly) plugins.
 
-```json5
+For example, if you want to treat [MDX](https://github.com/mdx-js/mdx) as markdown, put following config to `.textlintrc`:
+
+```json
 {
-    "plugins": {
-        "@textlint/markdown": {
-            "extensions": [".mdx"]
-        }
+  "plugins": {
+    "@textlint/markdown": {
+      "extensions": [".mdx"]
     }
+  }
 }
 ```
 
+For example, the following Markdown is parsed as emphasis and strikethrough when `cjkFriendly` is enabled:
+
+```md
+**このアスタリスクは強調記号として認識されず、そのまま表示されます。**この文のせいで。
+
+**该星号不会被识别，而是直接显示。**这是因为它没有被识别为强调符号。
+
+**이 별표는 강조 표시로 인식되지 않고 그대로 표시됩니다(이 괄호 때문에)**이 문장 때문에.
+```
+
+```json
+{
+  "plugins": {
+    "@textlint/markdown": {
+      "cjkFriendly": true
+    }
+  }
+}
+```
 
 ## Tests
 
-    npm test
+```sh
+npm test
+```
 
 ## Contributing
 

--- a/packages/@textlint/textlint-plugin-markdown/README.md
+++ b/packages/@textlint/textlint-plugin-markdown/README.md
@@ -44,14 +44,19 @@ For example, if you want to treat [MDX](https://github.com/mdx-js/mdx) as markdo
 }
 ```
 
-For example, the following Markdown is parsed as emphasis and strikethrough when `cjkFriendly` is enabled:
+Enable `cjkFriendly` when the target Markdown renderer supports CJK-friendly parsing rules for emphasis and GFM strikethrough, such as GitLab Flavored Markdown, Rspress, or VitePress. Otherwise, keep the default `false` to match CommonMark and GFM parsing.
+
+When `cjkFriendly` is enabled, textlint recognizes emphasis and GFM strikethrough next to CJK text without spaces:
 
 ```md
-**このアスタリスクは強調記号として認識されず、そのまま表示されます。**この文のせいで。
+**重要です。**次の文です。
+~~削除します。~~次の文です。
 
-**该星号不会被识别，而是直接显示。**这是因为它没有被识别为强调符号。
+**很重要。**下一句。
+~~删除。~~下一句。
 
-**이 별표는 강조 표시로 인식되지 않고 그대로 표시됩니다(이 괄호 때문에)**이 문장 때문에.
+**중요합니다.**다음 문장입니다.
+~~삭제합니다.~~다음 문장입니다.
 ```
 
 ```json

--- a/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.ts
+++ b/packages/@textlint/textlint-plugin-markdown/src/MarkdownProcessor.ts
@@ -24,9 +24,10 @@ export class MarkdownProcessor {
         preProcess: (text: string, _filePath?: string) => TextlintPluginPreProcessResult;
         postProcess: (messages: TextlintMessage[], filePath?: string) => TextlintPluginPostProcessResult;
     } {
+        const cjkFriendly = this.config.cjkFriendly === true;
         return {
             preProcess(text: string, _filePath?: string) {
-                return parse(text);
+                return parse(text, { cjkFriendly });
             },
             postProcess(messages: TextlintMessage[], filePath?: string) {
                 return {

--- a/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
+++ b/packages/@textlint/textlint-plugin-markdown/test/MarkdownProcessor.test.ts
@@ -3,6 +3,7 @@
 import assert from "node:assert";
 import { describe, it } from "vitest";
 import { TextlintKernel, TextlintPluginOptions } from "@textlint/kernel";
+import { parse } from "@textlint/markdown-to-ast";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import noTodo from "textlint-rule-no-todo";
@@ -57,6 +58,19 @@ describe("MarkdownPlugin", function () {
                 assert(results.messages.length > 0);
                 assert(results.filePath === fixturePath);
             });
+        });
+    });
+    describe("cjkFriendly", function () {
+        const input = "**このアスタリスクは強調記号として認識されず、そのまま表示されます。**この文のせいで。";
+
+        it("should be disabled by default", function () {
+            const processor = new MarkdownPlugin.Processor().processor(".md");
+            assert.deepStrictEqual(processor.preProcess(input), parse(input));
+        });
+
+        it("should pass the option to the Markdown parser", function () {
+            const processor = new MarkdownPlugin.Processor({ cjkFriendly: true }).processor(".md");
+            assert.deepStrictEqual(processor.preProcess(input), parse(input, { cjkFriendly: true }));
         });
     });
     describe("When no file path", function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,12 @@ catalogs:
     read-package-up:
       specifier: ^11.0.0
       version: 11.0.0
+    remark-cjk-friendly:
+      specifier: ^2.3.1
+      version: 2.3.1
+    remark-cjk-friendly-gfm-strikethrough:
+      specifier: ^2.3.1
+      version: 2.3.1
     remark-footnotes:
       specifier: ^3.0.0
       version: 3.0.0
@@ -805,6 +811,12 @@ importers:
       neotraverse:
         specifier: 'catalog:'
         version: 0.6.18
+      remark-cjk-friendly:
+        specifier: 'catalog:'
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
+      remark-cjk-friendly-gfm-strikethrough:
+        specifier: 'catalog:'
+        version: 2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5)
       remark-footnotes:
         specifier: 'catalog:'
         version: 3.0.0
@@ -5577,6 +5589,10 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -6709,6 +6725,24 @@ packages:
   mdast-util-to-hast@13.2.0:
     resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
 
+  mdast-util-to-markdown-cjk-friendly-gfm-strikethrough@1.0.0:
+    resolution: {integrity: sha512-1ePVfB4P/vz3xSsm6H3D32r6VYGErxclnuLLFK02/2ReF+UdEKm7caulK6Vm0LBIp5gPRtB2Z1OYDznCkX3k2w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': '*'
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
+  mdast-util-to-markdown-cjk-friendly@1.0.0:
+    resolution: {integrity: sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': '*'
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
   mdast-util-to-markdown@0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
 
@@ -6766,6 +6800,35 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-cjk-friendly-gfm-strikethrough@2.0.1:
+    resolution: {integrity: sha512-wVC0zwjJNqQeX+bb07YTPu/CvSAyCTafyYb7sMhX1r62/Lw5M/df3JyYaANyp8g15c1ypJRFSsookTqA1IDsUg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly-util@3.0.1:
+    resolution: {integrity: sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark-util-types: '*'
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
+
+  micromark-extension-cjk-friendly@2.0.1:
+    resolution: {integrity: sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      micromark: ^4.0.0
+      micromark-util-types: ^2.0.0
+    peerDependenciesMeta:
+      micromark-util-types:
+        optional: true
 
   micromark-extension-directive@3.0.2:
     resolution: {integrity: sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==}
@@ -8267,6 +8330,26 @@ packages:
   relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
+
+  remark-cjk-friendly-gfm-strikethrough@2.3.1:
+    resolution: {integrity: sha512-JE3TGgouk/sy92SemNMEUhO5mNP4on04cmzOV3s3R5Dbk160ewmpM4tgPiinKKvoJ5UW2fTu7FOYsjVbusSA9w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
+
+  remark-cjk-friendly@2.3.1:
+    resolution: {integrity: sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
+    peerDependenciesMeta:
+      '@types/mdast':
+        optional: true
 
   remark-directive@3.0.1:
     resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
@@ -15189,6 +15272,8 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
@@ -16554,6 +16639,28 @@ snapshots:
       unist-util-visit: 5.0.0
       vfile: 6.0.3
 
+  mdast-util-to-markdown-cjk-friendly-gfm-strikethrough@1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2):
+    dependencies:
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark-util-types
+      - supports-color
+
+  mdast-util-to-markdown-cjk-friendly@1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2):
+    dependencies:
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark-util-types
+
   mdast-util-to-markdown@0.6.5:
     dependencies:
       '@types/unist': 2.0.11
@@ -16651,6 +16758,38 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-gfm-strikethrough@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      get-east-asian-width: 1.6.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly-util@3.0.1(micromark-util-types@2.0.2):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-cjk-friendly@2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2):
+    dependencies:
+      devlop: 1.1.0
+      micromark: 4.0.2
+      micromark-extension-cjk-friendly-util: 3.0.1(micromark-util-types@2.0.2)
+      micromark-util-chunked: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+    optionalDependencies:
       micromark-util-types: 2.0.2
 
   micromark-extension-directive@3.0.2:
@@ -18459,6 +18598,29 @@ snapshots:
       - supports-color
 
   relateurl@0.2.7: {}
+
+  remark-cjk-friendly-gfm-strikethrough@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      mdast-util-to-markdown-cjk-friendly-gfm-strikethrough: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
+      micromark-extension-cjk-friendly-gfm-strikethrough: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
+      - supports-color
+
+  remark-cjk-friendly@2.3.1(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):
+    dependencies:
+      mdast-util-to-markdown-cjk-friendly: 1.0.0(@types/mdast@4.0.4)(micromark-util-types@2.0.2)
+      micromark-extension-cjk-friendly: 2.0.1(micromark-util-types@2.0.2)(micromark@4.0.2)
+      unified: 11.0.5
+    optionalDependencies:
+      '@types/mdast': 4.0.4
+    transitivePeerDependencies:
+      - micromark
+      - micromark-util-types
 
   remark-directive@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,8 @@ catalog:
   react-dom: "^19.2.8"
   read-package-up: "^11.0.0"
   remark-footnotes: "^3.0.0"
+  remark-cjk-friendly: "^2.3.1"
+  remark-cjk-friendly-gfm-strikethrough: "^2.3.1"
   remark-frontmatter: "^5.0.0"
   remark-gfm: "^4.0.1"
   remark-parse: "^11.0.0"


### PR DESCRIPTION
Related to https://github.com/textlint-ja/textlint-rule-preset-ja-spacing/issues/132.

This PR adds an opt-in `cjkFriendly` option to `@textlint/textlint-plugin-markdown` and `@textlint/markdown-to-ast`.

CommonMark's delimiter rules can prevent emphasis from being recognized in Chinese, Japanese, and Korean text when punctuation appears immediately inside the closing delimiter and a non-space character follows it. The same delimiter behavior also applies to GFM strikethrough. This option allows textlint to parse these cases using the [`remark-cjk-friendly`](https://github.com/tats-u/markdown-cjk-friendly) plugins. CJK-friendly emphasis is supported by several widely used Markdown implementations and documentation frameworks, including GitLab Flavored Markdown, Rspress, and VitePress.

The option is disabled by default, so existing Markdown parsing behavior is preserved unless `cjkFriendly` is explicitly set to `true`.