### PR TITLE
docs(contributing): replace eslint with oxlint

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -141,18 +141,18 @@ We are migrating entire codes to TypeScript.
 
 ##### Linting and Style
 
-This repository uses [ESLint](https://eslint.org/) for JavaScript linter and [Prettier](https://prettier.io/) for code formatter. We use [`lint-staged`](https://www.npmjs.com/package/lint-staged) and [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to make coding style consistent before commit, but if you have your own Git hooks locally, these setup doesn't work. In such case, please run ESLint and Prettier manually as below after making changes.
+This repository uses [oxlint](https://oxc.rs/docs/guide/usage/linter) for JavaScript and TypeScript linter and [Prettier](https://prettier.io/) for code formatter. We use [`lint-staged`](https://www.npmjs.com/package/lint-staged) and [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to make coding style consistent before commit, but if you have your own Git hooks locally, these setup doesn't work. In such case, please run oxlint and Prettier manually as below after making changes.
 
-- Run ESLint:
+- Run oxlint:
 
     ```sh
-    $ pnpm run eslint
+    $ pnpm run lint
     ```
 
-- Run ESLint with [`--fix`](https://eslint.org/docs/user-guide/command-line-interface#--fix) feature to fix some wrong style automatically:
+- Run oxlint with [`--fix`](https://oxc.rs/docs/guide/usage/linter/automatic-fixes.html) feature to fix some wrong style automatically:
 
     ```sh
-    $ pnpm run eslint:fix
+    $ pnpm run lint:fix
     ```
 
 - Run Prettier to reformat code:
@@ -235,7 +235,7 @@ We care version number while releasing packages to npm registry so you should no
         - It might break type interface(`.d.ts`)
     - A new formatter is created
 - Major release (break your lint build)
-    - A new option to an existing rule that results in ESLint reporting more errors by default
+    - A new option to an existing rule that results in textlint reporting more errors by default
     - An existing formatter is removed
     - Part of the public API is removed or changed in an incompatible way
 


### PR DESCRIPTION
## Problem

The contribution guideline still tells contributors to lint with ESLint:

```sh
$ pnpm run eslint
$ pnpm run eslint:fix
```

Neither script exists. The repository migrated to oxlint in #1992, and the root `package.json` now defines `lint` / `lint:fix`. Someone following the "Linting and Style" section hits a "Missing script" error on their first lint run.

`docs/CONTRIBUTING.md` was last touched in #1538, before that migration.

## Changes

Documentation only — no code or script changes.

- Point the "Linting and Style" section at oxlint and the actual `lint` / `lint:fix` scripts
- Update the `--fix` link to oxlint's "Automatic fixes" page
- Fix a stale copy-paste in the Versioning section: the major release bullet read "results in **ESLint** reporting more errors by default" where it means textlint

## Verification

- Checked every other command in `docs/CONTRIBUTING.md` against the root `package.json`. `build`, `website`, `format`, `test`, `test:examples`, `test:integration`, `test:docs`, `test:all`, `update:projectReferences` and `test:projectReferences` all still exist — only the two eslint scripts were stale.
- Both new oxlint URLs return HTTP 200.
- `pnpm install` and `pnpm run build` succeed.
- textlint reports no errors on the changed file.

One note on that last point: to run textlint over `docs/` at all I had to disable the `prh` and `eslint` rules, because on current `master` both fail to load — `website/prh.yml` and `website/.eslintrc.js` no longer exist, and `textlint-rule-eslint@4.0.2` rejects `eslint@9` (`Unknown options: useEslintrc`). This is pre-existing and unrelated to this PR. Happy to open a separate issue with the details if that is useful.

Ref. #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmXjszHU9gWCDtWbN6WMTz
