### PR TITLE
docs: fix broken links and images in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ These modules are useful integration with textlint.
 
 | Package                                  | Version                                  | Description              |
 | :--------------------------------------- | :--------------------------------------- | :----------------------- |
-| [`gulp-textlint`](./packages/gulp-textlint) | [![npm](https://img.shields.io/npm/v/gulp-textlint.svg?style=flat-square)](https://www.npmjs.com/package/gulp-textlint) | gulp plugin for textlint |
+| [`gulp-textlint`](https://github.com/textlint/gulp-textlint) | [![npm](https://img.shields.io/npm/v/gulp-textlint.svg?style=flat-square)](https://www.npmjs.com/package/gulp-textlint) | gulp plugin for textlint |
 
 
 ### Internal

--- a/docs/rule-advanced.md
+++ b/docs/rule-advanced.md
@@ -81,7 +81,7 @@ is described as `Paragraph.children = ["Str"]`
 :information_source: Info:
 
 - Please see [txtnode.md](./txtnode.md) for Abstract Syntax Tree details.
-- Use [Markdown-to-AST demo](http://azu.github.io/markdown-to-ast/example/)
+- Use [AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint")
 
 But, Following `Paragraph` node contain `Code` node. 
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -82,8 +82,6 @@ In textlint@11.1.0<=, you had to write `[Syntax.Document + ":exit"]`.
 
 [visualize-txt-traverse](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse") help you better understand this traversing.
 
-[![gif visualize-txt-traverse](https://gyazo.com/155c68f0f9ff35e0a549d655a787c01e.gif)](https://github.com/azu/visualize-txt-traverse "azu/visualize-txt-traverse")
-
 [AST explorer for textlint](https://textlint.org/astexplorer/ "AST explorer for textlint") help you better understand [TxtAST](./txtnode.md).
 
 [![ast-explorer fork](assets/ast-explorer.png)](https://textlint.org/astexplorer/)
@@ -490,7 +488,7 @@ $ npm run build
 $ textlint --rulesdir lib/ README.md -f pretty-error
 ```
 
-![result error](https://monosnap.com/image/9FeIQr95kXjGPWFjZFRq6ZFG16YscF.png)
+![result error](assets/screenshot-lint-pretty-error.png)
 
 ### Advanced rules
 

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -488,8 +488,6 @@ $ npm run build
 $ textlint --rulesdir lib/ README.md -f pretty-error
 ```
 
-![result error](assets/screenshot-lint-pretty-error.png)
-
 ### Advanced rules
 
 When linting following text with above `no-todo` rule, a result was error.

--- a/packages/textlint-tester/README.md
+++ b/packages/textlint-tester/README.md
@@ -323,7 +323,7 @@ tester.run("no-todo", rule, {
 });
 ```
 
-See [`textlint-tester-test.ts`](./test/textlint-tester-test.ts)
+See [`textlint-tester.test.ts`](./test/textlint-tester.test.ts)
 or [`textlint-tester-plugin.ts`](./test/textlint-tester-plugin.ts) for concrete examples.
 
 ## Contributing


### PR DESCRIPTION
Fixes https://github.com/textlint/textlint/issues/2123

Fixes the four broken links / images reported in the issue. All four were reproduced before changing anything (`curl` returned 404 for the three external URLs, and the two local paths do not exist on disk).

## Changes

| File | Problem | Fix |
| --- | --- | --- |
| `README.md` L557 | `./packages/gulp-textlint` does not exist — the package was moved out of the monorepo in textlint v14 (see `website/blog/2024-02-03-textlint-14.md`) | Link to https://github.com/textlint/gulp-textlint. Same style as the `create-textlint-rule` row just above, which already links out, and the same URL README.md:476 already uses. |
| `packages/textlint-tester/README.md` L326 | `./test/textlint-tester-test.ts` does not exist — the file was renamed | Point to `./test/textlint-tester.test.ts` (the neighbouring `textlint-tester-plugin.ts` link is still valid, left as is) |
| `docs/rule-advanced.md` L84 | `http://azu.github.io/markdown-to-ast/example/` returns 404 | Link [AST explorer for textlint](https://textlint.org/astexplorer/) (returns 200), which `docs/rule.md` already recommends for the same purpose |
| `docs/rule.md` L85 | The gyazo GIF returns 404 and no local copy exists | Remove the image. The text link to `azu/visualize-txt-traverse` on the line above it is kept, so no information is lost. |
| `docs/rule.md` L493 | The monosnap screenshot returns 404 and no equivalent image exists | Remove the image. The only similar asset in the repo (`assets/screenshot-lint-pretty-error.png`) shows a different command, file and error count than this `no-todo` tutorial, so it would not match what a reader actually sees. The `sh` block above already describes the step. |

## Notes

- Docs only, no code changes. `prettier` in this repo only formats `js/jsx/ts/tsx/css`, so no formatting step applies to these files.
- No references to `markdown-to-ast/example`, gyazo, monosnap, or `packages/gulp-textlint` remain in the repo outside of the historical blog posts under `website/blog/`, which are left untouched on purpose.
- This overlaps with the WIP https://github.com/textlint/textlint/pull/2124; feel free to close whichever is less useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPEdZYCSU9mhtccZ7ex9Bm