### PR TITLE
fix(config-loader): load sharable configs

### DIFF
--- a/packages/@textlint/config-loader/src/config-loader.ts
+++ b/packages/@textlint/config-loader/src/config-loader.ts
@@ -203,9 +203,20 @@ export const loadConfig = async (options: TextlintConfigLoaderOptions): Promise<
  */
 export const loadRawConfig = async (options: TextlintConfigLoaderOptions): Promise<TextlintConfigLoaderRawResult> => {
     try {
+        let configFileName = options.configFilePath;
+        if (configFileName) {
+            const moduleResolver = new TextLintModuleResolver({
+                rulesBaseDirectory: options.node_modulesDir
+            });
+            try {
+                configFileName = moduleResolver.resolveConfigPackageName(configFileName);
+            } catch {
+                // Fall back to loading configFileName as a file path.
+            }
+        }
         const results = rcFile<TextlintRcConfig>("textlint", {
             cwd: options.cwd,
-            configFileName: options.configFilePath,
+            configFileName,
             packageJSON: {
                 fieldName: "textlint"
             }

--- a/packages/@textlint/config-loader/src/config-loader.ts
+++ b/packages/@textlint/config-loader/src/config-loader.ts
@@ -210,7 +210,10 @@ export const loadRawConfig = async (options: TextlintConfigLoaderOptions): Promi
             });
             try {
                 configFileName = moduleResolver.resolveConfigPackageName(configFileName);
-            } catch {
+            } catch (error) {
+                if (!(error instanceof ReferenceError)) {
+                    throw error;
+                }
                 // Fall back to loading configFileName as a file path.
             }
         }

--- a/packages/@textlint/config-loader/test/index.test.ts
+++ b/packages/@textlint/config-loader/test/index.test.ts
@@ -148,4 +148,20 @@ describe("@textlint/config-loader", () => {
             });
         });
     });
+    describe("when a sharable config module is specified", () => {
+        it("loads a scoped package subpath", async () => {
+            const result = await loadRawConfig({
+                configFilePath: "@acme/textlint/default",
+                node_modulesDir: modulesDir
+            });
+
+            assert.ok(result.ok);
+            assert.deepStrictEqual(result.rawConfig, {
+                rules: {
+                    "shared-rule": true
+                }
+            });
+            assert.strictEqual(result.configFilePath, path.join(modulesDir, "@acme", "textlint", "default.js"));
+        });
+    });
 });

--- a/packages/@textlint/config-loader/test/index.test.ts
+++ b/packages/@textlint/config-loader/test/index.test.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
-import { describe, it } from "vitest";
+import { describe, it, vi } from "vitest";
 import * as path from "node:path";
 import * as assert from "node:assert";
 import { loadRawConfig, loadPackagesFromRawConfig } from "../src/index.js";
+import { TextLintModuleResolver } from "../src/textlint-module-resolver.js";
 
 const currentDir = __dirname;
 const fixturesDir = path.join(currentDir, "snapshots");
@@ -162,6 +163,29 @@ describe("@textlint/config-loader", () => {
                 }
             });
             assert.strictEqual(result.configFilePath, path.join(modulesDir, "@acme", "textlint", "default.js"));
+        });
+
+        it("reports unexpected module resolution errors", async () => {
+            const resolutionError = new TypeError("unexpected resolver failure");
+            const resolveSpy = vi
+                .spyOn(TextLintModuleResolver.prototype, "resolveConfigPackageName")
+                .mockImplementationOnce(() => {
+                    throw resolutionError;
+                });
+
+            try {
+                const result = await loadRawConfig({
+                    configFilePath: "example-config",
+                    node_modulesDir: modulesDir
+                });
+
+                assert.strictEqual(result.ok, false);
+                if (!result.ok) {
+                    assert.strictEqual(result.error.errors[0], resolutionError);
+                }
+            } finally {
+                resolveSpy.mockRestore();
+            }
         });
     });
 });

--- a/packages/@textlint/config-loader/test/modules_fixtures/@acme/textlint/default.js
+++ b/packages/@textlint/config-loader/test/modules_fixtures/@acme/textlint/default.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        "shared-rule": true
+    }
+};

--- a/packages/@textlint/config-loader/test/modules_fixtures/@acme/textlint/package.json
+++ b/packages/@textlint/config-loader/test/modules_fixtures/@acme/textlint/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "@acme/textlint",
+    "private": true,
+    "type": "commonjs"
+}


### PR DESCRIPTION
## Problem

The documented `--config` option cannot load an installed sharable config such as `@acme/textlint/default`. The config loader sends the module specifier to its file loader, even though the existing config-package resolver can resolve it.

## Fix

Resolve an explicitly supplied config through `TextLintModuleResolver` first, then retain the existing file-path fallback when it is not a module. A scoped package-subpath fixture covers the reported form.

## Tests

- `pnpm --filter @textlint/config-loader exec vitest run test/index.test.ts -t 'loads a scoped package subpath'` — failed before the fix and passed after it
- `pnpm --filter @textlint/config-loader test` — passed, 12 tests
- `pnpm --filter @textlint/config-loader run build` — passed
- `pnpm run test` — passed
- `node -e 'const assert=require("node:assert/strict"); const path=require("node:path"); const {loadRawConfig}=require("./packages/@textlint/config-loader/lib/src/index.js"); (async()=>{ const modules=path.resolve("packages/@textlint/config-loader/test/modules_fixtures"); const explicit=path.resolve("packages/@textlint/config-loader/test/snapshots/rules/input.json"); const fileResult=await loadRawConfig({configFilePath:explicit,node_modulesDir:modules}); assert.equal(fileResult.ok,true); const missingResult=await loadRawConfig({configFilePath:"definitely-missing-config",node_modulesDir:modules}); assert.equal(missingResult.ok,false); console.log("explicit file fallback: ok; missing config error: ok"); })().catch(error=>{console.error(error);process.exitCode=1;});'` — passed
- `git diff HEAD^ HEAD --check` — passed

## Compatibility

This restores the documented package-resolution path while preserving explicit file loading and existing missing-config errors. It adds no dependency or public type change.

## Related issue

Fixes #1896
